### PR TITLE
Fix stale timeline appearing in second mission export

### DIFF
--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -66,7 +66,7 @@ def generate_mission_combined_csv(
         for leg in mission.legs:
             try:
                 # Load timeline for this leg
-                timeline = load_mission_timeline(leg.id)
+                timeline = load_mission_timeline(leg.id, parent_mission_id=mission.id)
                 if not timeline:
                     continue
 
@@ -234,7 +234,7 @@ def generate_mission_combined_pptx(
     # For each leg, generate slides using shared builder
     for leg_idx, leg in enumerate(mission.legs):
         # Load timeline for this leg
-        leg_timeline = load_mission_timeline(leg.id)
+        leg_timeline = load_mission_timeline(leg.id, parent_mission_id=mission.id)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, adding summary slide only"
@@ -452,7 +452,7 @@ def _add_per_leg_exports_to_zip(
     """
     for leg in mission.legs:
         # Load timeline for this specific leg
-        leg_timeline = load_mission_timeline(leg.id)
+        leg_timeline = load_mission_timeline(leg.id, parent_mission_id=mission.id)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, skipping exports for this leg"

--- a/backend/starlink-location/app/mission/routes_v2.py
+++ b/backend/starlink-location/app/mission/routes_v2.py
@@ -94,7 +94,9 @@ async def create_mission(
                             coverage_sampler=_coverage_sampler,
                             parent_mission_id=mission.id,
                         )
-                        save_mission_timeline(leg.id, timeline, parent_mission_id=mission.id)
+                        save_mission_timeline(
+                            leg.id, timeline, parent_mission_id=mission.id
+                        )
                         logger.info(f"Timeline generated and saved for leg {leg.id}")
                     except Exception as e:
                         logger.error(
@@ -797,7 +799,9 @@ async def add_leg_to_mission(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg.id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg.id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(f"Timeline generated and saved for new leg {leg.id}")
                 except Exception as e:
                     logger.error(
@@ -918,7 +922,9 @@ async def update_leg(
                             f"ends at {last_end}, "
                             f"{len(timeline.segments)} segments"
                         )
-                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg_id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(f"Timeline saved to disk for leg {leg_id}")
                 except Exception as e:
                     logger.error(
@@ -1138,7 +1144,9 @@ async def activate_leg(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg_id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(f"Timeline generated and saved for leg {leg_id}")
                 except Exception as e:
                     logger.error(f"Failed to generate timeline for leg {leg_id}: {e}")
@@ -1494,7 +1502,9 @@ async def update_leg_route(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg_id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(
                         f"Timeline regenerated and saved for leg {leg_id} with new route"
                     )

--- a/backend/starlink-location/app/mission/routes_v2.py
+++ b/backend/starlink-location/app/mission/routes_v2.py
@@ -30,6 +30,8 @@ from app.mission.storage import (
     save_mission_v2,
     load_mission_v2,
     save_mission_timeline,
+    load_mission_timeline,
+    delete_mission_timeline,
     get_mission_lock,
     load_mission_metadata_v2,
 )
@@ -92,7 +94,7 @@ async def create_mission(
                             coverage_sampler=_coverage_sampler,
                             parent_mission_id=mission.id,
                         )
-                        save_mission_timeline(leg.id, timeline)
+                        save_mission_timeline(leg.id, timeline, parent_mission_id=mission.id)
                         logger.info(f"Timeline generated and saved for leg {leg.id}")
                     except Exception as e:
                         logger.error(
@@ -602,7 +604,7 @@ def _generate_timelines_for_imported_legs(
                     coverage_sampler=coverage_sampler,
                     parent_mission_id=mission.id,
                 )
-                save_mission_timeline(leg.id, timeline)
+                save_mission_timeline(leg.id, timeline, parent_mission_id=mission.id)
                 logger.info(f"Timeline generated and saved for imported leg {leg.id}")
             except Exception as e:
                 logger.error(
@@ -795,7 +797,7 @@ async def add_leg_to_mission(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg.id, timeline)
+                    save_mission_timeline(leg.id, timeline, parent_mission_id=mission_id)
                     logger.info(f"Timeline generated and saved for new leg {leg.id}")
                 except Exception as e:
                     logger.error(
@@ -916,7 +918,7 @@ async def update_leg(
                             f"ends at {last_end}, "
                             f"{len(timeline.segments)} segments"
                         )
-                    save_mission_timeline(leg_id, timeline)
+                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
                     logger.info(f"Timeline saved to disk for leg {leg_id}")
                 except Exception as e:
                     logger.error(
@@ -1048,6 +1050,10 @@ async def delete_leg(
                     logger.error(f"Failed to delete leg file {leg_file}: {e}")
                     raise
 
+            # 5. Delete leg timeline file
+            delete_mission_timeline(leg_id, parent_mission_id=mission_id)
+            logger.info(f"Deleted timeline for leg {leg_id}")
+
             logger.info(
                 f"Deleted leg {leg_id} from mission {mission_id} with route {route_id}"
             )
@@ -1132,7 +1138,7 @@ async def activate_leg(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline)
+                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
                     logger.info(f"Timeline generated and saved for leg {leg_id}")
                 except Exception as e:
                     logger.error(f"Failed to generate timeline for leg {leg_id}: {e}")
@@ -1488,7 +1494,7 @@ async def update_leg_route(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline)
+                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
                     logger.info(
                         f"Timeline regenerated and saved for leg {leg_id} with new route"
                     )
@@ -1523,8 +1529,6 @@ async def get_leg_timeline(mission_id: str, leg_id: str) -> dict:
         Timeline object with segments and metadata
     """
     try:
-        from app.mission.storage import load_mission_timeline
-
         # Load mission to verify it exists
         mission = load_mission_v2(mission_id)
         if not mission:
@@ -1542,7 +1546,7 @@ async def get_leg_timeline(mission_id: str, leg_id: str) -> dict:
             )
 
         # Load timeline for the leg
-        timeline = load_mission_timeline(leg_id)
+        timeline = load_mission_timeline(leg_id, parent_mission_id=mission_id)
         if not timeline:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -425,7 +425,7 @@ def save_mission_timeline(
     timeline_path.parent.mkdir(parents=True, exist_ok=True)
     with open(timeline_path, "w") as handle:
         json.dump(timeline.model_dump(), handle, indent=2, default=str)
-    logger.info("Saved mission timeline for %s", leg_id)
+    logger.info("Saved leg timeline for %s", leg_id)
     return timeline_path
 
 

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -54,7 +54,9 @@ def get_mission_checksum_path(mission_id: str) -> Path:
     return MISSIONS_DIR / f"{mission_id}.sha256"
 
 
-def get_mission_timeline_path(leg_id: str, parent_mission_id: str | None = None) -> Path:
+def get_mission_timeline_path(
+    leg_id: str, parent_mission_id: str | None = None
+) -> Path:
     """Get the file path for a leg's cached timeline.
 
     When parent_mission_id is provided the timeline is stored inside the
@@ -474,9 +476,7 @@ def delete_mission_timeline(
             try:
                 scoped_path.unlink()
             except OSError as exc:
-                logger.warning(
-                    "Failed to delete scoped timeline %s: %s", leg_id, exc
-                )
+                logger.warning("Failed to delete scoped timeline %s: %s", leg_id, exc)
 
     # Always attempt to remove the legacy flat file to prevent future pollution.
     legacy_path = get_mission_timeline_path(leg_id)
@@ -484,9 +484,7 @@ def delete_mission_timeline(
         try:
             legacy_path.unlink()
         except OSError as exc:
-            logger.warning(
-                "Failed to delete legacy timeline %s: %s", leg_id, exc
-            )
+            logger.warning("Failed to delete legacy timeline %s: %s", leg_id, exc)
 
 
 def mission_exists(mission_id: str) -> bool:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -54,9 +54,7 @@ def get_mission_checksum_path(mission_id: str) -> Path:
     return MISSIONS_DIR / f"{mission_id}.sha256"
 
 
-def get_mission_timeline_path(
-    leg_id: str, parent_mission_id: str | None = None
-) -> Path:
+def get_leg_timeline_path(leg_id: str, parent_mission_id: str | None = None) -> Path:
     """Get the file path for a leg's cached timeline.
 
     When parent_mission_id is provided the timeline is stored inside the
@@ -381,7 +379,7 @@ def delete_mission(mission_id: str) -> bool:
     """
     mission_path = get_mission_path(mission_id)
     checksum_path = get_mission_checksum_path(mission_id)
-    timeline_path = get_mission_timeline_path(mission_id)
+    timeline_path = get_leg_timeline_path(mission_id)
 
     deleted = False
 
@@ -423,7 +421,7 @@ def save_mission_timeline(
 ) -> Path:
     """Persist a leg timeline to disk."""
     ensure_missions_directory()
-    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
+    timeline_path = get_leg_timeline_path(leg_id, parent_mission_id)
     timeline_path.parent.mkdir(parents=True, exist_ok=True)
     with open(timeline_path, "w") as handle:
         json.dump(timeline.model_dump(), handle, indent=2, default=str)
@@ -441,23 +439,35 @@ def load_mission_timeline(
     legacy flat-file path so existing data continues to work after upgrades.
     """
     if parent_mission_id:
-        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
         if scoped_path.exists():
             with open(scoped_path, "r") as handle:
                 return MissionLegTimeline(**json.load(handle))
     # Legacy fallback: flat file written before the scoped-path fix.
     # Two missions whose legs share a slug will still collide here until each
-    # leg is re-saved (which writes the scoped file). Log so operators know.
-    legacy_path = get_mission_timeline_path(leg_id)
+    # leg is loaded at least once after the upgrade (auto-migration below).
+    legacy_path = get_leg_timeline_path(leg_id)
     if not legacy_path.exists():
         return None
     logger.warning(
-        "Loading timeline for leg %s from legacy flat-file path; "
-        "re-save the leg to migrate to the mission-scoped path.",
+        "Loading timeline for leg %s from legacy flat-file path; migrating now.",
         leg_id,
     )
     with open(legacy_path, "r") as handle:
-        return MissionLegTimeline(**json.load(handle))
+        timeline = MissionLegTimeline(**json.load(handle))
+    # Auto-migrate: write the scoped file and remove the flat one so future
+    # loads go through the per-mission path and the warning disappears.
+    if parent_mission_id:
+        try:
+            scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
+            scoped_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(scoped_path, "w") as handle:
+                json.dump(timeline.model_dump(), handle, indent=2, default=str)
+            legacy_path.unlink(missing_ok=True)
+            logger.info("Migrated timeline for leg %s to scoped path", leg_id)
+        except OSError as exc:
+            logger.warning("Failed to migrate timeline for leg %s: %s", leg_id, exc)
+    return timeline
 
 
 def delete_mission_timeline(
@@ -471,15 +481,17 @@ def delete_mission_timeline(
     that happen to share the same slug.
     """
     if parent_mission_id:
-        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
         if scoped_path.exists():
             try:
                 scoped_path.unlink()
             except OSError as exc:
-                logger.warning("Failed to delete scoped timeline %s: %s", leg_id, exc)
+                logger.warning(
+                    "Failed to delete scoped timeline %s: %s", scoped_path, exc
+                )
 
     # Always attempt to remove the legacy flat file to prevent future pollution.
-    legacy_path = get_mission_timeline_path(leg_id)
+    legacy_path = get_leg_timeline_path(leg_id)
     if legacy_path.exists():
         try:
             legacy_path.unlink()

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -54,9 +54,16 @@ def get_mission_checksum_path(mission_id: str) -> Path:
     return MISSIONS_DIR / f"{mission_id}.sha256"
 
 
-def get_mission_timeline_path(mission_id: str) -> Path:
-    """Get the file path for a mission's cached timeline."""
-    return MISSIONS_DIR / f"{mission_id}{TIMELINE_SUFFIX}"
+def get_mission_timeline_path(leg_id: str, parent_mission_id: str | None = None) -> Path:
+    """Get the file path for a leg's cached timeline.
+
+    When parent_mission_id is provided the timeline is stored inside the
+    mission directory alongside its leg file, preventing name collisions
+    between legs with the same name in different missions.
+    """
+    if parent_mission_id:
+        return get_mission_legs_dir(parent_mission_id) / f"{leg_id}{TIMELINE_SUFFIX}"
+    return MISSIONS_DIR / f"{leg_id}{TIMELINE_SUFFIX}"
 
 
 def get_mission_directory(mission_id: str) -> Path:
@@ -407,34 +414,54 @@ def delete_mission(mission_id: str) -> bool:
     return deleted
 
 
-def save_mission_timeline(mission_id: str, timeline: MissionLegTimeline) -> Path:
-    """Persist a mission timeline to disk."""
+def save_mission_timeline(
+    leg_id: str,
+    timeline: MissionLegTimeline,
+    parent_mission_id: str | None = None,
+) -> Path:
+    """Persist a leg timeline to disk."""
     ensure_missions_directory()
-    timeline_path = get_mission_timeline_path(mission_id)
+    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
+    timeline_path.parent.mkdir(parents=True, exist_ok=True)
     with open(timeline_path, "w") as handle:
         json.dump(timeline.model_dump(), handle, indent=2, default=str)
-    logger.info("Saved mission timeline for %s", mission_id)
+    logger.info("Saved mission timeline for %s", leg_id)
     return timeline_path
 
 
-def load_mission_timeline(mission_id: str) -> MissionLegTimeline | None:
-    """Load a previously computed mission timeline."""
-    timeline_path = get_mission_timeline_path(mission_id)
-    if not timeline_path.exists():
+def load_mission_timeline(
+    leg_id: str,
+    parent_mission_id: str | None = None,
+) -> MissionLegTimeline | None:
+    """Load a previously computed leg timeline.
+
+    Checks the mission-scoped path first (new layout), then falls back to the
+    legacy flat-file path so existing data continues to work.
+    """
+    if parent_mission_id:
+        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        if scoped_path.exists():
+            with open(scoped_path, "r") as handle:
+                return MissionLegTimeline(**json.load(handle))
+    # Legacy fallback: flat file written before this fix
+    legacy_path = get_mission_timeline_path(leg_id)
+    if not legacy_path.exists():
         return None
-    with open(timeline_path, "r") as handle:
-        data = json.load(handle)
-    return MissionLegTimeline(**data)
+    with open(legacy_path, "r") as handle:
+        return MissionLegTimeline(**json.load(handle))
 
 
-def delete_mission_timeline(mission_id: str) -> None:
-    """Remove cached mission timeline without touching mission data."""
-    timeline_path = get_mission_timeline_path(mission_id)
+def delete_mission_timeline(
+    leg_id: str,
+    parent_mission_id: str | None = None,
+) -> None:
+    """Remove a cached leg timeline without touching mission data."""
+    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
     if timeline_path.exists():
         try:
             timeline_path.unlink()
         except OSError as exc:
-            logger.warning("Failed to delete mission timeline %s: %s", mission_id, exc)
+            logger.warning("Failed to delete mission timeline %s: %s", leg_id, exc)
 
 
 def mission_exists(mission_id: str) -> bool:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -436,17 +436,24 @@ def load_mission_timeline(
     """Load a previously computed leg timeline.
 
     Checks the mission-scoped path first (new layout), then falls back to the
-    legacy flat-file path so existing data continues to work.
+    legacy flat-file path so existing data continues to work after upgrades.
     """
     if parent_mission_id:
         scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
         if scoped_path.exists():
             with open(scoped_path, "r") as handle:
                 return MissionLegTimeline(**json.load(handle))
-    # Legacy fallback: flat file written before this fix
+    # Legacy fallback: flat file written before the scoped-path fix.
+    # Two missions whose legs share a slug will still collide here until each
+    # leg is re-saved (which writes the scoped file). Log so operators know.
     legacy_path = get_mission_timeline_path(leg_id)
     if not legacy_path.exists():
         return None
+    logger.warning(
+        "Loading timeline for leg %s from legacy flat-file path; "
+        "re-save the leg to migrate to the mission-scoped path.",
+        leg_id,
+    )
     with open(legacy_path, "r") as handle:
         return MissionLegTimeline(**json.load(handle))
 
@@ -455,13 +462,31 @@ def delete_mission_timeline(
     leg_id: str,
     parent_mission_id: str | None = None,
 ) -> None:
-    """Remove a cached leg timeline without touching mission data."""
-    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
-    if timeline_path.exists():
+    """Remove a cached leg timeline without touching mission data.
+
+    Deletes both the mission-scoped path (when parent_mission_id is given) and
+    the legacy flat-file path, so stale flat files can't bleed into future legs
+    that happen to share the same slug.
+    """
+    if parent_mission_id:
+        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        if scoped_path.exists():
+            try:
+                scoped_path.unlink()
+            except OSError as exc:
+                logger.warning(
+                    "Failed to delete scoped timeline %s: %s", leg_id, exc
+                )
+
+    # Always attempt to remove the legacy flat file to prevent future pollution.
+    legacy_path = get_mission_timeline_path(leg_id)
+    if legacy_path.exists():
         try:
-            timeline_path.unlink()
+            legacy_path.unlink()
         except OSError as exc:
-            logger.warning("Failed to delete mission timeline %s: %s", leg_id, exc)
+            logger.warning(
+                "Failed to delete legacy timeline %s: %s", leg_id, exc
+            )
 
 
 def mission_exists(mission_id: str) -> bool:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -379,7 +379,6 @@ def delete_mission(mission_id: str) -> bool:
     """
     mission_path = get_mission_path(mission_id)
     checksum_path = get_mission_checksum_path(mission_id)
-    timeline_path = get_leg_timeline_path(mission_id)
 
     deleted = False
 
@@ -400,13 +399,10 @@ def delete_mission(mission_id: str) -> bool:
             logger.error(f"Failed to delete checksum file {checksum_path}: {e}")
             raise
 
-    if timeline_path.exists():
-        try:
-            timeline_path.unlink()
-            logger.info(f"Deleted timeline file {timeline_path}")
-        except OSError as e:
-            logger.error(f"Failed to delete timeline file {timeline_path}: {e}")
-            raise
+    # Scoped leg timelines live inside the mission directory and are removed
+    # automatically when the v2 delete endpoint calls shutil.rmtree(mission_dir).
+    # The old flat-file timeline ({mission_id}.timeline.json) never existed in
+    # practice because timelines were always keyed by leg_id, not mission_id.
 
     if not deleted:
         logger.warning(f"Mission {mission_id} not found for deletion")
@@ -437,6 +433,11 @@ def load_mission_timeline(
 
     Checks the mission-scoped path first (new layout), then falls back to the
     legacy flat-file path so existing data continues to work after upgrades.
+
+    Note: callers that omit parent_mission_id will never find a scoped file and
+    will only hit the legacy flat-file path.  After migration is complete (all
+    flat files removed) those call sites will always return None.  Pass
+    parent_mission_id whenever the mission context is available.
     """
     if parent_mission_id:
         scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
@@ -457,6 +458,8 @@ def load_mission_timeline(
         timeline = MissionLegTimeline(**json.load(handle))
     # Auto-migrate: write the scoped file and remove the flat one so future
     # loads go through the per-mission path and the warning disappears.
+    # Not atomic — a crash between the write and the unlink leaves both files,
+    # which is safe: the scoped path wins on the next load.
     if parent_mission_id:
         try:
             scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
@@ -491,6 +494,7 @@ def delete_mission_timeline(
                 )
 
     # Always attempt to remove the legacy flat file to prevent future pollution.
+    # TODO: remove this probe once all deployments have migrated to scoped paths.
     legacy_path = get_leg_timeline_path(leg_id)
     if legacy_path.exists():
         try:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -86,6 +86,14 @@ def get_mission_leg_file_path(mission_id: str, leg_id: str) -> Path:
     return get_mission_legs_dir(mission_id) / f"{leg_id}.json"
 
 
+def _iter_mission_leg_files(legs_dir: Path):
+    """Yield persisted mission leg JSON files, excluding cached timelines."""
+    for leg_file in sorted(legs_dir.glob("*.json")):
+        if leg_file.name.endswith(TIMELINE_SUFFIX):
+            continue
+        yield leg_file
+
+
 def compute_file_checksum(file_path: Path) -> str:
     """Compute SHA256 checksum of a file."""
     sha256 = hashlib.sha256()
@@ -209,7 +217,7 @@ def load_mission_v2(mission_id: str) -> Optional[Mission]:
     legs = []
 
     if legs_dir.exists():
-        for leg_file in sorted(legs_dir.glob("*.json")):
+        for leg_file in _iter_mission_leg_files(legs_dir):
             with open(leg_file, "r") as f:
                 leg_data = json.load(f)
                 legs.append(MissionLeg(**leg_data))
@@ -250,7 +258,7 @@ def load_mission_metadata_v2(mission_id: str) -> Optional[Mission]:
         leg_stubs = []
 
         if legs_dir.exists():
-            for leg_file in sorted(legs_dir.glob("*.json")):
+            for leg_file in _iter_mission_leg_files(legs_dir):
                 # Extract leg ID from filename (e.g., "leg-1.json" -> "leg-1")
                 leg_id = leg_file.stem
                 # Create minimal leg stub with only required fields

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -799,3 +799,31 @@ class TestTimelineStorage:
         delete_mission_timeline("leg-1", parent_mission_id="mission-a")
 
         assert not flat_path.exists()
+
+    def test_save_and_load_without_mission_id_uses_flat_path(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """save/load without parent_mission_id round-trips through the legacy flat path."""
+        save_mission_timeline("leg-1", sample_timeline)
+
+        flat = temp_missions_dir / "leg-1.timeline.json"
+        assert flat.exists()
+
+        loaded = load_mission_timeline("leg-1")
+        assert loaded is not None
+        assert loaded.mission_leg_id == "leg-1"
+
+    def test_legacy_fallback_auto_migrates_to_scoped_path(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """Loading a legacy flat file with parent_mission_id migrates it to the scoped path."""
+        import json as _json
+
+        flat_path = temp_missions_dir / "leg-1.timeline.json"
+        flat_path.write_text(_json.dumps(sample_timeline.model_dump(), default=str))
+
+        load_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        scoped = temp_missions_dir / "mission-a" / "legs" / "leg-1.timeline.json"
+        assert scoped.exists()
+        assert not flat_path.exists()

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -11,18 +11,22 @@ from app.mission.storage import (
     compute_file_checksum,
     compute_mission_checksum,
     delete_mission,
+    delete_mission_timeline,
     get_mission_checksum_path,
     get_mission_directory,
     get_mission_file_path,
     get_mission_leg_file_path,
     get_mission_legs_dir,
     get_mission_path,
+    get_mission_timeline_path,
     list_missions,
     load_mission,
+    load_mission_timeline,
     load_mission_v2,
     load_mission_metadata_v2,
     mission_exists,
     save_mission,
+    save_mission_timeline,
     save_mission_v2,
 )
 
@@ -708,3 +712,97 @@ class TestHierarchicalMissionStorageV2:
         assert loaded.id == "empty-mission"
         assert loaded.name == "Empty Mission"
         assert loaded.legs == []
+
+
+class TestTimelineStorage:
+    """Tests for mission-scoped leg timeline storage.
+
+    These tests encode the bug fixed in PR #34: slugified leg IDs colliding
+    across missions caused stale timeline data to bleed into unrelated exports.
+    """
+
+    @pytest.fixture
+    def sample_timeline(self):
+        from app.mission.models import MissionLegTimeline
+
+        return MissionLegTimeline(mission_leg_id="leg-1")
+
+    @pytest.fixture
+    def sample_timeline_b(self):
+        from app.mission.models import MissionLegTimeline
+
+        return MissionLegTimeline(mission_leg_id="leg-1-mission-b")
+
+    def test_scoped_path_used_when_mission_id_provided(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """Timeline is stored inside {mission_id}/legs/ when parent_mission_id is given."""
+        save_mission_timeline("leg-1", sample_timeline, parent_mission_id="mission-a")
+
+        scoped = temp_missions_dir / "mission-a" / "legs" / "leg-1.timeline.json"
+        flat = temp_missions_dir / "leg-1.timeline.json"
+
+        assert scoped.exists()
+        assert not flat.exists()
+
+    def test_legacy_fallback_reads_flat_file(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """load_mission_timeline falls back to the flat file for pre-fix data."""
+        # Write directly to the legacy flat path (simulating pre-fix data)
+        import json
+
+        flat_path = temp_missions_dir / "leg-1.timeline.json"
+        flat_path.write_text(
+            json.dumps(sample_timeline.model_dump(), default=str)
+        )
+
+        # Load with a mission ID whose scoped path doesn't exist
+        loaded = load_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        assert loaded is not None
+        assert loaded.mission_leg_id == "leg-1"
+
+    def test_cross_mission_collision_is_fixed(
+        self, sample_timeline, sample_timeline_b, temp_missions_dir
+    ):
+        """Two missions with the same leg slug use independent timeline files."""
+        save_mission_timeline("leg-1", sample_timeline, parent_mission_id="mission-a")
+        save_mission_timeline("leg-1", sample_timeline_b, parent_mission_id="mission-b")
+
+        loaded_a = load_mission_timeline("leg-1", parent_mission_id="mission-a")
+        loaded_b = load_mission_timeline("leg-1", parent_mission_id="mission-b")
+
+        assert loaded_a is not None
+        assert loaded_b is not None
+        assert loaded_a.mission_leg_id == "leg-1"
+        assert loaded_b.mission_leg_id == "leg-1-mission-b"
+
+    def test_delete_leg_removes_scoped_timeline(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """delete_mission_timeline removes the scoped timeline file."""
+        save_mission_timeline("leg-1", sample_timeline, parent_mission_id="mission-a")
+
+        scoped = temp_missions_dir / "mission-a" / "legs" / "leg-1.timeline.json"
+        assert scoped.exists()
+
+        delete_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        assert not scoped.exists()
+
+    def test_delete_also_removes_legacy_flat_file(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """delete_mission_timeline cleans up legacy flat files to prevent future pollution."""
+        import json
+
+        # Simulate a legacy flat file left over from before the fix
+        flat_path = temp_missions_dir / "leg-1.timeline.json"
+        flat_path.write_text(
+            json.dumps(sample_timeline.model_dump(), default=str)
+        )
+
+        delete_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        assert not flat_path.exists()

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -730,6 +730,9 @@ class TestTimelineStorage:
     def sample_timeline_b(self):
         from app.mission.models import MissionLegTimeline
 
+        # Distinct mission_leg_id so test_cross_mission_collision_is_fixed can
+        # assert the two timelines didn't bleed into each other — both are stored
+        # under leg_id="leg-1" but in different mission directories.
         return MissionLegTimeline(mission_leg_id="leg-1-mission-b")
 
     def test_scoped_path_used_when_mission_id_provided(

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -18,7 +18,6 @@ from app.mission.storage import (
     get_mission_leg_file_path,
     get_mission_legs_dir,
     get_mission_path,
-    get_mission_timeline_path,
     list_missions,
     load_mission,
     load_mission_timeline,
@@ -745,17 +744,13 @@ class TestTimelineStorage:
         assert scoped.exists()
         assert not flat.exists()
 
-    def test_legacy_fallback_reads_flat_file(
-        self, sample_timeline, temp_missions_dir
-    ):
+    def test_legacy_fallback_reads_flat_file(self, sample_timeline, temp_missions_dir):
         """load_mission_timeline falls back to the flat file for pre-fix data."""
         # Write directly to the legacy flat path (simulating pre-fix data)
         import json
 
         flat_path = temp_missions_dir / "leg-1.timeline.json"
-        flat_path.write_text(
-            json.dumps(sample_timeline.model_dump(), default=str)
-        )
+        flat_path.write_text(json.dumps(sample_timeline.model_dump(), default=str))
 
         # Load with a mission ID whose scoped path doesn't exist
         loaded = load_mission_timeline("leg-1", parent_mission_id="mission-a")
@@ -799,9 +794,7 @@ class TestTimelineStorage:
 
         # Simulate a legacy flat file left over from before the fix
         flat_path = temp_missions_dir / "leg-1.timeline.json"
-        flat_path.write_text(
-            json.dumps(sample_timeline.model_dump(), default=str)
-        )
+        flat_path.write_text(json.dumps(sample_timeline.model_dump(), default=str))
 
         delete_mission_timeline("leg-1", parent_mission_id="mission-a")
 

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -427,6 +427,42 @@ class TestHierarchicalMissionStorageV2:
         assert loaded.legs[1].name == "Leg 2"
         assert loaded.legs[1].route_id == "route-2"
 
+    def test_load_mission_v2_ignores_scoped_timeline_files(
+        self, sample_mission_with_legs, temp_missions_dir
+    ):
+        """Timeline cache files in legs/ must not be parsed as MissionLegs."""
+        from app.mission.models import MissionLegTimeline
+
+        save_mission_v2(sample_mission_with_legs)
+        save_mission_timeline(
+            "leg-1",
+            MissionLegTimeline(mission_leg_id="leg-1", segments=[]),
+            parent_mission_id="operation-falcon",
+        )
+
+        loaded = load_mission_v2("operation-falcon")
+
+        assert loaded is not None
+        assert [leg.id for leg in loaded.legs] == ["leg-1", "leg-2"]
+
+    def test_load_mission_metadata_v2_ignores_scoped_timeline_files(
+        self, sample_mission_with_legs, temp_missions_dir
+    ):
+        """Metadata loads should count only actual leg JSON files."""
+        from app.mission.models import MissionLegTimeline
+
+        save_mission_v2(sample_mission_with_legs)
+        save_mission_timeline(
+            "leg-1",
+            MissionLegTimeline(mission_leg_id="leg-1", segments=[]),
+            parent_mission_id="operation-falcon",
+        )
+
+        loaded = load_mission_metadata_v2("operation-falcon")
+
+        assert loaded is not None
+        assert [leg.id for leg in loaded.legs] == ["leg-1", "leg-2"]
+
     def test_load_mission_v2_preserves_leg_order(
         self, sample_mission_with_legs, temp_missions_dir
     ):


### PR DESCRIPTION
Leg IDs are derived from leg names (slugified), so two legs with the
same name in different missions share the same timeline file path
(data/missions/{leg_id}.timeline.json). Exporting mission B after
mission A would load A's timeline file when both had a leg named the
same thing, causing the PPTX to show A's timing data while the map
(driven by the leg's own route_id) showed B's correct route.

Fix by scoping timeline files inside their mission's directory:
  data/missions/{mission_id}/legs/{leg_id}.timeline.json

All call sites already had mission_id available; added parent_mission_id
parameter to save/load/delete_mission_timeline and threaded it through
every caller in routes_v2.py and package/__main__.py. A legacy fallback
in load_mission_timeline handles existing flat-file data transparently.

Also fix delete_leg: it was not cleaning up the timeline file on leg
deletion, leaving orphaned timeline files that could pollute future
legs with the same name.

https://claude.ai/code/session_019gHSvYYC4zdkL5RuRjstmZ