### PR TITLE
feat: normalize mission call availability tables

### DIFF
--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -1,0 +1,346 @@
+"""Normalize mission timelines into operational call-availability blocks.
+
+The raw mission timeline can carry overlapping context such as SOF/AAR windows
+in statistics while transport state segments remain nominal. This module applies
+a sweep-line pass so the primary table can show one chronological,
+non-overlapping call posture per row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable
+
+from app.mission.models import (
+    MissionLegTimeline,
+    TimelineSegment,
+    TimelineStatus,
+    Transport,
+    TransportState,
+)
+
+
+@dataclass(frozen=True)
+class AARBlock:
+    """Safety-of-flight AAR interval clipped into the mission timeline."""
+
+    start: datetime
+    end: datetime
+
+
+@dataclass(frozen=True)
+class AvailabilityDecision:
+    """Resolved operational call posture for an atomic interval."""
+
+    status: TimelineStatus
+    call_posture: str
+    primary_reason: str
+    availability_label: str
+    impacted_transports: tuple[Transport, ...]
+    x_state: TransportState
+    ka_state: TransportState
+    ku_state: TransportState
+    notes: tuple[str, ...]
+    source_reasons: tuple[str, ...]
+    source_segment_ids: tuple[str, ...]
+
+
+_STATE_PRIORITY = {
+    TransportState.AVAILABLE: 0,
+    TransportState.DEGRADED: 1,
+    TransportState.OFFLINE: 2,
+}
+
+_REASON_LABELS = {
+    "outage": "system outage",
+    "sof": "SOF AAR",
+    "ku_x": "Ku/X conflict",
+    "activity": "operational activity conflict",
+    "nominal": "nominal window",
+}
+
+
+def normalize_call_availability_timeline(timeline: MissionLegTimeline) -> None:
+    """Replace timeline segments with merged, non-overlapping availability rows.
+
+    The normalized segments retain the existing `TimelineSegment` model for API
+    compatibility while adding table-ready labels in `metadata`:
+    `call_posture`, `primary_reason`, `availability_label`, `systems_affected`,
+    `notes`, `source_reasons`, and `source_segment_ids`.
+    """
+
+    if not timeline.segments:
+        return
+
+    source_segments = sorted(
+        timeline.segments,
+        key=lambda seg: (_ensure_utc(seg.start_time), _ensure_utc(seg.end_time)),
+    )
+    mission_start = min(_ensure_utc(seg.start_time) for seg in source_segments)
+    mission_end = max(_ensure_utc(seg.end_time) for seg in source_segments)
+    aar_blocks = _extract_aar_blocks(timeline, mission_start, mission_end)
+
+    boundaries = {mission_start, mission_end}
+    for segment in source_segments:
+        boundaries.add(_ensure_utc(segment.start_time))
+        boundaries.add(_ensure_utc(segment.end_time))
+    for block in aar_blocks:
+        boundaries.add(block.start)
+        boundaries.add(block.end)
+
+    normalized: list[TimelineSegment] = []
+    ordered_boundaries = sorted(boundaries)
+    for index in range(len(ordered_boundaries) - 1):
+        start = ordered_boundaries[index]
+        end = ordered_boundaries[index + 1]
+        if start >= end:
+            continue
+
+        active_segments = [
+            segment
+            for segment in source_segments
+            if _ensure_utc(segment.start_time) <= start < _ensure_utc(segment.end_time)
+        ]
+        if not active_segments:
+            continue
+
+        in_sof = any(block.start <= start < block.end for block in aar_blocks)
+        decision = _decide_availability(active_segments, in_sof)
+        segment = _build_segment(
+            timeline.mission_leg_id,
+            len(normalized) + 1,
+            start,
+            end,
+            decision,
+        )
+        if normalized and _can_merge(normalized[-1], segment):
+            normalized[-1] = _merge_segments(normalized[-1], segment)
+        else:
+            normalized.append(segment)
+
+    timeline.segments = [
+        _renumber_segment(timeline.mission_leg_id, idx, segment)
+        for idx, segment in enumerate(normalized, start=1)
+    ]
+
+
+def _extract_aar_blocks(
+    timeline: MissionLegTimeline,
+    mission_start: datetime,
+    mission_end: datetime,
+) -> list[AARBlock]:
+    blocks = []
+    raw_blocks = (timeline.statistics or {}).get("_aar_blocks") or []
+    for raw in raw_blocks:
+        start_raw = raw.get("start") if isinstance(raw, dict) else None
+        end_raw = raw.get("end") if isinstance(raw, dict) else None
+        if not start_raw or not end_raw:
+            continue
+        start = max(_parse_timestamp(start_raw), mission_start)
+        end = min(_parse_timestamp(end_raw), mission_end)
+        if end > start:
+            blocks.append(AARBlock(start=start, end=end))
+    return blocks
+
+
+def _decide_availability(
+    segments: list[TimelineSegment], in_sof: bool
+) -> AvailabilityDecision:
+    x_state = _highest_state(segment.x_state for segment in segments)
+    ka_state = _highest_state(segment.ka_state for segment in segments)
+    ku_state = _highest_state(segment.ku_state for segment in segments)
+    source_reasons = tuple(
+        _unique(reason for segment in segments for reason in segment.reasons)
+    )
+    source_segment_ids = tuple(
+        _unique(segment.id for segment in segments if segment.id)
+    )
+    notes = tuple(
+        _unique(note for segment in segments for note in _segment_notes(segment))
+    )
+
+    impacted = tuple(
+        transport
+        for transport, state in (
+            (Transport.X, x_state),
+            (Transport.KA, ka_state),
+            (Transport.KU, ku_state),
+        )
+        if state != TransportState.AVAILABLE
+    )
+
+    if any(state == TransportState.OFFLINE for state in (x_state, ka_state, ku_state)):
+        status = (
+            TimelineStatus.CRITICAL if len(impacted) > 1 else TimelineStatus.DEGRADED
+        )
+        posture = "Unavailable"
+        primary = _primary_outage_reason(source_reasons)
+    elif in_sof:
+        status = TimelineStatus.DEGRADED
+        posture = "Avoid calls"
+        primary = _REASON_LABELS["sof"]
+    elif _has_ku_x_conflict(source_reasons):
+        status = TimelineStatus.DEGRADED
+        posture = "Degraded"
+        primary = _REASON_LABELS["ku_x"]
+    elif impacted or any(
+        segment.status != TimelineStatus.NOMINAL for segment in segments
+    ):
+        status = (
+            TimelineStatus.DEGRADED if len(impacted) <= 1 else TimelineStatus.CRITICAL
+        )
+        posture = "Activity conflict"
+        primary = _REASON_LABELS["activity"]
+    else:
+        status = TimelineStatus.NOMINAL
+        posture = "Nominal calls"
+        primary = _REASON_LABELS["nominal"]
+
+    if posture in ("Nominal calls", "Activity conflict"):
+        label = posture
+    else:
+        label = f"{posture} — {primary}"
+    return AvailabilityDecision(
+        status=status,
+        call_posture=posture,
+        primary_reason=primary,
+        availability_label=label,
+        impacted_transports=impacted,
+        x_state=x_state,
+        ka_state=ka_state,
+        ku_state=ku_state,
+        notes=notes,
+        source_reasons=source_reasons,
+        source_segment_ids=source_segment_ids,
+    )
+
+
+def _build_segment(
+    mission_id: str,
+    index: int,
+    start: datetime,
+    end: datetime,
+    decision: AvailabilityDecision,
+) -> TimelineSegment:
+    systems = [transport.value for transport in decision.impacted_transports]
+    metadata = {
+        "call_posture": decision.call_posture,
+        "primary_reason": decision.primary_reason,
+        "availability_label": decision.availability_label,
+        "systems_affected": systems,
+        "notes": list(decision.notes),
+        "source_reasons": list(decision.source_reasons),
+        "source_segment_ids": list(decision.source_segment_ids),
+    }
+    return TimelineSegment(
+        id=f"{mission_id}-availability-{index:03d}",
+        start_time=start,
+        end_time=end,
+        status=decision.status,
+        x_state=decision.x_state,
+        ka_state=decision.ka_state,
+        ku_state=decision.ku_state,
+        reasons=[decision.availability_label],
+        impacted_transports=list(decision.impacted_transports),
+        metadata=metadata,
+    )
+
+
+def _can_merge(left: TimelineSegment, right: TimelineSegment) -> bool:
+    left_meta = left.metadata or {}
+    right_meta = right.metadata or {}
+    return (
+        _ensure_utc(left.end_time) == _ensure_utc(right.start_time)
+        and left.status == right.status
+        and left.x_state == right.x_state
+        and left.ka_state == right.ka_state
+        and left.ku_state == right.ku_state
+        and left.impacted_transports == right.impacted_transports
+        and left_meta.get("call_posture") == right_meta.get("call_posture")
+        and left_meta.get("primary_reason") == right_meta.get("primary_reason")
+        and left_meta.get("availability_label") == right_meta.get("availability_label")
+        and left_meta.get("systems_affected") == right_meta.get("systems_affected")
+        and left_meta.get("notes") == right_meta.get("notes")
+        and left_meta.get("source_reasons") == right_meta.get("source_reasons")
+    )
+
+
+def _merge_segments(left: TimelineSegment, right: TimelineSegment) -> TimelineSegment:
+    merged_metadata = dict(left.metadata or {})
+    merged_metadata["source_segment_ids"] = list(
+        _unique(
+            list((left.metadata or {}).get("source_segment_ids", []))
+            + list((right.metadata or {}).get("source_segment_ids", []))
+        )
+    )
+    return left.model_copy(
+        update={"end_time": right.end_time, "metadata": merged_metadata}
+    )
+
+
+def _renumber_segment(
+    mission_id: str, index: int, segment: TimelineSegment
+) -> TimelineSegment:
+    return segment.model_copy(update={"id": f"{mission_id}-availability-{index:03d}"})
+
+
+def _highest_state(states: Iterable[TransportState]) -> TransportState:
+    ordered = list(states)
+    if not ordered:
+        return TransportState.AVAILABLE
+    return max(ordered, key=lambda state: _STATE_PRIORITY[state])
+
+
+def _segment_notes(segment: TimelineSegment) -> list[str]:
+    metadata = segment.metadata or {}
+    notes: list[str] = []
+    raw_notes = metadata.get("notes")
+    if isinstance(raw_notes, list):
+        notes.extend(str(note) for note in raw_notes if str(note).strip())
+    elif isinstance(raw_notes, str) and raw_notes.strip():
+        notes.append(raw_notes)
+    raw_note = metadata.get("note")
+    if isinstance(raw_note, str) and raw_note.strip():
+        notes.append(raw_note)
+    return notes
+
+
+def _primary_outage_reason(reasons: tuple[str, ...]) -> str:
+    for reason in reasons:
+        if "outage" in reason.lower():
+            return "system outage"
+    return "system outage"
+
+
+def _has_ku_x_conflict(reasons: tuple[str, ...]) -> bool:
+    for reason in reasons:
+        normalized = reason.lower().replace(" ", "")
+        if "x-ku" in normalized or "ku-x" in normalized or "x/ku" in normalized:
+            return True
+        if "ku/x" in normalized or (
+            "ku" in normalized and "x" in normalized and "conflict" in normalized
+        ):
+            return True
+    return False
+
+
+def _parse_timestamp(raw: str) -> datetime:
+    return _ensure_utc(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -34,6 +34,7 @@ from pptx import Presentation
 from pptx.util import Inches, Pt
 from pptx.enum.text import PP_ALIGN
 
+from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.models import (
     Mission,
     MissionLeg,
@@ -1271,10 +1272,12 @@ def _segment_rows(
     mission: Mission | None,
 ) -> pd.DataFrame:
     """Convert timeline segments into a pandas DataFrame."""
-    mission_start = mission_start_timestamp(timeline)
+    export_timeline = timeline.model_copy(deep=True)
+    normalize_call_availability_timeline(export_timeline)
+    mission_start = mission_start_timestamp(export_timeline)
     rows: list[tuple[datetime, int, dict]] = []
 
-    for idx, segment in enumerate(timeline.segments, start=1):
+    for idx, segment in enumerate(export_timeline.segments, start=1):
         start_utc = ensure_timezone(segment.start_time)
         end_value = segment.end_time if segment.end_time else segment.start_time
         end_utc = ensure_timezone(end_value)
@@ -1286,10 +1289,22 @@ def _segment_rows(
             else str(segment.status)
         )
         status_value = status_value.upper()
+        metadata = segment.metadata or {}
+        call_posture = metadata.get("call_posture") or status_value
+        primary_reason = metadata.get("primary_reason") or (
+            segment.reasons[0] if segment.reasons else ""
+        )
+        systems_affected = metadata.get("systems_affected") or [
+            transport.value for transport in segment.impacted_transports
+        ]
+        notes = metadata.get("notes") or []
+        source_reasons = metadata.get("source_reasons") or segment.reasons
+        notes_and_sources = _format_notes_and_sources(notes, source_reasons)
         impacted_display = serialize_transport_list(segment.impacted_transports)
         if warning_only:
             status_value = TimelineStatus.NOMINAL.value.upper()
             impacted_display = ""
+            systems_affected = []
         record = {
             "Segment #": idx,
             "Mission ID": mission.id if mission else timeline.mission_id,
@@ -1297,6 +1312,8 @@ def _segment_rows(
                 mission.name if mission and mission.name else timeline.mission_id
             ),
             "Status": status_value,
+            "Call Posture": call_posture,
+            "Primary Reason": primary_reason,
             "Start Time": compose_time_block(start_utc, mission_start),
             "End Time": compose_time_block(end_utc, mission_start),
             "Duration": format_seconds_hms(duration_seconds),
@@ -1306,20 +1323,25 @@ def _segment_rows(
             TRANSPORT_DISPLAY[Transport.KA]: segment.ka_state.value.upper(),
             TRANSPORT_DISPLAY[Transport.KU]: segment.ku_state.value.upper(),
             "Impacted Transports": impacted_display,
+            "Systems Affected": ", ".join(systems_affected),
             "Reasons": ", ".join(segment.reasons),
+            "Notes / Source Events": notes_and_sources,
             "Metadata": (
                 json.dumps(segment.metadata, sort_keys=True) if segment.metadata else ""
             ),
         }
         rows.append((start_utc, 1, record))
 
-    rows.extend(_aar_block_rows(timeline, mission, mission_start))
+    # AAR/SOF blocks are incorporated by normalize_call_availability_timeline()
+    # above so the primary table stays chronological and non-overlapping.
 
     columns = [
         "Segment #",
         "Mission ID",
         "Mission Name",
         "Status",
+        "Call Posture",
+        "Primary Reason",
         "Start Time",
         "End Time",
         "Duration",
@@ -1327,7 +1349,9 @@ def _segment_rows(
         TRANSPORT_DISPLAY[Transport.KA],
         TRANSPORT_DISPLAY[Transport.KU],
         "Impacted Transports",
+        "Systems Affected",
         "Reasons",
+        "Notes / Source Events",
         "Metadata",
     ]
 
@@ -1394,6 +1418,28 @@ def _statistics_rows(timeline: MissionLegTimeline) -> pd.DataFrame:
             display_value = format_seconds_hms(value)
         rows.append({"Metric": display_name, "Value": display_value})
     return pd.DataFrame(rows, columns=["Metric", "Value"])
+
+
+def _format_notes_and_sources(notes: object, source_reasons: object) -> str:
+    """Format concise notes/source context for the availability table."""
+    values: list[str] = []
+    if isinstance(notes, list):
+        values.extend(str(note) for note in notes if str(note).strip())
+    elif isinstance(notes, str) and notes.strip():
+        values.append(notes)
+    if isinstance(source_reasons, list):
+        values.extend(str(reason) for reason in source_reasons if str(reason).strip())
+    elif isinstance(source_reasons, str) and source_reasons.strip():
+        values.append(source_reasons)
+
+    seen: set[str] = set()
+    unique_values: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        unique_values.append(value)
+    return "; ".join(unique_values)
 
 
 # Note: format_seconds_hms, humanize_metric_name, and compose_time_block are now

--- a/backend/starlink-location/app/mission/timeline_service.py
+++ b/backend/starlink-location/app/mission/timeline_service.py
@@ -6,6 +6,7 @@ import logging
 import time
 from pathlib import Path
 
+from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.models import MissionLeg, MissionLegTimeline, Transport
 from app.mission.state import generate_transport_intervals
 from app.mission.timeline import assemble_mission_timeline
@@ -174,6 +175,7 @@ def build_mission_timeline(
         intervals=intervals,
     )
     annotate_aar_markers(timeline, events)
+    normalize_call_availability_timeline(timeline)
     attach_statistics(timeline, mission_start, mission_end)
 
     # Attach route samples if requested (for preview rendering)

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from io import BytesIO
 
-import openpyxl
 import pytest
 
 import app.mission.exporter as mission_exporter
@@ -97,7 +95,7 @@ def _build_test_timeline(mission_id: str) -> MissionLegTimeline:
 class TestTimelineExportFormat:
     def test_from_string_accepts_mixed_casing(self):
         assert TimelineExportFormat.from_string("CSV") is TimelineExportFormat.CSV
-        assert TimelineExportFormat.from_string("Pdf") is TimelineExportFormat.PDF
+        assert TimelineExportFormat.from_string("Pptx") is TimelineExportFormat.PPTX
 
     def test_from_string_invalid_raises(self):
         with pytest.raises(ExportGenerationError):
@@ -124,22 +122,11 @@ class TestMissionTimelineExporters:
         assert "CommKa" in output
         assert "StarShield" in output
 
-    def test_generate_xlsx_creates_multiple_sheets(self, mission, timeline):
+    def test_generate_pptx_starts_with_zip_header(self, mission, timeline):
         output = generate_timeline_export(
-            TimelineExportFormat.XLSX, mission, timeline
+            TimelineExportFormat.PPTX, mission, timeline
         ).content
-        workbook = openpyxl.load_workbook(filename=BytesIO(output))
-        assert "Timeline" in workbook.sheetnames
-        assert workbook["Timeline"]["A2"].value == 1  # First segment number
-
-        # Advisories sheet should exist because we provided one
-        assert "Advisories" in workbook.sheetnames
-
-    def test_generate_pdf_starts_with_pdf_header(self, mission, timeline):
-        output = generate_timeline_export(
-            TimelineExportFormat.PDF, mission, timeline
-        ).content
-        assert output.startswith(b"%PDF")
+        assert output.startswith(b"PK")
 
     def test_generate_timeline_export_router(self, mission, timeline):
         artifact = generate_timeline_export(TimelineExportFormat.CSV, mission, timeline)
@@ -169,11 +156,13 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         row = df.iloc[0]
-        assert row["Status"] == "NOMINAL"
-        assert row["X-Band"] == "WARNING"
-        assert row["Impacted Transports"] == ""
+        assert row["Status"] == "DEGRADED"
+        assert row["Call Posture"] == "Degraded"
+        assert row["Primary Reason"] == "Ku/X conflict"
+        assert row["X-Band"] == "DEGRADED"
+        assert row["Systems Affected"] == "X"
 
-    def test_aar_block_rows_inserted(self, mission):
+    def test_aar_block_rows_normalize_primary_table_without_overlap(self, mission):
         start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
         segments = [
             TimelineSegment(
@@ -204,11 +193,8 @@ class TestMissionTimelineExporters:
         )
 
         df = mission_exporter._segment_rows(timeline, mission)
-        assert "WARNING" in df["Status"].values
-        aar_rows = df[df["Segment #"] == "AAR"]
-        assert len(aar_rows) == 1
-        aar_row = aar_rows.iloc[0]
-        assert aar_row["Reasons"] == "AAR"
-        assert aar_row["X-Band"] == "AVAILABLE"
-        assert aar_row["CommKa"] == "AVAILABLE"
-        assert aar_row["StarShield"] == "AVAILABLE"
+        assert "AAR" not in df["Segment #"].values
+        assert list(df["Call Posture"]) == ["Avoid calls", "Nominal calls"]
+        assert list(df["Primary Reason"]) == ["SOF AAR", "nominal window"]
+        assert list(df["Reasons"]) == ["Avoid calls — SOF AAR", "Nominal calls"]
+        assert df.iloc[0]["Systems Affected"] == ""

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -9,6 +9,7 @@ from app.mission.models import (
     Transport,
     TransportState,
 )
+from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.state import TransportInterval
 from app.mission.timeline import build_timeline_segments
 from app.mission.timeline_builder.stats import annotate_aar_markers
@@ -195,3 +196,185 @@ def test_annotate_aar_markers_appends_reasons():
     expected_end = (BASE + timedelta(minutes=45)).isoformat()
     assert block["start"] == expected_start
     assert block["end"] == expected_end
+
+
+def _timeline_from_segments(segments, statistics=None):
+    return MissionLegTimeline(
+        mission_leg_id="mission-1",
+        segments=segments,
+        advisories=[],
+        statistics=statistics or {},
+    )
+
+
+def _segment(seg_id, start_offset, end_offset, status, reasons=None, metadata=None):
+    return TimelineSegment(
+        id=seg_id,
+        start_time=BASE + timedelta(minutes=start_offset),
+        end_time=BASE + timedelta(minutes=end_offset),
+        status=status,
+        x_state=TransportState.AVAILABLE,
+        ka_state=TransportState.AVAILABLE,
+        ku_state=TransportState.AVAILABLE,
+        reasons=reasons or [],
+        impacted_transports=[],
+        metadata=metadata or {},
+    )
+
+
+def test_call_availability_sof_carves_hole_out_of_nominal_window():
+    timeline = _timeline_from_segments(
+        [_segment("seg-1", 0, 60, TimelineStatus.NOMINAL)],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=20)).isoformat(),
+                    "end": (BASE + timedelta(minutes=40)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert [(s.start_time, s.end_time) for s in timeline.segments] == [
+        (BASE, BASE + timedelta(minutes=20)),
+        (BASE + timedelta(minutes=20), BASE + timedelta(minutes=40)),
+        (BASE + timedelta(minutes=40), BASE + timedelta(minutes=60)),
+    ]
+    assert [s.metadata["call_posture"] for s in timeline.segments] == [
+        "Nominal calls",
+        "Avoid calls",
+        "Nominal calls",
+    ]
+    assert timeline.segments[1].metadata["primary_reason"] == "SOF AAR"
+    assert timeline.segments[1].reasons == ["Avoid calls — SOF AAR"]
+
+
+def test_call_availability_priority_sof_wins_over_nominal_but_not_outage():
+    outage = _segment(
+        "seg-outage",
+        10,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["Ka outage"],
+    )
+    outage.ka_state = TransportState.OFFLINE
+    outage.impacted_transports = [Transport.KA]
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-nominal-a", 0, 10, TimelineStatus.NOMINAL),
+            outage,
+            _segment("seg-nominal-b", 20, 30, TimelineStatus.NOMINAL),
+        ],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=5)).isoformat(),
+                    "end": (BASE + timedelta(minutes=25)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    labels = [s.metadata["availability_label"] for s in timeline.segments]
+    assert labels == [
+        "Nominal calls",
+        "Avoid calls — SOF AAR",
+        "Unavailable — system outage",
+        "Avoid calls — SOF AAR",
+        "Nominal calls",
+    ]
+
+
+def test_call_availability_ku_x_conflict_is_degraded_block():
+    conflict = _segment(
+        "seg-conflict",
+        15,
+        25,
+        TimelineStatus.DEGRADED,
+        reasons=["X-Ku Conflict az=180° el=20°"],
+    )
+    conflict.x_state = TransportState.DEGRADED
+    conflict.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-a", 0, 15, TimelineStatus.NOMINAL),
+            conflict,
+            _segment("seg-b", 25, 40, TimelineStatus.NOMINAL),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[1].metadata["call_posture"] == "Degraded"
+    assert timeline.segments[1].metadata["primary_reason"] == "Ku/X conflict"
+    assert (
+        timeline.segments[1].metadata["availability_label"]
+        == "Degraded — Ku/X conflict"
+    )
+    assert timeline.segments[1].impacted_transports == [Transport.X]
+
+
+def test_call_availability_merges_adjacent_only_when_labels_match():
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-a", 0, 10, TimelineStatus.NOMINAL),
+            _segment("seg-b", 10, 20, TimelineStatus.NOMINAL),
+            _segment(
+                "seg-c", 20, 30, TimelineStatus.NOMINAL, metadata={"note": "handoff"}
+            ),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert [(s.start_time, s.end_time) for s in timeline.segments] == [
+        (BASE, BASE + timedelta(minutes=20)),
+        (BASE + timedelta(minutes=20), BASE + timedelta(minutes=30)),
+    ]
+    assert timeline.segments[0].metadata["source_segment_ids"] == ["seg-a", "seg-b"]
+    assert timeline.segments[1].metadata["notes"] == ["handoff"]
+
+
+def test_call_availability_rows_are_sorted_and_non_overlapping():
+    conflict = _segment(
+        "seg-conflict",
+        5,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["Other activity conflict"],
+    )
+    conflict.x_state = TransportState.DEGRADED
+    conflict.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [
+            conflict,
+            _segment("seg-nominal", 0, 5, TimelineStatus.NOMINAL),
+            _segment("seg-tail", 20, 30, TimelineStatus.NOMINAL),
+        ],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=10)).isoformat(),
+                    "end": (BASE + timedelta(minutes=15)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    starts = [s.start_time for s in timeline.segments]
+    assert starts == sorted(starts)
+    for prev, nxt in zip(timeline.segments, timeline.segments[1:]):
+        assert prev.end_time <= nxt.start_time
+    assert [s.metadata["availability_label"] for s in timeline.segments] == [
+        "Nominal calls",
+        "Activity conflict",
+        "Avoid calls — SOF AAR",
+        "Activity conflict",
+        "Nominal calls",
+    ]

--- a/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
+++ b/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
@@ -50,6 +50,51 @@ function calculateDuration(start: string, end: string): string {
   }
 }
 
+function metadataString(segment: TimelineSegment, key: string): string | null {
+  const value = segment.metadata?.[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function metadataStringList(segment: TimelineSegment, key: string): string[] {
+  const value = segment.metadata?.[key];
+  if (Array.isArray(value)) {
+    return value.filter(
+      (item): item is string =>
+        typeof item === 'string' && item.trim().length > 0
+    );
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [value];
+  }
+  return [];
+}
+
+function availabilityLabel(segment: TimelineSegment): string {
+  return metadataString(segment, 'availability_label') || segment.status;
+}
+
+function callPosture(segment: TimelineSegment): string {
+  return metadataString(segment, 'call_posture') || segment.status;
+}
+
+function primaryReason(segment: TimelineSegment): string {
+  return (
+    metadataString(segment, 'primary_reason') || segment.reasons?.[0] || '—'
+  );
+}
+
+function systemsAffected(segment: TimelineSegment): string {
+  const systems = metadataStringList(segment, 'systems_affected');
+  return systems.length > 0 ? systems.join(', ') : '—';
+}
+
+function notesAndSources(segment: TimelineSegment): string[] {
+  const notes = metadataStringList(segment, 'notes');
+  const sources = metadataStringList(segment, 'source_reasons');
+  const values = [...notes, ...sources];
+  return values.filter((item, index) => values.indexOf(item) === index);
+}
+
 export const TimelineTable: React.FC<TimelineTableProps> = ({
   timeline,
   isLoading = false,
@@ -88,88 +133,94 @@ export const TimelineTable: React.FC<TimelineTableProps> = ({
               Segment
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Status
+              Call Posture
+            </th>
+            <th className="px-4 py-2 text-left font-semibold text-gray-700">
+              Primary Reason
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
               Start Time (UTC)
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
+              End Time (UTC)
+            </th>
+            <th className="px-4 py-2 text-left font-semibold text-gray-700">
               Duration
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              X State
+              Systems Affected
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Ka State
-            </th>
-            <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Ku State
-            </th>
-            <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Reasons
+              Notes / Source Events
             </th>
           </tr>
         </thead>
         <tbody className="divide-y">
-          {displaySegments.map((segment: TimelineSegment, index: number) => (
-            <tr
-              key={segment.id || index}
-              className={`hover:bg-gray-50 ${
-                STATUS_COLORS[segment.status.toLowerCase()] || ''
-              }`}
-            >
-              <td className="px-4 py-2 text-gray-700">{index + 1}</td>
-              <td className="px-4 py-2">
-                <div className="flex items-center gap-2">
-                  <div
-                    className={`w-3 h-3 rounded-full ${
-                      STATUS_BADGE_COLORS[segment.status.toLowerCase()] ||
-                      'bg-gray-400'
-                    }`}
-                  ></div>
-                  <span className="font-medium capitalize">
-                    {segment.status}
-                  </span>
-                </div>
-              </td>
-              <td className="px-4 py-2 font-mono text-xs">
-                {formatTime(segment.start_time)}
-              </td>
-              <td className="px-4 py-2">
-                {calculateDuration(segment.start_time, segment.end_time)}
-              </td>
-              <td className="px-4 py-2 capitalize text-xs">
-                {segment.x_state || 'unknown'}
-              </td>
-              <td className="px-4 py-2 capitalize text-xs">
-                {segment.ka_state || 'unknown'}
-              </td>
-              <td className="px-4 py-2 capitalize text-xs">
-                {segment.ku_state || 'unknown'}
-              </td>
-              <td className="px-4 py-2 text-xs">
-                {segment.reasons && segment.reasons.length > 0 ? (
-                  <div className="space-y-1">
-                    {segment.reasons.slice(0, 2).map((reason, i) => (
-                      <div
-                        key={i}
-                        className="bg-gray-200 px-2 py-1 rounded text-gray-700"
-                      >
-                        {reason}
-                      </div>
-                    ))}
-                    {segment.reasons.length > 2 && (
-                      <div className="text-gray-500">
-                        +{segment.reasons.length - 2} more
-                      </div>
-                    )}
+          {displaySegments.map((segment: TimelineSegment, index: number) => {
+            const sourceNotes = notesAndSources(segment);
+            return (
+              <tr
+                key={segment.id || index}
+                className={`hover:bg-gray-50 ${
+                  STATUS_COLORS[segment.status.toLowerCase()] || ''
+                }`}
+              >
+                <td className="px-4 py-2 text-gray-700">{index + 1}</td>
+                <td className="px-4 py-2">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={`w-3 h-3 rounded-full ${
+                        STATUS_BADGE_COLORS[segment.status.toLowerCase()] ||
+                        'bg-gray-400'
+                      }`}
+                    ></div>
+                    <span className="font-medium">
+                      {availabilityLabel(segment)}
+                    </span>
                   </div>
-                ) : (
-                  '-'
-                )}
-              </td>
-            </tr>
-          ))}
+                  <div className="text-xs text-gray-600">
+                    {callPosture(segment)}
+                  </div>
+                </td>
+                <td className="px-4 py-2 text-xs text-gray-700">
+                  {primaryReason(segment)}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs">
+                  {formatTime(segment.start_time)}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs">
+                  {formatTime(segment.end_time)}
+                </td>
+                <td className="px-4 py-2">
+                  {calculateDuration(segment.start_time, segment.end_time)}
+                </td>
+                <td className="px-4 py-2 text-xs">
+                  {systemsAffected(segment)}
+                </td>
+                <td className="px-4 py-2 text-xs">
+                  {sourceNotes.length > 0 ? (
+                    <div className="space-y-1">
+                      {sourceNotes.slice(0, 2).map((note, i) => (
+                        <div
+                          key={i}
+                          className="bg-gray-200 px-2 py-1 rounded text-gray-700"
+                        >
+                          {note}
+                        </div>
+                      ))}
+                      {sourceNotes.length > 2 && (
+                        <div className="text-gray-500">
+                          +{sourceNotes.length - 2} more
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- add a sweep-line call availability normalizer that emits chronological, non-overlapping mission timeline blocks
- fold SOF/AAR, outage, Ku/X conflict, and activity priority labels into API/export metadata
- update mission timeline UI/export rows to show call posture, primary reason, systems affected, and concise source notes
- add regression coverage for SOF carve-outs, priority ordering, Ku/X degraded blocks, merge behavior, and sorted non-overlapping rows

## Test Plan
- [x] `python -m pytest tests/unit/test_mission_timeline.py tests/unit/test_mission_exporter.py`
- [x] `python -m ruff check app/mission/call_availability.py app/mission/exporter/__main__.py app/mission/timeline_service.py tests/unit/test_mission_timeline.py tests/unit/test_mission_exporter.py`
- [x] `python -m black --check app/mission/call_availability.py app/mission/exporter/__main__.py app/mission/timeline_service.py tests/unit/test_mission_timeline.py tests/unit/test_mission_exporter.py`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx prettier --check src/components/timeline/TimelineTable.tsx`

## Known limitations / unrelated failures
- `python -m pytest tests/unit` currently fails during collection in `tests/unit/test_package_exporter.py` because it imports missing `generate_mission_combined_xlsx` from `app.mission.package.__main__`; this appears unrelated to this change.
- Docker runtime verification could not be performed in this worker environment because `docker` is not installed (`/usr/bin/bash: docker: command not found`).
- The original uploaded chat attachment was not present in the worker environment; implementation proceeded from the card description and repo fixtures.

Refs kanban task `t_9229765d`.
