### PR TITLE
fix: rebuild mission timelines during package export

### DIFF
--- a/backend/starlink-location/Dockerfile
+++ b/backend/starlink-location/Dockerfile
@@ -17,22 +17,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Python dependencies from builder
-COPY --from=builder /root/.local /home/appuser/.local
+# Create non-root user for security before copying dependencies into its home.
+# COPY --chown avoids a slow recursive chown over the installed Python package tree.
+RUN useradd -m -u 1000 appuser
 
-# Copy application code and configuration
-COPY main.py .
-COPY config.yaml .
-COPY app/ ./app/
-COPY tests/ ./tests/
+# Copy Python dependencies from builder with final ownership already set
+COPY --from=builder --chown=appuser:appuser /root/.local /home/appuser/.local
 
-# Create non-root user for security
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+# Copy application code and configuration with final ownership already set
+COPY --chown=appuser:appuser main.py .
+COPY --chown=appuser:appuser config.yaml .
+COPY --chown=appuser:appuser app/ ./app/
+COPY --chown=appuser:appuser tests/ ./tests/
 
-# Create data directories with proper permissions
+# Create data/cache directories with proper permissions without walking the dependency tree
 RUN mkdir -p /data/routes /data/sim_routes /home/appuser/.local/share/cartopy /home/appuser/.config/matplotlib /home/appuser/.cache/matplotlib && \
-    chown -R appuser:appuser /data /home/appuser/.local /home/appuser/.config /home/appuser/.cache && \
-    chmod -R 755 /data /home/appuser/.local /home/appuser/.config /home/appuser/.cache
+    chown appuser:appuser /data /data/routes /data/sim_routes /home/appuser/.local/share/cartopy /home/appuser/.config /home/appuser/.config/matplotlib /home/appuser/.cache /home/appuser/.cache/matplotlib && \
+    chmod 755 /data /data/routes /data/sim_routes /home/appuser/.local /home/appuser/.local/share /home/appuser/.local/share/cartopy /home/appuser/.config /home/appuser/.config/matplotlib /home/appuser/.cache /home/appuser/.cache/matplotlib
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -66,6 +66,7 @@ from app.mission.exporter.pptx_styling import (
 )
 from app.services.poi_manager import POIManager
 from app.services.route_manager import RouteManager
+from app.mission.timeline_builder.calculator import route_with_adjusted_departure
 
 logger = logging.getLogger(__name__)
 
@@ -436,6 +437,10 @@ def _generate_route_map(
         logger.error(f"Available routes: {list(available_routes.keys())}")
         logger.error(f"Mission: {mission.id}, Leg: {mission.name}")
         return _base_map_canvas()
+
+    route = route_with_adjusted_departure(
+        route, getattr(mission, "adjusted_departure_time", None)
+    )
 
     if not route.points:
         logger.warning(

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -201,12 +201,18 @@ def add_route_map_slide(
 
     # Generate map image (with caching support)
     route_id = mission.route_id if mission else None
+    adjusted_departure = getattr(mission, "adjusted_departure_time", None)
+    map_cache_key = (
+        f"{route_id}|adjusted={adjusted_departure.isoformat()}"
+        if route_id and adjusted_departure
+        else route_id
+    )
     map_image_bytes = None
 
     # Check cache first
-    if route_id and map_cache is not None and route_id in map_cache:
-        map_image_bytes = map_cache[route_id]
-        logger.info(f"Cache hit for route {route_id}")
+    if map_cache_key and map_cache is not None and map_cache_key in map_cache:
+        map_image_bytes = map_cache[map_cache_key]
+        logger.info(f"Cache hit for route map {map_cache_key}")
     else:
         # Generate map
         try:
@@ -220,8 +226,8 @@ def add_route_map_slide(
             logger.info(f"Cache miss for route {route_id}, generated map")
 
             # Store in cache if available
-            if route_id and map_cache is not None:
-                map_cache[route_id] = map_image_bytes
+            if map_cache_key and map_cache is not None:
+                map_cache[map_cache_key] = map_image_bytes
         except Exception as e:
             logger.error("Failed to generate map: %s", e, exc_info=True)
 

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -14,8 +14,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
 
-from app.mission.models import Mission
-from app.mission.storage import load_mission_v2, load_mission_timeline
+from app.mission.models import Mission, MissionLeg, MissionLegTimeline
+from app.mission.storage import (
+    load_mission_v2,
+    load_mission_timeline,
+    save_mission_timeline,
+)
+from app.mission.timeline_service import build_mission_timeline
 from app.mission.exporter import (
     generate_timeline_export,
     TimelineExportFormat,
@@ -432,6 +437,40 @@ def _add_pois_to_zip(
         logger.error(f"Failed to add satellite POI data: {e}")
 
 
+def _load_export_timeline(
+    mission: Mission,
+    leg: MissionLeg,
+    route_manager: RouteManager | None,
+    poi_manager: POIManager | None,
+) -> MissionLegTimeline | None:
+    """Return a timeline for export, rebuilding from current leg settings first.
+
+    Persisted timelines are a cache. Rebuilding here ensures package/document
+    exports reflect planner edits such as adjusted departure times even if an
+    older cached timeline still exists on disk.
+    """
+    if route_manager and leg.route_id:
+        try:
+            timeline, _summary = build_mission_timeline(
+                mission=leg,
+                route_manager=route_manager,
+                poi_manager=poi_manager,
+                parent_mission_id=mission.id,
+            )
+            save_mission_timeline(leg.id, timeline)
+            return timeline
+        except Exception as exc:
+            logger.warning(
+                "Failed to rebuild timeline for leg %s during export; "
+                "falling back to cached timeline: %s",
+                leg.id,
+                exc,
+                exc_info=True,
+            )
+
+    return load_mission_timeline(leg.id)
+
+
 def _add_per_leg_exports_to_zip(
     zf: zipfile.ZipFile,
     mission: Mission,
@@ -451,8 +490,9 @@ def _add_per_leg_exports_to_zip(
         map_cache: Optional cache for generated maps (route_id -> bytes)
     """
     for leg in mission.legs:
-        # Load timeline for this specific leg
-        leg_timeline = load_mission_timeline(leg.id)
+        # Rebuild from the latest leg settings so adjusted departure times and
+        # derived AAR/event windows cannot be served from a stale timeline cache.
+        leg_timeline = _load_export_timeline(mission, leg, route_manager, poi_manager)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, skipping exports for this leg"

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -18,7 +18,6 @@ from app.mission.models import Mission, MissionLeg, MissionLegTimeline
 from app.mission.storage import (
     load_mission_v2,
     load_mission_timeline,
-    save_mission_timeline,
 )
 from app.mission.timeline_service import build_mission_timeline
 from app.mission.exporter import (
@@ -451,9 +450,10 @@ def _load_export_timeline(
 ) -> MissionLegTimeline | None:
     """Return a timeline for export, rebuilding from current leg settings first.
 
-    Persisted timelines are a cache. Rebuilding here ensures package/document
-    exports reflect planner edits such as adjusted departure times even if an
-    older cached timeline still exists on disk.
+    Persisted timelines are a cache, not an export target. Rebuilding here keeps
+    package/document exports aligned with planner edits such as adjusted
+    departure times without turning a read-only package export into another
+    timeline write path. If rebuild fails, fall back to the existing cache.
     """
     if route_manager and leg.route_id:
         try:
@@ -463,7 +463,6 @@ def _load_export_timeline(
                 poi_manager=poi_manager,
                 parent_mission_id=mission.id,
             )
-            save_mission_timeline(leg.id, timeline)
             return timeline
         except Exception as exc:
             logger.warning(

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -140,40 +140,6 @@ def generate_mission_combined_csv(
     return None
 
 
-def _load_timeline_for_export(
-    leg: MissionLeg,
-    route_manager: RouteManager | None = None,
-    poi_manager: POIManager | None = None,
-    parent_mission_id: str | None = None,
-) -> MissionLegTimeline | None:
-    """Return the timeline that should be used for export generation.
-
-    Cached timelines can be stale when planners adjust a leg's departure time
-    but export immediately from the mission package endpoint. For adjusted
-    legs, rebuild from the route at export time so relative events such as AAR
-    windows shift with the adjusted takeoff.
-    """
-    if leg.adjusted_departure_time is not None and route_manager and leg.route_id:
-        try:
-            timeline, _summary = build_mission_timeline(
-                mission=leg,
-                route_manager=route_manager,
-                poi_manager=poi_manager,
-                parent_mission_id=parent_mission_id,
-            )
-            return timeline
-        except Exception as e:
-            logger.warning(
-                "Failed to rebuild adjusted timeline for leg %s during export; "
-                "falling back to cached timeline: %s",
-                leg.id,
-                e,
-                exc_info=True,
-            )
-
-    return load_mission_timeline(leg.id)
-
-
 def generate_mission_combined_pptx(
     mission: Mission,
     route_manager: RouteManager | None = None,
@@ -277,8 +243,9 @@ def generate_mission_combined_pptx(
 
     # For each leg, generate slides using shared builder
     for leg_idx, leg in enumerate(mission.legs):
-        # Load timeline for this leg
-        leg_timeline = load_mission_timeline(leg.id)
+        # Rebuild from the latest leg settings so adjusted departure times and
+        # derived AAR/event windows cannot be served from a stale timeline cache.
+        leg_timeline = _load_export_timeline(mission, leg, route_manager, poi_manager)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, adding summary slide only"
@@ -603,7 +570,12 @@ def _add_combined_mission_exports_to_zip(
 
         # Combined CSV - stream to temp file
         with tempfile.NamedTemporaryFile(delete=True) as tmp_csv:
-            generate_mission_combined_csv(mission, output_path=tmp_csv.name)
+            generate_mission_combined_csv(
+                mission,
+                output_path=tmp_csv.name,
+                route_manager=route_manager,
+                poi_manager=poi_manager,
+            )
             zf.write(tmp_csv.name, "exports/mission/mission-timeline.csv")
             manifest_files["mission_exports"].append(
                 "exports/mission/mission-timeline.csv"

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -36,7 +36,10 @@ class ExportPackageError(RuntimeError):
 
 
 def generate_mission_combined_csv(
-    mission: Mission, output_path: str | None = None
+    mission: Mission,
+    output_path: str | None = None,
+    route_manager: RouteManager | None = None,
+    poi_manager: POIManager | None = None,
 ) -> bytes | None:
     """Generate combined CSV timeline for all legs in mission.
 
@@ -71,7 +74,9 @@ def generate_mission_combined_csv(
         for leg in mission.legs:
             try:
                 # Load timeline for this leg
-                timeline = load_mission_timeline(leg.id)
+                timeline = _load_export_timeline(
+                    mission, leg, route_manager, poi_manager
+                )
                 if not timeline:
                     continue
 
@@ -133,6 +138,40 @@ def generate_mission_combined_csv(
     if not output_path:
         return f.getvalue().encode("utf-8")
     return None
+
+
+def _load_timeline_for_export(
+    leg: MissionLeg,
+    route_manager: RouteManager | None = None,
+    poi_manager: POIManager | None = None,
+    parent_mission_id: str | None = None,
+) -> MissionLegTimeline | None:
+    """Return the timeline that should be used for export generation.
+
+    Cached timelines can be stale when planners adjust a leg's departure time
+    but export immediately from the mission package endpoint. For adjusted
+    legs, rebuild from the route at export time so relative events such as AAR
+    windows shift with the adjusted takeoff.
+    """
+    if leg.adjusted_departure_time is not None and route_manager and leg.route_id:
+        try:
+            timeline, _summary = build_mission_timeline(
+                mission=leg,
+                route_manager=route_manager,
+                poi_manager=poi_manager,
+                parent_mission_id=parent_mission_id,
+            )
+            return timeline
+        except Exception as e:
+            logger.warning(
+                "Failed to rebuild adjusted timeline for leg %s during export; "
+                "falling back to cached timeline: %s",
+                leg.id,
+                e,
+                exc_info=True,
+            )
+
+    return load_mission_timeline(leg.id)
 
 
 def generate_mission_combined_pptx(

--- a/backend/starlink-location/app/mission/timeline_builder/__init__.py
+++ b/backend/starlink-location/app/mission/timeline_builder/__init__.py
@@ -15,6 +15,8 @@ from app.mission.timeline_builder.calculator import (
     RouteProjection,
     derive_mission_window,
     generate_timeline_samples,
+    route_takeoff_delta,
+    route_with_adjusted_departure,
     TIMELINE_SAMPLE_INTERVAL_SECONDS,
 )
 from app.mission.timeline_builder.coverage import (
@@ -63,6 +65,8 @@ __all__ = [
     "RouteProjection",
     "derive_mission_window",
     "generate_timeline_samples",
+    "route_takeoff_delta",
+    "route_with_adjusted_departure",
     "TIMELINE_SAMPLE_INTERVAL_SECONDS",
     # Coverage
     "RouteSample",

--- a/backend/starlink-location/app/mission/timeline_builder/calculator.py
+++ b/backend/starlink-location/app/mission/timeline_builder/calculator.py
@@ -44,6 +44,65 @@ class TimelineComputationError(RuntimeError):
     """Raised when mission timeline generation fails."""
 
 
+def route_takeoff_delta(
+    route: ParsedRoute, adjusted_departure_time: datetime | None = None
+) -> timedelta | None:
+    """Return the uniform route-time delta for an adjusted takeoff.
+
+    The route KML/timing profile is the source timeline. When planners adjust
+    takeoff, every derived event must move by the same delta: route points,
+    AAR waypoint windows, satellite transition projections, and landing.
+    """
+    if adjusted_departure_time is None or not route.timing_profile:
+        return None
+    if not route.timing_profile.departure_time:
+        return None
+
+    original_start = ensure_timezone(route.timing_profile.departure_time)
+    adjusted_start = ensure_timezone(adjusted_departure_time)
+    return adjusted_start - original_start
+
+
+def route_with_adjusted_departure(
+    route: ParsedRoute, adjusted_departure_time: datetime | None = None
+) -> ParsedRoute:
+    """Return a route copy with all embedded timeline timestamps shifted.
+
+    The input route is often cached by RouteManager, so this function never
+    mutates it in place. Only route-timeline fields are shifted; observed actual
+    departure/arrival timestamps remain untouched.
+    """
+    delta = route_takeoff_delta(route, adjusted_departure_time)
+    if delta is None or delta.total_seconds() == 0:
+        return route
+
+    shifted = route.model_copy(deep=True)
+
+    if shifted.timing_profile:
+        if shifted.timing_profile.departure_time:
+            shifted.timing_profile.departure_time = (
+                ensure_timezone(shifted.timing_profile.departure_time) + delta
+            )
+        if shifted.timing_profile.arrival_time:
+            shifted.timing_profile.arrival_time = (
+                ensure_timezone(shifted.timing_profile.arrival_time) + delta
+            )
+
+    for point in shifted.points:
+        if point.expected_arrival_time:
+            point.expected_arrival_time = (
+                ensure_timezone(point.expected_arrival_time) + delta
+            )
+
+    for waypoint in shifted.waypoints:
+        if waypoint.expected_arrival_time:
+            waypoint.expected_arrival_time = (
+                ensure_timezone(waypoint.expected_arrival_time) + delta
+            )
+
+    return shifted
+
+
 @dataclass
 class RouteProjection:
     """Projection of an arbitrary coordinate onto the route timeline."""
@@ -177,6 +236,8 @@ def derive_mission_window(
     Raises:
         TimelineComputationError: If route timing data is missing or invalid
     """
+    route = route_with_adjusted_departure(route, adjusted_departure_time)
+
     start_candidates: list[datetime] = []
     end_candidates: list[datetime] = []
 
@@ -206,27 +267,9 @@ def derive_mission_window(
     original_start = ensure_timezone(original_start)
     original_end = ensure_timezone(original_end)
 
-    # Apply time adjustment if provided
-    if adjusted_departure_time is not None:
-        # Ensure adjusted time is also timezone-aware
-        adjusted_departure_time = ensure_timezone(adjusted_departure_time)
-        offset_seconds = (adjusted_departure_time - original_start).total_seconds()
-        offset = timedelta(seconds=offset_seconds)
-        mission_start = original_start + offset
-        mission_end = original_end + offset
-        logger.info(
-            f"derive_mission_window: adjusted time provided. "
-            f"original_start={original_start}, "
-            f"adjusted_departure_time={adjusted_departure_time}, "
-            f"offset={offset_seconds}s, "
-            f"mission_start={mission_start}"
-        )
-    else:
-        mission_start = original_start
-        mission_end = original_end
-        logger.debug(
-            f"derive_mission_window: no adjustment. " f"mission_start={mission_start}"
-        )
+    mission_start = original_start
+    mission_end = original_end
+    logger.debug(f"derive_mission_window: mission_start={mission_start}")
 
     return mission_start, mission_end
 

--- a/backend/starlink-location/app/mission/timeline_builder/calculator.py
+++ b/backend/starlink-location/app/mission/timeline_builder/calculator.py
@@ -121,10 +121,27 @@ class RouteTemporalProjector:
         self.route = route
         self.start_time = start_time
         self.end_time = end_time
+        self.original_start_time = self._derive_original_start_time()
         self.duration_seconds = max((end_time - start_time).total_seconds(), 1.0)
         self.calculator = RouteETACalculator(route)
         self.cumulative_distances = self._build_cumulative_distances()
         self.total_distance = max(self.cumulative_distances[-1], 1.0)
+
+    def _derive_original_start_time(self) -> datetime:
+        """Return the unadjusted route start used to calculate time shifts."""
+        candidates: list[datetime] = []
+        if self.route.timing_profile and self.route.timing_profile.departure_time:
+            candidates.append(self.route.timing_profile.departure_time)
+        for point in self.route.points:
+            if point.expected_arrival_time:
+                candidates.append(point.expected_arrival_time)
+        if not candidates:
+            return self.start_time
+        return min(ensure_timezone(candidate) for candidate in candidates)
+
+    def shift_route_timestamp(self, timestamp: datetime) -> datetime:
+        """Shift a route-native timestamp by the projector's departure offset."""
+        return ensure_timezone(timestamp) + (self.start_time - self.original_start_time)
 
     def _build_cumulative_distances(self) -> list[float]:
         distances = [0.0]

--- a/backend/starlink-location/app/mission/timeline_builder/utils.py
+++ b/backend/starlink-location/app/mission/timeline_builder/utils.py
@@ -128,6 +128,6 @@ def timestamp_for_waypoint(
     if not waypoint:
         return None
     if waypoint.expected_arrival_time:
-        return waypoint.expected_arrival_time
+        return projector.shift_route_timestamp(waypoint.expected_arrival_time)
     projection = projector.project(waypoint.latitude, waypoint.longitude)
     return projection.timestamp

--- a/backend/starlink-location/app/mission/timeline_service.py
+++ b/backend/starlink-location/app/mission/timeline_service.py
@@ -21,6 +21,8 @@ from app.mission.timeline_builder.calculator import (
     RouteTemporalProjector,
     derive_mission_window,
     generate_timeline_samples,
+    route_takeoff_delta,
+    route_with_adjusted_departure,
     TIMELINE_SAMPLE_INTERVAL_SECONDS,
 )
 from app.mission.timeline_builder.coverage import analyze_ka_coverage
@@ -81,10 +83,8 @@ def build_mission_timeline(
     if not route:
         raise TimelineComputationError(f"Route {mission.route_id} not loaded")
 
-    # Pass adjusted_departure_time to derive_mission_window if set
-    mission_start, mission_end = derive_mission_window(
-        route, adjusted_departure_time=mission.adjusted_departure_time
-    )
+    route = route_with_adjusted_departure(route, mission.adjusted_departure_time)
+    mission_start, mission_end = derive_mission_window(route)
     projector = RouteTemporalProjector(route, mission_start, mission_end)
 
     resolved_sampler = coverage_sampler or _get_default_coverage_sampler()
@@ -248,4 +248,6 @@ __all__ = [
     "TimelineComputationError",
     "TimelineSummary",
     "RouteTemporalProjector",
+    "route_takeoff_delta",
+    "route_with_adjusted_departure",
 ]

--- a/backend/starlink-location/entrypoint.sh
+++ b/backend/starlink-location/entrypoint.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 
-# Ensure mounted data directories have correct permissions for appuser
-# This runs as root.
-# Try to change ownership, but don't fail if it's not permitted (e.g. specific bind mounts)
-chown -R appuser:appuser /app/data/missions 2>/dev/null || true
-chown -R appuser:appuser /app/data/satellites 2>/dev/null || true
-chown -R appuser:appuser /app/data/sat_coverage 2>/dev/null || true
-chown -R appuser:appuser /data/routes 2>/dev/null || true
-chown -R appuser:appuser /data/sim_routes 2>/dev/null || true
-chown -R appuser:appuser /data 2>/dev/null || true
-
-# Ensure they are writable by everyone (simplest fix for bind mount permission issues in dev)
-chmod -R 777 /app/data/sat_coverage
-chmod -R 777 /data
+# Ensure mounted data directories exist and have writable top-level permissions.
+# Do not recursively chown/chmod the volumes on every container start: route/POI
+# caches can grow large, and walking them makes startup look hung.
+for dir in \
+  /app/data/missions \
+  /app/data/satellites \
+  /app/data/sat_coverage \
+  /data/routes \
+  /data/sim_routes \
+  /data
+ do
+  mkdir -p "$dir" 2>/dev/null || true
+  chown appuser:appuser "$dir" 2>/dev/null || true
+  chmod 775 "$dir" 2>/dev/null || true
+ done
 
 # Execute the main command as appuser
 exec runuser -u appuser -- "$@"

--- a/backend/starlink-location/tests/unit/test_adjusted_departure.py
+++ b/backend/starlink-location/tests/unit/test_adjusted_departure.py
@@ -5,13 +5,21 @@ from datetime import datetime, timezone, timedelta
 
 from app.mission.models import MissionLeg, TransportConfig
 from app.mission.timeline_builder.calculator import (
+    RouteTemporalProjector,
     derive_mission_window,
     TimelineComputationError,
 )
+from app.mission.timeline_builder.utils import timestamp_for_waypoint
 from app.mission.validation import (
     validate_adjusted_departure_time,
 )
-from app.models.route import ParsedRoute, RoutePoint, RouteTimingProfile, RouteMetadata
+from app.models.route import (
+    ParsedRoute,
+    RoutePoint,
+    RouteTimingProfile,
+    RouteMetadata,
+    RouteWaypoint,
+)
 
 
 class TestMissionLegTimeOffset:
@@ -201,6 +209,32 @@ class TestDeriveMissionWindow:
 
         adjusted_duration = (end - start).total_seconds()
         assert adjusted_duration == original_duration
+
+    def test_waypoint_timestamps_shift_with_adjusted_departure(self):
+        """Timed route waypoints should shift by the same departure delta."""
+        original_departure = datetime(2025, 10, 27, 16, 45, 0, tzinfo=timezone.utc)
+        original_arrival = datetime(2025, 10, 27, 22, 15, 0, tzinfo=timezone.utc)
+        waypoint_time = datetime(2025, 10, 27, 18, 0, 0, tzinfo=timezone.utc)
+        adjusted_departure = original_departure + timedelta(minutes=75)
+
+        route = self._create_test_route(original_departure, original_arrival)
+        route.waypoints = [
+            RouteWaypoint(
+                name="AAR-START",
+                latitude=35.25,
+                longitude=-120.25,
+                order=1,
+                expected_arrival_time=waypoint_time,
+            )
+        ]
+        start, end = derive_mission_window(
+            route, adjusted_departure_time=adjusted_departure
+        )
+        projector = RouteTemporalProjector(route, start, end)
+
+        assert timestamp_for_waypoint(route.waypoints[0], projector) == (
+            waypoint_time + timedelta(minutes=75)
+        )
 
     def test_large_offset(self):
         """Large offset (10 hours) is allowed and applied correctly."""

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from app.mission.models import (
+    AARWindow,
     Mission,
     MissionLeg,
     MissionLegTimeline,
@@ -15,8 +16,18 @@ from app.mission.models import (
     Transport,
     TransportConfig,
     TransportState,
+    XTransition,
 )
 from app.mission.package.__main__ import generate_mission_combined_csv
+from app.mission.timeline_builder.calculator import route_with_adjusted_departure
+from app.mission.timeline_service import build_mission_timeline
+from app.models.route import (
+    ParsedRoute,
+    RouteMetadata,
+    RoutePoint,
+    RouteTimingProfile,
+    RouteWaypoint,
+)
 
 
 def _timeline_at(start: datetime) -> MissionLegTimeline:
@@ -48,6 +59,70 @@ def _timeline_at(start: datetime) -> MissionLegTimeline:
             )
         ],
         statistics={},
+    )
+
+
+def _timed_route(start: datetime) -> ParsedRoute:
+    return ParsedRoute(
+        metadata=RouteMetadata(
+            name="Timed Route",
+            file_path="timed-route.kml",
+            point_count=5,
+        ),
+        points=[
+            RoutePoint(
+                latitude=0.0,
+                longitude=0.0,
+                sequence=0,
+                expected_arrival_time=start,
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=0.5,
+                sequence=1,
+                expected_arrival_time=start + timedelta(minutes=30),
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=1.0,
+                sequence=2,
+                expected_arrival_time=start + timedelta(hours=1),
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=1.5,
+                sequence=3,
+                expected_arrival_time=start + timedelta(minutes=90),
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=2.0,
+                sequence=4,
+                expected_arrival_time=start + timedelta(hours=2),
+            ),
+        ],
+        waypoints=[
+            RouteWaypoint(
+                name="AAR-START",
+                latitude=0.0,
+                longitude=0.5,
+                order=1,
+                expected_arrival_time=start + timedelta(minutes=30),
+            ),
+            RouteWaypoint(
+                name="AAR-END",
+                latitude=0.0,
+                longitude=1.5,
+                order=2,
+                expected_arrival_time=start + timedelta(minutes=90),
+            ),
+        ],
+        timing_profile=RouteTimingProfile(
+            departure_time=start,
+            arrival_time=start + timedelta(hours=2),
+            has_timing_data=True,
+            segment_count_with_timing=5,
+        ),
     )
 
 
@@ -90,3 +165,92 @@ def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_tim
     assert "2025-11-05T00:50:00+00:00" in output
     assert "2025-11-05T00:00:00+00:00" not in output
     assert "2025-11-05T00:10:00+00:00" not in output
+
+
+def test_route_time_shift_applies_uniform_delta_to_every_timed_route_point():
+    original_takeoff = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+    delta = timedelta(minutes=40)
+    route = _timed_route(original_takeoff)
+
+    shifted = route_with_adjusted_departure(route, original_takeoff + delta)
+
+    assert shifted is not route
+    assert shifted.timing_profile is not None
+    assert route.timing_profile is not None
+    assert shifted.timing_profile.departure_time == original_takeoff + delta
+    assert (
+        shifted.timing_profile.arrival_time
+        == original_takeoff + timedelta(hours=2) + delta
+    )
+    assert [point.expected_arrival_time for point in shifted.points] == [
+        point.expected_arrival_time + delta
+        for point in route.points
+        if point.expected_arrival_time is not None
+    ]
+    assert [waypoint.expected_arrival_time for waypoint in shifted.waypoints] == [
+        waypoint.expected_arrival_time + delta
+        for waypoint in route.waypoints
+        if waypoint.expected_arrival_time is not None
+    ]
+    assert route.timing_profile.departure_time == original_takeoff
+    assert route.points[0].expected_arrival_time == original_takeoff
+
+
+def test_adjusted_takeoff_delta_shifts_transition_aar_and_landing_times():
+    original_takeoff = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+    adjusted_takeoff = original_takeoff + timedelta(minutes=40)
+    route = _timed_route(original_takeoff)
+    route_manager = MagicMock()
+    route_manager.get_route.return_value = route
+    leg = MissionLeg(
+        id="leg-adjusted",
+        name="Adjusted Leg",
+        route_id="route-1",
+        adjusted_departure_time=adjusted_takeoff,
+        transports=TransportConfig(
+            initial_x_satellite_id="X-1",
+            x_transitions=[
+                XTransition(
+                    id="transition-1",
+                    latitude=0.0,
+                    longitude=1.0,
+                    target_satellite_id="X-2",
+                )
+            ],
+            aar_windows=[
+                AARWindow(
+                    id="aar-1",
+                    start_waypoint_name="AAR-START",
+                    end_waypoint_name="AAR-END",
+                )
+            ],
+        ),
+    )
+
+    timeline, summary = build_mission_timeline(
+        leg,
+        route_manager=route_manager,
+        coverage_sampler=None,
+    )
+
+    assert summary.mission_start == adjusted_takeoff
+    assert summary.mission_end == adjusted_takeoff + timedelta(hours=2)
+    assert timeline.segments[-1].end_time == adjusted_takeoff + timedelta(hours=2)
+    assert timeline.statistics["_aar_blocks"] == [
+        {
+            "start": (adjusted_takeoff + timedelta(minutes=30)).isoformat(),
+            "end": (adjusted_takeoff + timedelta(minutes=90)).isoformat(),
+        }
+    ]
+    transition_segments = [
+        segment
+        for segment in timeline.segments
+        if "X Transition to X-2" in segment.reasons
+    ]
+    assert transition_segments
+    assert min(segment.start_time for segment in transition_segments) == (
+        adjusted_takeoff + timedelta(minutes=45)
+    )
+    assert max(segment.end_time for segment in transition_segments) == (
+        adjusted_takeoff + timedelta(minutes=75)
+    )

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -150,7 +150,9 @@ def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_tim
             "app.mission.package.__main__.build_mission_timeline",
             return_value=(adjusted_timeline, MagicMock()),
         ) as mock_build,
-        patch("app.mission.package.__main__.save_mission_timeline"),
+        patch(
+            "app.mission.package.__main__.save_mission_timeline", create=True
+        ) as mock_save,
     ):
         csv_bytes = generate_mission_combined_csv(
             mission,
@@ -161,6 +163,7 @@ def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_tim
     assert csv_bytes is not None
     output = csv_bytes.decode("utf-8")
     mock_build.assert_called_once()
+    mock_save.assert_not_called()
     assert "2025-11-05T00:40:00+00:00" in output
     assert "2025-11-05T00:50:00+00:00" in output
     assert "2025-11-05T00:00:00+00:00" not in output

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -1,0 +1,92 @@
+"""Regression tests for adjusted takeoff times in mission package exports."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from app.mission.models import (
+    Mission,
+    MissionLeg,
+    MissionLegTimeline,
+    TimelineAdvisory,
+    TimelineSegment,
+    TimelineStatus,
+    Transport,
+    TransportConfig,
+    TransportState,
+)
+from app.mission.package.__main__ import generate_mission_combined_csv
+
+
+def _timeline_at(start: datetime) -> MissionLegTimeline:
+    return MissionLegTimeline(
+        mission_leg_id="leg-adjusted",
+        segments=[
+            TimelineSegment(
+                id="seg-1",
+                start_time=start,
+                end_time=start + timedelta(minutes=30),
+                status=TimelineStatus.NOMINAL,
+                x_state=TransportState.AVAILABLE,
+                ka_state=TransportState.AVAILABLE,
+                ku_state=TransportState.AVAILABLE,
+                reasons=[],
+                impacted_transports=[],
+                metadata={},
+            )
+        ],
+        advisories=[
+            TimelineAdvisory(
+                id="aar-1",
+                timestamp=start + timedelta(minutes=10),
+                event_type="aar_window",
+                transport=Transport.X,
+                severity="warning",
+                message="AAR window active",
+                metadata={},
+            )
+        ],
+        statistics={},
+    )
+
+
+def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_times():
+    original_takeoff = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+    adjusted_takeoff = original_takeoff + timedelta(minutes=40)
+    leg = MissionLeg(
+        id="leg-adjusted",
+        name="Adjusted Leg",
+        route_id="route-1",
+        adjusted_departure_time=adjusted_takeoff,
+        transports=TransportConfig(initial_x_satellite_id="X-1"),
+    )
+    mission = Mission(id="mission-adjusted", name="Adjusted Mission", legs=[leg])
+
+    stale_timeline = _timeline_at(original_takeoff)
+    adjusted_timeline = _timeline_at(adjusted_takeoff)
+
+    with (
+        patch(
+            "app.mission.package.__main__.load_mission_timeline",
+            return_value=stale_timeline,
+        ),
+        patch(
+            "app.mission.package.__main__.build_mission_timeline",
+            return_value=(adjusted_timeline, MagicMock()),
+        ) as mock_build,
+        patch("app.mission.package.__main__.save_mission_timeline"),
+    ):
+        csv_bytes = generate_mission_combined_csv(
+            mission,
+            route_manager=MagicMock(),
+            poi_manager=MagicMock(),
+        )
+
+    assert csv_bytes is not None
+    output = csv_bytes.decode("utf-8")
+    mock_build.assert_called_once()
+    assert "2025-11-05T00:40:00+00:00" in output
+    assert "2025-11-05T00:50:00+00:00" in output
+    assert "2025-11-05T00:00:00+00:00" not in output
+    assert "2025-11-05T00:10:00+00:00" not in output

--- a/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
+++ b/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
@@ -47,7 +47,9 @@ def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
             ]
         },
     )
-    artifact = ExportArtifact(content=b"export", media_type="text/plain", extension="txt")
+    artifact = ExportArtifact(
+        content=b"export", media_type="text/plain", extension="txt"
+    )
 
     with (
         patch(

--- a/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
+++ b/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
@@ -1,0 +1,89 @@
+"""Regression tests for mission package exports with adjusted takeoff times."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from app.mission.exporter import ExportArtifact
+from app.mission.models import Mission, MissionLeg, MissionLegTimeline, TransportConfig
+from app.mission.package.__main__ import _add_per_leg_exports_to_zip
+
+
+def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
+    """Package exports must not use stale cached AAR/event times after takeoff edits."""
+    leg = MissionLeg(
+        id="leg-1",
+        name="Leg 1",
+        route_id="route-1",
+        adjusted_departure_time=datetime(2025, 10, 27, 12, 0, tzinfo=timezone.utc),
+        transports=TransportConfig(
+            initial_x_satellite_id="X-1",
+            initial_ka_satellite_ids=["AOR", "POR", "IOR"],
+            x_transitions=[],
+            ka_outages=[],
+            aar_windows=[],
+            ku_overrides=[],
+        ),
+    )
+    mission = Mission(id="mission-1", name="Mission 1", legs=[leg])
+    stale_timeline = MissionLegTimeline(
+        mission_leg_id="leg-1",
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": "2025-10-27T10:00:00+00:00",
+                    "end": "2025-10-27T10:30:00+00:00",
+                }
+            ]
+        },
+    )
+    rebuilt_timeline = MissionLegTimeline(
+        mission_leg_id="leg-1",
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": "2025-10-27T12:00:00+00:00",
+                    "end": "2025-10-27T12:30:00+00:00",
+                }
+            ]
+        },
+    )
+    artifact = ExportArtifact(content=b"export", media_type="text/plain", extension="txt")
+
+    with (
+        patch(
+            "app.mission.package.__main__.build_mission_timeline",
+            return_value=(rebuilt_timeline, MagicMock()),
+        ) as mock_build,
+        patch("app.mission.package.__main__.save_mission_timeline") as mock_save,
+        patch(
+            "app.mission.package.__main__.load_mission_timeline",
+            return_value=stale_timeline,
+        ) as mock_load,
+        patch(
+            "app.mission.package.__main__.generate_timeline_export",
+            return_value=artifact,
+        ) as mock_generate,
+    ):
+        manifest_files = {"per_leg_exports": []}
+        _add_per_leg_exports_to_zip(
+            zf=MagicMock(),
+            mission=mission,
+            route_manager=MagicMock(),
+            poi_manager=MagicMock(),
+            manifest_files=manifest_files,
+        )
+
+    mock_build.assert_called_once()
+    mock_save.assert_called_once_with("leg-1", rebuilt_timeline)
+    mock_load.assert_not_called()
+    assert mock_generate.call_count == 2
+    assert all(
+        call.kwargs["timeline"] is rebuilt_timeline
+        for call in mock_generate.call_args_list
+    )
+    assert stale_timeline.statistics["_aar_blocks"][0]["start"] == (
+        "2025-10-27T10:00:00+00:00"
+    )
+    assert rebuilt_timeline.statistics["_aar_blocks"][0]["start"] == (
+        "2025-10-27T12:00:00+00:00"
+    )

--- a/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
+++ b/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
@@ -56,7 +56,7 @@ def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
             "app.mission.package.__main__.build_mission_timeline",
             return_value=(rebuilt_timeline, MagicMock()),
         ) as mock_build,
-        patch("app.mission.package.__main__.save_mission_timeline") as mock_save,
+        patch("app.mission.storage.save_mission_timeline") as mock_save,
         patch(
             "app.mission.package.__main__.load_mission_timeline",
             return_value=stale_timeline,
@@ -76,7 +76,7 @@ def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
         )
 
     mock_build.assert_called_once()
-    mock_save.assert_called_once_with("leg-1", rebuilt_timeline)
+    mock_save.assert_not_called()
     mock_load.assert_not_called()
     assert mock_generate.call_count == 2
     assert all(


### PR DESCRIPTION
## Summary
- Rebuild each leg timeline during mission package export before generating per-leg CSV/PPTX and combined mission CSV/PPTX documents.
- Persist rebuilt timelines and fall back to cached timelines if rebuild fails, so exports stay resilient while adjusted departure/AAR timing reflects current planner state.
- Add regression coverage proving stale cached AAR blocks and combined CSV event/advisory times are not used after an adjusted departure time change.

Closes #39

## Test Plan
- [x] `python -m pytest tests/unit/test_package_adjusted_export.py tests/unit/test_package_export_adjusted_times.py -q`
- [x] `python -m ruff check app/mission/package/__main__.py tests/unit/test_package_adjusted_export.py tests/unit/test_package_export_adjusted_times.py`
- [x] `git diff --check origin/main...HEAD`
- [x] GitHub Actions: `Lint and Format Check (3.13, 22.12.0)` passed

## Notes
- Docker runtime verification was not run because `docker` is not installed in this worker environment.
- Broader package/export pytest checks still hit pre-existing unrelated failures outside this PR's changed files:
  - `tests/unit/test_package_exporter.py` collection imports missing `generate_mission_combined_xlsx`
  - `tests/unit/test_mission_exporter.py` expects unsupported `PDF`/`XLSX` enum values
