### PR TITLE
Release: promote aircraft-test timeline updates

### DIFF
--- a/backend/starlink-location/Dockerfile
+++ b/backend/starlink-location/Dockerfile
@@ -17,22 +17,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Python dependencies from builder
-COPY --from=builder /root/.local /home/appuser/.local
+# Create non-root user for security before copying dependencies into its home.
+# COPY --chown avoids a slow recursive chown over the installed Python package tree.
+RUN useradd -m -u 1000 appuser
 
-# Copy application code and configuration
-COPY main.py .
-COPY config.yaml .
-COPY app/ ./app/
-COPY tests/ ./tests/
+# Copy Python dependencies from builder with final ownership already set
+COPY --from=builder --chown=appuser:appuser /root/.local /home/appuser/.local
 
-# Create non-root user for security
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+# Copy application code and configuration with final ownership already set
+COPY --chown=appuser:appuser main.py .
+COPY --chown=appuser:appuser config.yaml .
+COPY --chown=appuser:appuser app/ ./app/
+COPY --chown=appuser:appuser tests/ ./tests/
 
-# Create data directories with proper permissions
+# Create data/cache directories with proper permissions without walking the dependency tree
 RUN mkdir -p /data/routes /data/sim_routes /home/appuser/.local/share/cartopy /home/appuser/.config/matplotlib /home/appuser/.cache/matplotlib && \
-    chown -R appuser:appuser /data /home/appuser/.local /home/appuser/.config /home/appuser/.cache && \
-    chmod -R 755 /data /home/appuser/.local /home/appuser/.config /home/appuser/.cache
+    chown appuser:appuser /data /data/routes /data/sim_routes /home/appuser/.local/share/cartopy /home/appuser/.config /home/appuser/.config/matplotlib /home/appuser/.cache /home/appuser/.cache/matplotlib && \
+    chmod 755 /data /data/routes /data/sim_routes /home/appuser/.local /home/appuser/.local/share /home/appuser/.local/share/cartopy /home/appuser/.config /home/appuser/.config/matplotlib /home/appuser/.cache /home/appuser/.cache/matplotlib
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -199,7 +199,11 @@ def _decide_availability(
     ka_state = _highest_state(segment.ka_state for segment in segments)
     ku_state = _highest_state(segment.ku_state for segment in segments)
     source_reasons = tuple(
-        _unique(reason for segment in segments for reason in _segment_source_reasons(segment))
+        _unique(
+            reason
+            for segment in segments
+            for reason in _segment_source_reasons(segment)
+        )
     )
     source_segment_ids = tuple(
         _unique(segment.id for segment in segments if segment.id)
@@ -253,10 +257,15 @@ def _decide_availability(
         status = TimelineStatus.DEGRADED
         posture = "Degraded"
         primary = _REASON_LABELS["x_aar"]
-    elif impacted or source_status in (TimelineStatus.DEGRADED, TimelineStatus.CRITICAL):
-        status = TimelineStatus.CRITICAL if (
-            len(impacted) > 1 or source_status == TimelineStatus.CRITICAL
-        ) else TimelineStatus.DEGRADED
+    elif impacted or source_status in (
+        TimelineStatus.DEGRADED,
+        TimelineStatus.CRITICAL,
+    ):
+        status = (
+            TimelineStatus.CRITICAL
+            if (len(impacted) > 1 or source_status == TimelineStatus.CRITICAL)
+            else TimelineStatus.DEGRADED
+        )
         posture = "Degraded" if status == TimelineStatus.DEGRADED else "Critical"
         primary = _combined_degrade_reason(source_reasons, skip_ku_x=has_ku_x_conflict)
     elif sof_reason := _primary_sof_reason(source_reasons):
@@ -280,9 +289,7 @@ def _decide_availability(
         label = primary
     else:
         label = f"{posture} — {primary}"
-    operational_markers = _operational_markers(
-        source_reasons, in_sof, boundary_markers
-    )
+    operational_markers = _operational_markers(source_reasons, in_sof, boundary_markers)
     label = _label_with_markers(label, operational_markers)
     return AvailabilityDecision(
         status=status,
@@ -431,11 +438,18 @@ def _combined_degrade_reason(
         if skip_ku_x and _has_ku_x_conflict((reason,)):
             continue
         normalized = reason.lower()
-        if "safety-of-flight" in normalized or normalized == _REASON_LABELS["aar"].lower():
+        if (
+            "safety-of-flight" in normalized
+            or normalized == _REASON_LABELS["aar"].lower()
+        ):
             continue
         if _is_satellite_swap_reason(reason):
             label = f"Satellite swap: {reason}"
-        elif "outage" in normalized or "coverage gap" in normalized or "transition" in normalized:
+        elif (
+            "outage" in normalized
+            or "coverage gap" in normalized
+            or "transition" in normalized
+        ):
             label = reason
         else:
             label = reason
@@ -455,7 +469,9 @@ def _primary_activity_reason(
     reasons: tuple[str, ...], *, skip_ku_x: bool = False
 ) -> str:
     filtered_reasons = tuple(
-        reason for reason in reasons if not (skip_ku_x and _has_ku_x_conflict((reason,)))
+        reason
+        for reason in reasons
+        if not (skip_ku_x and _has_ku_x_conflict((reason,)))
     )
     for reason in filtered_reasons:
         if _is_satellite_swap_reason(reason):

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -45,6 +45,7 @@ class AvailabilityDecision:
     source_reasons: tuple[str, ...]
     source_segment_ids: tuple[str, ...]
     boundary_markers: tuple[str, ...]
+    operational_markers: tuple[str, ...]
 
 
 _STATE_PRIORITY = {
@@ -166,6 +167,29 @@ def _boundary_markers(start: datetime, aar_blocks: list[AARBlock]) -> tuple[str,
     return tuple(markers)
 
 
+def _operational_markers(
+    source_reasons: tuple[str, ...],
+    in_sof: bool,
+    boundary_markers: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return operator-legible timeline markers separate from status reasons."""
+
+    markers: list[str] = list(boundary_markers)
+    if in_sof:
+        markers.append("AAR window")
+    for reason in source_reasons:
+        normalized = reason.lower()
+        if "safety-of-flight" not in normalized:
+            continue
+        if "landing" in normalized:
+            markers.append("Landing safety window")
+        elif "takeoff" in normalized:
+            markers.append("Takeoff safety window")
+        else:
+            markers.append("Safety-of-flight window")
+    return tuple(_unique(markers))
+
+
 def _decide_availability(
     segments: list[TimelineSegment],
     in_sof: bool,
@@ -256,8 +280,9 @@ def _decide_availability(
         label = primary
     else:
         label = f"{posture} — {primary}"
-    if boundary_markers and status in (TimelineStatus.DEGRADED, TimelineStatus.CRITICAL):
-        label = f"{label}; {', '.join(boundary_markers)}"
+    operational_markers = _operational_markers(
+        source_reasons, in_sof, boundary_markers
+    )
     return AvailabilityDecision(
         status=status,
         call_posture=posture,
@@ -271,6 +296,7 @@ def _decide_availability(
         source_reasons=source_reasons,
         source_segment_ids=source_segment_ids,
         boundary_markers=boundary_markers,
+        operational_markers=operational_markers,
     )
 
 
@@ -291,6 +317,7 @@ def _build_segment(
         "source_reasons": list(decision.source_reasons),
         "source_segment_ids": list(decision.source_segment_ids),
         "boundary_markers": list(decision.boundary_markers),
+        "operational_markers": list(decision.operational_markers),
     }
     return TimelineSegment(
         id=f"{mission_id}-availability-{index:03d}",
@@ -321,8 +348,9 @@ def _can_merge(left: TimelineSegment, right: TimelineSegment) -> bool:
         and left_meta.get("availability_label") == right_meta.get("availability_label")
         and left_meta.get("systems_affected") == right_meta.get("systems_affected")
         and left_meta.get("notes") == right_meta.get("notes")
-        and left_meta.get("source_reasons") == right_meta.get("source_reasons")
         and left_meta.get("boundary_markers") == right_meta.get("boundary_markers")
+        and left_meta.get("operational_markers")
+        == right_meta.get("operational_markers")
     )
 
 

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -283,6 +283,7 @@ def _decide_availability(
     operational_markers = _operational_markers(
         source_reasons, in_sof, boundary_markers
     )
+    label = _label_with_markers(label, operational_markers)
     return AvailabilityDecision(
         status=status,
         call_posture=posture,
@@ -298,6 +299,16 @@ def _decide_availability(
         boundary_markers=boundary_markers,
         operational_markers=operational_markers,
     )
+
+
+def _label_with_markers(label: str, markers: tuple[str, ...]) -> str:
+    visible_markers = tuple(
+        marker for marker in markers if marker.lower() not in label.lower()
+    )
+    if not visible_markers:
+        return label
+    marker_text = "; ".join(visible_markers)
+    return f"{label}; {marker_text}"
 
 
 def _build_segment(

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -54,8 +54,9 @@ _STATE_PRIORITY = {
 
 _REASON_LABELS = {
     "outage": "system outage",
-    "sof": "SOF AAR",
-    "ku_x": "Ku/X conflict",
+    "aar": "AAR window",
+    "ku_x": "X Band / Ku conflict",
+    "x_aar": "X Band / AAR conflict",
     "activity": "operational activity conflict",
     "nominal": "nominal window",
 }
@@ -176,29 +177,39 @@ def _decide_availability(
         )
         posture = "Unavailable"
         primary = _primary_outage_reason(source_reasons)
-    elif in_sof:
-        status = TimelineStatus.DEGRADED
-        posture = "Avoid calls"
-        primary = _REASON_LABELS["sof"]
     elif _has_ku_x_conflict(source_reasons):
         status = TimelineStatus.DEGRADED
         posture = "Degraded"
         primary = _REASON_LABELS["ku_x"]
+    elif _has_x_aar_conflict(source_reasons, in_sof, impacted, x_state):
+        status = TimelineStatus.DEGRADED
+        posture = "Degraded"
+        primary = _REASON_LABELS["x_aar"]
     elif impacted or any(
         segment.status != TimelineStatus.NOMINAL for segment in segments
     ):
         status = (
             TimelineStatus.DEGRADED if len(impacted) <= 1 else TimelineStatus.CRITICAL
         )
-        posture = "Activity conflict"
-        primary = _REASON_LABELS["activity"]
+        posture = "Degraded" if status == TimelineStatus.DEGRADED else "Critical"
+        primary = _primary_activity_reason(source_reasons)
+    elif sof_reason := _primary_sof_reason(source_reasons):
+        status = TimelineStatus.DEGRADED
+        posture = "Avoid calls"
+        primary = sof_reason
+    elif in_sof:
+        status = TimelineStatus.NOMINAL
+        posture = "Safety-of-flight advised"
+        primary = _REASON_LABELS["aar"]
     else:
         status = TimelineStatus.NOMINAL
         posture = "Nominal calls"
         primary = _REASON_LABELS["nominal"]
 
-    if posture in ("Nominal calls", "Activity conflict"):
+    if posture == "Nominal calls":
         label = posture
+    elif posture == "Degraded" and primary.lower().endswith("activity conflict"):
+        label = primary
     else:
         label = f"{posture} — {primary}"
     return AvailabilityDecision(
@@ -313,6 +324,39 @@ def _primary_outage_reason(reasons: tuple[str, ...]) -> str:
     return "system outage"
 
 
+def _primary_sof_reason(reasons: tuple[str, ...]) -> str | None:
+    for reason in reasons:
+        if "safety-of-flight" in reason.lower():
+            return reason
+    return None
+
+
+def _primary_activity_reason(reasons: tuple[str, ...]) -> str:
+    for reason in reasons:
+        if _is_satellite_swap_reason(reason):
+            return f"Satellite swap: {reason}"
+    for reason in reasons:
+        if reason and reason.strip():
+            return reason
+    return _REASON_LABELS["activity"]
+
+
+def _is_satellite_swap_reason(reason: str | None) -> bool:
+    if not reason:
+        return False
+    normalized = reason.lower()
+    return any(
+        token in normalized
+        for token in (
+            "satellite swap",
+            "transition",
+            "coverage swap",
+            "coverage lost",
+            "coverage exit",
+        )
+    )
+
+
 def _has_ku_x_conflict(reasons: tuple[str, ...]) -> bool:
     for reason in reasons:
         normalized = reason.lower().replace(" ", "")
@@ -323,6 +367,23 @@ def _has_ku_x_conflict(reasons: tuple[str, ...]) -> bool:
         ):
             return True
     return False
+
+
+def _has_x_aar_conflict(
+    reasons: tuple[str, ...],
+    in_aar: bool,
+    impacted: tuple[Transport, ...],
+    x_state: TransportState,
+) -> bool:
+    for reason in reasons:
+        normalized = reason.lower().replace("-", " ").replace("/", " ")
+        has_x_band_marker = any(
+            marker in normalized
+            for marker in ("x band", "xband", "x aar", "x azimuth", "x conflict")
+        )
+        if "aar" in normalized and (has_x_band_marker or "azimuth" in normalized):
+            return True
+    return in_aar and Transport.X in impacted and x_state != TransportState.AVAILABLE
 
 
 def _parse_timestamp(raw: str) -> datetime:

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -68,6 +68,11 @@ _REASON_LABELS = {
     "nominal": "nominal window",
 }
 
+_KU_X_ADVISORY_LABEL = (
+    "Transport concurrency advisory: X Band / Ku conflict — choose one "
+    "transport; PACE preference Starlink > Comm Ka > X-Band"
+)
+
 
 def normalize_call_availability_timeline(timeline: MissionLegTimeline) -> None:
     """Replace timeline segments with merged, non-overlapping availability rows.
@@ -172,6 +177,23 @@ def _decide_availability(
         key=lambda status: _STATUS_PRIORITY.get(status, 0),
     )
 
+    has_ku_x_conflict = _has_ku_x_conflict(source_reasons)
+    if (
+        has_ku_x_conflict
+        and x_state == TransportState.DEGRADED
+        and not _has_actual_x_degradation(source_reasons, in_sof)
+    ):
+        x_state = TransportState.AVAILABLE
+
+    if (
+        has_ku_x_conflict
+        and source_status == TimelineStatus.DEGRADED
+        and all(
+            state == TransportState.AVAILABLE for state in (x_state, ka_state, ku_state)
+        )
+    ):
+        source_status = TimelineStatus.NOMINAL
+
     impacted = tuple(
         transport
         for transport, state in (
@@ -188,9 +210,9 @@ def _decide_availability(
         )
         posture = "Unavailable"
         primary = _primary_outage_reason(source_reasons)
-    elif _has_ku_x_conflict(source_reasons):
-        status = TimelineStatus.DEGRADED
-        posture = "Degraded"
+    elif has_ku_x_conflict and not impacted:
+        status = TimelineStatus.SOF
+        posture = "Transport concurrency advisory"
         primary = _REASON_LABELS["ku_x"]
     elif _has_x_aar_conflict(source_reasons, in_sof, impacted, x_state):
         status = TimelineStatus.DEGRADED
@@ -201,7 +223,7 @@ def _decide_availability(
             len(impacted) > 1 or source_status == TimelineStatus.CRITICAL
         ) else TimelineStatus.DEGRADED
         posture = "Degraded" if status == TimelineStatus.DEGRADED else "Critical"
-        primary = _primary_activity_reason(source_reasons)
+        primary = _primary_activity_reason(source_reasons, skip_ku_x=has_ku_x_conflict)
     elif sof_reason := _primary_sof_reason(source_reasons):
         status = TimelineStatus.SOF
         posture = "Avoid calls"
@@ -215,7 +237,9 @@ def _decide_availability(
         posture = "Nominal calls"
         primary = _REASON_LABELS["nominal"]
 
-    if posture == "Nominal calls":
+    if posture == "Transport concurrency advisory":
+        label = _KU_X_ADVISORY_LABEL
+    elif posture == "Nominal calls":
         label = posture
     elif posture == "Degraded" and primary.lower().endswith("activity conflict"):
         label = primary
@@ -340,11 +364,16 @@ def _primary_sof_reason(reasons: tuple[str, ...]) -> str | None:
     return None
 
 
-def _primary_activity_reason(reasons: tuple[str, ...]) -> str:
-    for reason in reasons:
+def _primary_activity_reason(
+    reasons: tuple[str, ...], *, skip_ku_x: bool = False
+) -> str:
+    filtered_reasons = tuple(
+        reason for reason in reasons if not (skip_ku_x and _has_ku_x_conflict((reason,)))
+    )
+    for reason in filtered_reasons:
         if _is_satellite_swap_reason(reason):
             return f"Satellite swap: {reason}"
-    for reason in reasons:
+    for reason in filtered_reasons:
         if reason and reason.strip():
             return reason
     return _REASON_LABELS["activity"]
@@ -374,6 +403,23 @@ def _has_ku_x_conflict(reasons: tuple[str, ...]) -> bool:
         if "ku/x" in normalized or (
             "ku" in normalized and "x" in normalized and "conflict" in normalized
         ):
+            return True
+    return False
+
+
+def _has_actual_x_degradation(reasons: tuple[str, ...], in_aar: bool) -> bool:
+    for reason in reasons:
+        if _has_ku_x_conflict((reason,)):
+            continue
+        if _is_satellite_swap_reason(reason):
+            return True
+        normalized = reason.lower().replace("-", " ").replace("/", " ")
+        if any(
+            marker in normalized
+            for marker in ("x band", "xband", "x transition", "x azimuth")
+        ):
+            return True
+        if in_aar and "x" in normalized and "aar" in normalized:
             return True
     return False
 

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -161,7 +161,7 @@ def _decide_availability(
     ka_state = _highest_state(segment.ka_state for segment in segments)
     ku_state = _highest_state(segment.ku_state for segment in segments)
     source_reasons = tuple(
-        _unique(reason for segment in segments for reason in segment.reasons)
+        _unique(reason for segment in segments for reason in _segment_source_reasons(segment))
     )
     source_segment_ids = tuple(
         _unique(segment.id for segment in segments if segment.id)
@@ -331,6 +331,18 @@ def _highest_state(states: Iterable[TransportState]) -> TransportState:
     if not ordered:
         return TransportState.AVAILABLE
     return max(ordered, key=lambda state: _STATE_PRIORITY[state])
+
+
+def _segment_source_reasons(segment: TimelineSegment) -> list[str]:
+    metadata = segment.metadata or {}
+    raw_source_reasons = metadata.get("source_reasons")
+    if isinstance(raw_source_reasons, list):
+        values = [str(reason) for reason in raw_source_reasons if str(reason).strip()]
+        if values:
+            return values
+    elif isinstance(raw_source_reasons, str) and raw_source_reasons.strip():
+        return [raw_source_reasons]
+    return [str(reason) for reason in segment.reasons if str(reason).strip()]
 
 
 def _segment_notes(segment: TimelineSegment) -> list[str]:

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -44,6 +44,7 @@ class AvailabilityDecision:
     notes: tuple[str, ...]
     source_reasons: tuple[str, ...]
     source_segment_ids: tuple[str, ...]
+    boundary_markers: tuple[str, ...]
 
 
 _STATE_PRIORITY = {
@@ -116,7 +117,8 @@ def normalize_call_availability_timeline(timeline: MissionLegTimeline) -> None:
             continue
 
         in_sof = any(block.start <= start < block.end for block in aar_blocks)
-        decision = _decide_availability(active_segments, in_sof)
+        boundary_markers = _boundary_markers(start, aar_blocks)
+        decision = _decide_availability(active_segments, in_sof, boundary_markers)
         segment = _build_segment(
             timeline.mission_leg_id,
             len(normalized) + 1,
@@ -154,8 +156,20 @@ def _extract_aar_blocks(
     return blocks
 
 
+def _boundary_markers(start: datetime, aar_blocks: list[AARBlock]) -> tuple[str, ...]:
+    markers: list[str] = []
+    for block in aar_blocks:
+        if start == block.start:
+            markers.append("AAR Start")
+        if start == block.end:
+            markers.append("AAR End")
+    return tuple(markers)
+
+
 def _decide_availability(
-    segments: list[TimelineSegment], in_sof: bool
+    segments: list[TimelineSegment],
+    in_sof: bool,
+    boundary_markers: tuple[str, ...] = (),
 ) -> AvailabilityDecision:
     x_state = _highest_state(segment.x_state for segment in segments)
     ka_state = _highest_state(segment.ka_state for segment in segments)
@@ -206,7 +220,7 @@ def _decide_availability(
             TimelineStatus.CRITICAL if len(impacted) > 1 else TimelineStatus.DEGRADED
         )
         posture = "Unavailable"
-        primary = _primary_outage_reason(source_reasons)
+        primary = _combined_degrade_reason(source_reasons, skip_ku_x=has_ku_x_conflict)
     elif has_ku_x_conflict and not impacted:
         status = TimelineStatus.SOF
         posture = "Transport concurrency advisory"
@@ -220,7 +234,7 @@ def _decide_availability(
             len(impacted) > 1 or source_status == TimelineStatus.CRITICAL
         ) else TimelineStatus.DEGRADED
         posture = "Degraded" if status == TimelineStatus.DEGRADED else "Critical"
-        primary = _primary_activity_reason(source_reasons, skip_ku_x=has_ku_x_conflict)
+        primary = _combined_degrade_reason(source_reasons, skip_ku_x=has_ku_x_conflict)
     elif sof_reason := _primary_sof_reason(source_reasons):
         status = TimelineStatus.SOF
         posture = "Avoid calls"
@@ -242,6 +256,8 @@ def _decide_availability(
         label = primary
     else:
         label = f"{posture} — {primary}"
+    if boundary_markers and status in (TimelineStatus.DEGRADED, TimelineStatus.CRITICAL):
+        label = f"{label}; {', '.join(boundary_markers)}"
     return AvailabilityDecision(
         status=status,
         call_posture=posture,
@@ -254,6 +270,7 @@ def _decide_availability(
         notes=notes,
         source_reasons=source_reasons,
         source_segment_ids=source_segment_ids,
+        boundary_markers=boundary_markers,
     )
 
 
@@ -273,6 +290,7 @@ def _build_segment(
         "notes": list(decision.notes),
         "source_reasons": list(decision.source_reasons),
         "source_segment_ids": list(decision.source_segment_ids),
+        "boundary_markers": list(decision.boundary_markers),
     }
     return TimelineSegment(
         id=f"{mission_id}-availability-{index:03d}",
@@ -304,6 +322,7 @@ def _can_merge(left: TimelineSegment, right: TimelineSegment) -> bool:
         and left_meta.get("systems_affected") == right_meta.get("systems_affected")
         and left_meta.get("notes") == right_meta.get("notes")
         and left_meta.get("source_reasons") == right_meta.get("source_reasons")
+        and left_meta.get("boundary_markers") == right_meta.get("boundary_markers")
     )
 
 
@@ -360,10 +379,30 @@ def _segment_notes(segment: TimelineSegment) -> list[str]:
 
 
 def _primary_outage_reason(reasons: tuple[str, ...]) -> str:
+    return _combined_degrade_reason(reasons)
+
+
+def _combined_degrade_reason(
+    reasons: tuple[str, ...], *, skip_ku_x: bool = False
+) -> str:
+    labels: list[str] = []
     for reason in reasons:
-        if "outage" in reason.lower():
-            return "system outage"
-    return "system outage"
+        if not reason or not reason.strip():
+            continue
+        if skip_ku_x and _has_ku_x_conflict((reason,)):
+            continue
+        normalized = reason.lower()
+        if "safety-of-flight" in normalized or normalized == _REASON_LABELS["aar"].lower():
+            continue
+        if _is_satellite_swap_reason(reason):
+            label = f"Satellite swap: {reason}"
+        elif "outage" in normalized or "coverage gap" in normalized or "transition" in normalized:
+            label = reason
+        else:
+            label = reason
+        if label not in labels:
+            labels.append(label)
+    return "; ".join(labels) if labels else "system outage"
 
 
 def _primary_sof_reason(reasons: tuple[str, ...]) -> str | None:

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -1,0 +1,346 @@
+"""Normalize mission timelines into operational call-availability blocks.
+
+The raw mission timeline can carry overlapping context such as SOF/AAR windows
+in statistics while transport state segments remain nominal. This module applies
+a sweep-line pass so the primary table can show one chronological,
+non-overlapping call posture per row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable
+
+from app.mission.models import (
+    MissionLegTimeline,
+    TimelineSegment,
+    TimelineStatus,
+    Transport,
+    TransportState,
+)
+
+
+@dataclass(frozen=True)
+class AARBlock:
+    """Safety-of-flight AAR interval clipped into the mission timeline."""
+
+    start: datetime
+    end: datetime
+
+
+@dataclass(frozen=True)
+class AvailabilityDecision:
+    """Resolved operational call posture for an atomic interval."""
+
+    status: TimelineStatus
+    call_posture: str
+    primary_reason: str
+    availability_label: str
+    impacted_transports: tuple[Transport, ...]
+    x_state: TransportState
+    ka_state: TransportState
+    ku_state: TransportState
+    notes: tuple[str, ...]
+    source_reasons: tuple[str, ...]
+    source_segment_ids: tuple[str, ...]
+
+
+_STATE_PRIORITY = {
+    TransportState.AVAILABLE: 0,
+    TransportState.DEGRADED: 1,
+    TransportState.OFFLINE: 2,
+}
+
+_REASON_LABELS = {
+    "outage": "system outage",
+    "sof": "SOF AAR",
+    "ku_x": "Ku/X conflict",
+    "activity": "operational activity conflict",
+    "nominal": "nominal window",
+}
+
+
+def normalize_call_availability_timeline(timeline: MissionLegTimeline) -> None:
+    """Replace timeline segments with merged, non-overlapping availability rows.
+
+    The normalized segments retain the existing `TimelineSegment` model for API
+    compatibility while adding table-ready labels in `metadata`:
+    `call_posture`, `primary_reason`, `availability_label`, `systems_affected`,
+    `notes`, `source_reasons`, and `source_segment_ids`.
+    """
+
+    if not timeline.segments:
+        return
+
+    source_segments = sorted(
+        timeline.segments,
+        key=lambda seg: (_ensure_utc(seg.start_time), _ensure_utc(seg.end_time)),
+    )
+    mission_start = min(_ensure_utc(seg.start_time) for seg in source_segments)
+    mission_end = max(_ensure_utc(seg.end_time) for seg in source_segments)
+    aar_blocks = _extract_aar_blocks(timeline, mission_start, mission_end)
+
+    boundaries = {mission_start, mission_end}
+    for segment in source_segments:
+        boundaries.add(_ensure_utc(segment.start_time))
+        boundaries.add(_ensure_utc(segment.end_time))
+    for block in aar_blocks:
+        boundaries.add(block.start)
+        boundaries.add(block.end)
+
+    normalized: list[TimelineSegment] = []
+    ordered_boundaries = sorted(boundaries)
+    for index in range(len(ordered_boundaries) - 1):
+        start = ordered_boundaries[index]
+        end = ordered_boundaries[index + 1]
+        if start >= end:
+            continue
+
+        active_segments = [
+            segment
+            for segment in source_segments
+            if _ensure_utc(segment.start_time) <= start < _ensure_utc(segment.end_time)
+        ]
+        if not active_segments:
+            continue
+
+        in_sof = any(block.start <= start < block.end for block in aar_blocks)
+        decision = _decide_availability(active_segments, in_sof)
+        segment = _build_segment(
+            timeline.mission_leg_id,
+            len(normalized) + 1,
+            start,
+            end,
+            decision,
+        )
+        if normalized and _can_merge(normalized[-1], segment):
+            normalized[-1] = _merge_segments(normalized[-1], segment)
+        else:
+            normalized.append(segment)
+
+    timeline.segments = [
+        _renumber_segment(timeline.mission_leg_id, idx, segment)
+        for idx, segment in enumerate(normalized, start=1)
+    ]
+
+
+def _extract_aar_blocks(
+    timeline: MissionLegTimeline,
+    mission_start: datetime,
+    mission_end: datetime,
+) -> list[AARBlock]:
+    blocks = []
+    raw_blocks = (timeline.statistics or {}).get("_aar_blocks") or []
+    for raw in raw_blocks:
+        start_raw = raw.get("start") if isinstance(raw, dict) else None
+        end_raw = raw.get("end") if isinstance(raw, dict) else None
+        if not start_raw or not end_raw:
+            continue
+        start = max(_parse_timestamp(start_raw), mission_start)
+        end = min(_parse_timestamp(end_raw), mission_end)
+        if end > start:
+            blocks.append(AARBlock(start=start, end=end))
+    return blocks
+
+
+def _decide_availability(
+    segments: list[TimelineSegment], in_sof: bool
+) -> AvailabilityDecision:
+    x_state = _highest_state(segment.x_state for segment in segments)
+    ka_state = _highest_state(segment.ka_state for segment in segments)
+    ku_state = _highest_state(segment.ku_state for segment in segments)
+    source_reasons = tuple(
+        _unique(reason for segment in segments for reason in segment.reasons)
+    )
+    source_segment_ids = tuple(
+        _unique(segment.id for segment in segments if segment.id)
+    )
+    notes = tuple(
+        _unique(note for segment in segments for note in _segment_notes(segment))
+    )
+
+    impacted = tuple(
+        transport
+        for transport, state in (
+            (Transport.X, x_state),
+            (Transport.KA, ka_state),
+            (Transport.KU, ku_state),
+        )
+        if state != TransportState.AVAILABLE
+    )
+
+    if any(state == TransportState.OFFLINE for state in (x_state, ka_state, ku_state)):
+        status = (
+            TimelineStatus.CRITICAL if len(impacted) > 1 else TimelineStatus.DEGRADED
+        )
+        posture = "Unavailable"
+        primary = _primary_outage_reason(source_reasons)
+    elif in_sof:
+        status = TimelineStatus.DEGRADED
+        posture = "Avoid calls"
+        primary = _REASON_LABELS["sof"]
+    elif _has_ku_x_conflict(source_reasons):
+        status = TimelineStatus.DEGRADED
+        posture = "Degraded"
+        primary = _REASON_LABELS["ku_x"]
+    elif impacted or any(
+        segment.status != TimelineStatus.NOMINAL for segment in segments
+    ):
+        status = (
+            TimelineStatus.DEGRADED if len(impacted) <= 1 else TimelineStatus.CRITICAL
+        )
+        posture = "Activity conflict"
+        primary = _REASON_LABELS["activity"]
+    else:
+        status = TimelineStatus.NOMINAL
+        posture = "Nominal calls"
+        primary = _REASON_LABELS["nominal"]
+
+    if posture in ("Nominal calls", "Activity conflict"):
+        label = posture
+    else:
+        label = f"{posture} — {primary}"
+    return AvailabilityDecision(
+        status=status,
+        call_posture=posture,
+        primary_reason=primary,
+        availability_label=label,
+        impacted_transports=impacted,
+        x_state=x_state,
+        ka_state=ka_state,
+        ku_state=ku_state,
+        notes=notes,
+        source_reasons=source_reasons,
+        source_segment_ids=source_segment_ids,
+    )
+
+
+def _build_segment(
+    mission_id: str,
+    index: int,
+    start: datetime,
+    end: datetime,
+    decision: AvailabilityDecision,
+) -> TimelineSegment:
+    systems = [transport.value for transport in decision.impacted_transports]
+    metadata = {
+        "call_posture": decision.call_posture,
+        "primary_reason": decision.primary_reason,
+        "availability_label": decision.availability_label,
+        "systems_affected": systems,
+        "notes": list(decision.notes),
+        "source_reasons": list(decision.source_reasons),
+        "source_segment_ids": list(decision.source_segment_ids),
+    }
+    return TimelineSegment(
+        id=f"{mission_id}-availability-{index:03d}",
+        start_time=start,
+        end_time=end,
+        status=decision.status,
+        x_state=decision.x_state,
+        ka_state=decision.ka_state,
+        ku_state=decision.ku_state,
+        reasons=[decision.availability_label],
+        impacted_transports=list(decision.impacted_transports),
+        metadata=metadata,
+    )
+
+
+def _can_merge(left: TimelineSegment, right: TimelineSegment) -> bool:
+    left_meta = left.metadata or {}
+    right_meta = right.metadata or {}
+    return (
+        _ensure_utc(left.end_time) == _ensure_utc(right.start_time)
+        and left.status == right.status
+        and left.x_state == right.x_state
+        and left.ka_state == right.ka_state
+        and left.ku_state == right.ku_state
+        and left.impacted_transports == right.impacted_transports
+        and left_meta.get("call_posture") == right_meta.get("call_posture")
+        and left_meta.get("primary_reason") == right_meta.get("primary_reason")
+        and left_meta.get("availability_label") == right_meta.get("availability_label")
+        and left_meta.get("systems_affected") == right_meta.get("systems_affected")
+        and left_meta.get("notes") == right_meta.get("notes")
+        and left_meta.get("source_reasons") == right_meta.get("source_reasons")
+    )
+
+
+def _merge_segments(left: TimelineSegment, right: TimelineSegment) -> TimelineSegment:
+    merged_metadata = dict(left.metadata or {})
+    merged_metadata["source_segment_ids"] = list(
+        _unique(
+            list((left.metadata or {}).get("source_segment_ids", []))
+            + list((right.metadata or {}).get("source_segment_ids", []))
+        )
+    )
+    return left.model_copy(
+        update={"end_time": right.end_time, "metadata": merged_metadata}
+    )
+
+
+def _renumber_segment(
+    mission_id: str, index: int, segment: TimelineSegment
+) -> TimelineSegment:
+    return segment.model_copy(update={"id": f"{mission_id}-availability-{index:03d}"})
+
+
+def _highest_state(states: Iterable[TransportState]) -> TransportState:
+    ordered = list(states)
+    if not ordered:
+        return TransportState.AVAILABLE
+    return max(ordered, key=lambda state: _STATE_PRIORITY[state])
+
+
+def _segment_notes(segment: TimelineSegment) -> list[str]:
+    metadata = segment.metadata or {}
+    notes: list[str] = []
+    raw_notes = metadata.get("notes")
+    if isinstance(raw_notes, list):
+        notes.extend(str(note) for note in raw_notes if str(note).strip())
+    elif isinstance(raw_notes, str) and raw_notes.strip():
+        notes.append(raw_notes)
+    raw_note = metadata.get("note")
+    if isinstance(raw_note, str) and raw_note.strip():
+        notes.append(raw_note)
+    return notes
+
+
+def _primary_outage_reason(reasons: tuple[str, ...]) -> str:
+    for reason in reasons:
+        if "outage" in reason.lower():
+            return "system outage"
+    return "system outage"
+
+
+def _has_ku_x_conflict(reasons: tuple[str, ...]) -> bool:
+    for reason in reasons:
+        normalized = reason.lower().replace(" ", "")
+        if "x-ku" in normalized or "ku-x" in normalized or "x/ku" in normalized:
+            return True
+        if "ku/x" in normalized or (
+            "ku" in normalized and "x" in normalized and "conflict" in normalized
+        ):
+            return True
+    return False
+
+
+def _parse_timestamp(raw: str) -> datetime:
+    return _ensure_utc(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -68,10 +68,7 @@ _REASON_LABELS = {
     "nominal": "nominal window",
 }
 
-_KU_X_ADVISORY_LABEL = (
-    "Transport concurrency advisory: X Band / Ku conflict — choose one "
-    "transport; PACE preference Starlink > Comm Ka > X-Band"
-)
+_KU_X_ADVISORY_LABEL = "X Band / Ku conflict — choose one transport"
 
 
 def normalize_call_availability_timeline(timeline: MissionLegTimeline) -> None:

--- a/backend/starlink-location/app/mission/call_availability.py
+++ b/backend/starlink-location/app/mission/call_availability.py
@@ -52,6 +52,13 @@ _STATE_PRIORITY = {
     TransportState.OFFLINE: 2,
 }
 
+_STATUS_PRIORITY = {
+    TimelineStatus.NOMINAL: 0,
+    TimelineStatus.SOF: 1,
+    TimelineStatus.DEGRADED: 2,
+    TimelineStatus.CRITICAL: 3,
+}
+
 _REASON_LABELS = {
     "outage": "system outage",
     "aar": "AAR window",
@@ -160,6 +167,10 @@ def _decide_availability(
     notes = tuple(
         _unique(note for segment in segments for note in _segment_notes(segment))
     )
+    source_status = max(
+        (segment.status for segment in segments),
+        key=lambda status: _STATUS_PRIORITY.get(status, 0),
+    )
 
     impacted = tuple(
         transport
@@ -185,20 +196,18 @@ def _decide_availability(
         status = TimelineStatus.DEGRADED
         posture = "Degraded"
         primary = _REASON_LABELS["x_aar"]
-    elif impacted or any(
-        segment.status != TimelineStatus.NOMINAL for segment in segments
-    ):
-        status = (
-            TimelineStatus.DEGRADED if len(impacted) <= 1 else TimelineStatus.CRITICAL
-        )
+    elif impacted or source_status in (TimelineStatus.DEGRADED, TimelineStatus.CRITICAL):
+        status = TimelineStatus.CRITICAL if (
+            len(impacted) > 1 or source_status == TimelineStatus.CRITICAL
+        ) else TimelineStatus.DEGRADED
         posture = "Degraded" if status == TimelineStatus.DEGRADED else "Critical"
         primary = _primary_activity_reason(source_reasons)
     elif sof_reason := _primary_sof_reason(source_reasons):
-        status = TimelineStatus.DEGRADED
+        status = TimelineStatus.SOF
         posture = "Avoid calls"
         primary = sof_reason
     elif in_sof:
-        status = TimelineStatus.NOMINAL
+        status = TimelineStatus.SOF
         posture = "Safety-of-flight advised"
         primary = _REASON_LABELS["aar"]
     else:

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -66,6 +66,7 @@ from app.mission.exporter.pptx_styling import (
 )
 from app.services.poi_manager import POIManager
 from app.services.route_manager import RouteManager
+from app.mission.timeline_builder.calculator import route_with_adjusted_departure
 
 logger = logging.getLogger(__name__)
 
@@ -436,6 +437,10 @@ def _generate_route_map(
         logger.error(f"Available routes: {list(available_routes.keys())}")
         logger.error(f"Mission: {mission.id}, Leg: {mission.name}")
         return _base_map_canvas()
+
+    route = route_with_adjusted_departure(
+        route, getattr(mission, "adjusted_departure_time", None)
+    )
 
     if not route.points:
         logger.warning(

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -1044,6 +1044,9 @@ def _generate_route_map(
         # Route status colors
         Line2D([0], [0], color=STATUS_COLORS["nominal"], linewidth=3, label="Nominal"),
         Line2D(
+            [0], [0], color=STATUS_COLORS["sof"], linewidth=3, label="Advisory"
+        ),
+        Line2D(
             [0], [0], color=STATUS_COLORS["degraded"], linewidth=3, label="Degraded"
         ),
         Line2D(
@@ -1288,7 +1291,7 @@ def _segment_rows(
             if isinstance(segment.status, TimelineStatus)
             else str(segment.status)
         )
-        status_value = status_value.upper()
+        status_value = _display_status(status_value)
         metadata = segment.metadata or {}
         call_posture = metadata.get("call_posture") or status_value
         primary_reason = metadata.get("primary_reason") or (
@@ -1418,6 +1421,14 @@ def _statistics_rows(timeline: MissionLegTimeline) -> pd.DataFrame:
             display_value = format_seconds_hms(value)
         rows.append({"Metric": display_name, "Value": display_value})
     return pd.DataFrame(rows, columns=["Metric", "Value"])
+
+
+def _display_status(status_value: str) -> str:
+    """Return user-facing timeline status text."""
+    normalized = status_value.strip().lower()
+    if normalized == TimelineStatus.SOF.value:
+        return "ADVISORY"
+    return normalized.upper()
 
 
 def _format_notes_and_sources(notes: object, source_reasons: object) -> str:

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -1303,6 +1303,7 @@ def _segment_rows(
         notes = metadata.get("notes") or []
         source_reasons = metadata.get("source_reasons") or segment.reasons
         notes_and_sources = _format_notes_and_sources(notes, source_reasons)
+        operational_markers = _format_marker_list(metadata.get("operational_markers"))
         impacted_display = serialize_transport_list(segment.impacted_transports)
         if warning_only:
             status_value = TimelineStatus.NOMINAL.value.upper()
@@ -1317,6 +1318,7 @@ def _segment_rows(
             "Status": status_value,
             "Call Posture": call_posture,
             "Primary Reason": primary_reason,
+            "Operational Markers": operational_markers,
             "Start Time": compose_time_block(start_utc, mission_start),
             "End Time": compose_time_block(end_utc, mission_start),
             "Duration": format_seconds_hms(duration_seconds),
@@ -1345,6 +1347,7 @@ def _segment_rows(
         "Status",
         "Call Posture",
         "Primary Reason",
+        "Operational Markers",
         "Start Time",
         "End Time",
         "Duration",
@@ -1453,6 +1456,55 @@ def _format_notes_and_sources(notes: object, source_reasons: object) -> str:
     return "; ".join(unique_values)
 
 
+def _format_marker_list(markers: object) -> str:
+    """Format operator-facing boundary/safety markers for table exports."""
+
+    if isinstance(markers, list):
+        values = [str(marker) for marker in markers if str(marker).strip()]
+    elif isinstance(markers, str) and markers.strip():
+        values = [markers]
+    else:
+        values = []
+    return "; ".join(dict.fromkeys(values))
+
+
+def _cover_metadata_line(
+    mission: Mission | MissionLeg | None,
+    leg_count: int,
+    parent_mission_id: str | None = None,
+) -> str:
+    """Build title-slide metadata without stale description/revision mismatches."""
+
+    leg_label = f"{leg_count} Leg{'s' if leg_count != 1 else ''}"
+    if mission is None:
+        return leg_label
+
+    metadata_source: Mission | MissionLeg | None = mission
+    if parent_mission_id and not hasattr(mission, "legs"):
+        try:
+            from app.mission.storage import load_mission_v2
+
+            metadata_source = load_mission_v2(parent_mission_id) or mission
+        except Exception:
+            metadata_source = mission
+
+    metadata = getattr(metadata_source, "metadata", None) or {}
+    mission_number = metadata.get("mission_number") if isinstance(metadata, dict) else None
+    revision = metadata.get("revision") if isinstance(metadata, dict) else None
+    parts = [leg_label]
+    if mission_number:
+        parts.append(f"Mission {mission_number}")
+    if revision:
+        parts.append(f"Rev {revision}")
+    if len(parts) > 1:
+        return " | ".join(parts)
+
+    description = getattr(mission, "description", None)
+    if description:
+        parts.append(str(description))
+    return " | ".join(parts)
+
+
 # Note: format_seconds_hms, humanize_metric_name, and compose_time_block are now
 # imported from exporter.formatting module above
 
@@ -1492,11 +1544,9 @@ def generate_pptx_export(
     # Mission metadata
     mission_id = mission.id if mission else timeline.mission_leg_id
     mission_name = mission.name if mission else "Mission"
-    organization = (
-        mission.description if (mission and mission.description) else "Organization"
-    )
     # Check if mission is a Mission (has .legs) or MissionLeg (no .legs)
-    leg_count = len(mission.legs) if (mission and hasattr(mission, "legs")) else 1
+    legs = getattr(mission, "legs", None) if mission is not None else None
+    leg_count = len(legs) if legs is not None else 1
 
     # Create presentation with standard dimensions
     prs = Presentation()
@@ -1541,12 +1591,12 @@ def generate_pptx_export(
     id_paragraph.font.size = Pt(14)
     id_paragraph.font.color.rgb = TEXT_BLACK
 
-    # Add leg count and organization
+    # Add leg count and mission metadata
     info_box = title_slide.shapes.add_textbox(
         Inches(1.5), Inches(3.5), Inches(7.0), Inches(0.5)
     )
     info_frame = info_box.text_frame
-    info_frame.text = f"{leg_count} Leg{'s' if leg_count != 1 else ''} | {organization}"
+    info_frame.text = _cover_metadata_line(mission, leg_count, parent_mission_id)
 
     info_paragraph = info_frame.paragraphs[0]
     info_paragraph.alignment = PP_ALIGN.CENTER

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -271,10 +271,10 @@ def _get_detailed_segment_statuses(
 
             if raw_status == "critical":
                 status = "critical"
-            elif raw_status == "degraded" or is_sof:
+            elif raw_status in ("degraded", "warning"):
                 status = "degraded"
-            elif raw_status == "warning":
-                status = "degraded"
+            elif raw_status == "sof" or is_sof:
+                status = "sof"
             else:
                 status = "nominal"
         else:

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -1044,9 +1044,7 @@ def _generate_route_map(
     legend_elements = [
         # Route status colors
         Line2D([0], [0], color=STATUS_COLORS["nominal"], linewidth=3, label="Nominal"),
-        Line2D(
-            [0], [0], color=STATUS_COLORS["sof"], linewidth=3, label="Advisory"
-        ),
+        Line2D([0], [0], color=STATUS_COLORS["sof"], linewidth=3, label="Advisory"),
         Line2D(
             [0], [0], color=STATUS_COLORS["degraded"], linewidth=3, label="Degraded"
         ),
@@ -1550,7 +1548,9 @@ def _cover_metadata_line(
             metadata_source = mission
 
     metadata = getattr(metadata_source, "metadata", None) or {}
-    mission_number = metadata.get("mission_number") if isinstance(metadata, dict) else None
+    mission_number = (
+        metadata.get("mission_number") if isinstance(metadata, dict) else None
+    )
     revision = metadata.get("revision") if isinstance(metadata, dict) else None
     parts = [leg_label]
     if mission_number:

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import re
 import matplotlib
 
 matplotlib.use("Agg")  # Headless mode for Docker
@@ -1270,6 +1271,69 @@ def _generate_timeline_chart(timeline: MissionLegTimeline) -> bytes:
     return buffer.read()
 
 
+def _compact_reason_label(segment: TimelineSegment) -> str:
+    """Return concise operator-facing reason labels for tabular exports."""
+    metadata = segment.metadata or {}
+    raw_markers = metadata.get("operational_markers") or []
+    markers = [str(marker) for marker in raw_markers if str(marker).strip()]
+    compact_parts: list[str] = []
+
+    has_aar_boundary = any(
+        marker.lower() in {"aar start", "aar end"} for marker in markers
+    )
+    for marker in markers:
+        marker_lower = marker.lower()
+        if marker_lower == "aar window":
+            if has_aar_boundary:
+                continue
+            compact = "AAR Window"
+        elif marker_lower in {"aar start", "aar end"}:
+            compact = marker.title().replace("Aar", "AAR")
+        elif "safety-of-flight" in marker_lower or "safety window" in marker_lower:
+            if any(part.startswith("AAR") for part in compact_parts):
+                continue
+            if "takeoff" in marker_lower:
+                compact = "Takeoff"
+            elif "landing" in marker_lower:
+                compact = "Landing"
+            else:
+                compact = "SOF"
+        else:
+            compact = marker
+        if compact not in compact_parts:
+            compact_parts.append(compact)
+
+    if any(part in {"AAR Start", "AAR End"} for part in compact_parts):
+        return "; ".join(compact_parts)
+
+    source_reasons = metadata.get("source_reasons") or segment.reasons
+    for reason_value in source_reasons:
+        reason = str(reason_value)
+        reason_lower = reason.lower()
+        compact = ""
+        if "x" in reason_lower and "ku" in reason_lower and "conflict" in reason_lower:
+            compact = "X/Ku Conflict"
+        elif match := re.search(
+            r"ka\s+transition\s+([A-Za-z0-9-]+)\s*(?:→|->|=>|to)\s*([A-Za-z0-9-]+)",
+            reason,
+            flags=re.IGNORECASE,
+        ):
+            compact = f"Ka {match.group(1).upper()} => {match.group(2).upper()}"
+        elif match := re.search(
+            r"x\s+transition\s+(?:to\s+)?([A-Za-z0-9-]+)",
+            reason,
+            flags=re.IGNORECASE,
+        ):
+            compact = f"X => {match.group(1).upper()}"
+
+        if compact and compact not in compact_parts:
+            compact_parts.append(compact)
+
+    if compact_parts:
+        return "; ".join(compact_parts)
+    return ", ".join(segment.reasons)
+
+
 def _segment_rows(
     timeline: MissionLegTimeline,
     mission: Mission | None,
@@ -1327,7 +1391,7 @@ def _segment_rows(
             TRANSPORT_DISPLAY[Transport.KU]: segment.ku_state.value.upper(),
             "Impacted Transports": impacted_display,
             "Systems Affected": ", ".join(systems_affected),
-            "Reasons": ", ".join(segment.reasons),
+            "Reasons": _compact_reason_label(segment),
             "Notes / Source Events": notes_and_sources,
             "Metadata": (
                 json.dumps(segment.metadata, sort_keys=True) if segment.metadata else ""

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -251,11 +251,10 @@ def _get_detailed_segment_statuses(
                 next_change = min(end_time, s_start)
                 break
 
-        # Check if current_time falls within an AAR block
-        in_aar_block = False
+        # Check if current_time falls within an AAR block so map intervals split at
+        # AAR boundaries without treating AAR as degraded by default.
         for aar_start, aar_end in aar_blocks:
             if aar_start <= current_time < aar_end:
-                in_aar_block = True
                 # AAR block might end before the segment ends
                 next_change = min(next_change, aar_end)
                 break
@@ -268,11 +267,11 @@ def _get_detailed_segment_statuses(
         if active_seg:
             raw_status = active_seg.status.value
             reasons = str(active_seg.reasons).lower()
-            is_sof = "safety-of-flight" in reasons or "aar" in reasons
+            is_sof = "safety-of-flight" in reasons
 
             if raw_status == "critical":
                 status = "critical"
-            elif raw_status == "degraded" or is_sof or in_aar_block:
+            elif raw_status == "degraded" or is_sof:
                 status = "degraded"
             elif raw_status == "warning":
                 status = "degraded"
@@ -280,10 +279,6 @@ def _get_detailed_segment_statuses(
                 status = "nominal"
         else:
             status = "unknown"  # Gap in timeline
-
-        # Override to degraded if in AAR block (even if segment is nominal)
-        if in_aar_block and status == "nominal":
-            status = "degraded"
 
         intervals.append((current_time, next_change, status))
         current_time = next_change

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -34,6 +34,7 @@ from pptx import Presentation
 from pptx.util import Inches, Pt
 from pptx.enum.text import PP_ALIGN
 
+from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.models import (
     Mission,
     MissionLeg,
@@ -1271,10 +1272,12 @@ def _segment_rows(
     mission: Mission | None,
 ) -> pd.DataFrame:
     """Convert timeline segments into a pandas DataFrame."""
-    mission_start = mission_start_timestamp(timeline)
+    export_timeline = timeline.model_copy(deep=True)
+    normalize_call_availability_timeline(export_timeline)
+    mission_start = mission_start_timestamp(export_timeline)
     rows: list[tuple[datetime, int, dict]] = []
 
-    for idx, segment in enumerate(timeline.segments, start=1):
+    for idx, segment in enumerate(export_timeline.segments, start=1):
         start_utc = ensure_timezone(segment.start_time)
         end_value = segment.end_time if segment.end_time else segment.start_time
         end_utc = ensure_timezone(end_value)
@@ -1286,10 +1289,22 @@ def _segment_rows(
             else str(segment.status)
         )
         status_value = status_value.upper()
+        metadata = segment.metadata or {}
+        call_posture = metadata.get("call_posture") or status_value
+        primary_reason = metadata.get("primary_reason") or (
+            segment.reasons[0] if segment.reasons else ""
+        )
+        systems_affected = metadata.get("systems_affected") or [
+            transport.value for transport in segment.impacted_transports
+        ]
+        notes = metadata.get("notes") or []
+        source_reasons = metadata.get("source_reasons") or segment.reasons
+        notes_and_sources = _format_notes_and_sources(notes, source_reasons)
         impacted_display = serialize_transport_list(segment.impacted_transports)
         if warning_only:
             status_value = TimelineStatus.NOMINAL.value.upper()
             impacted_display = ""
+            systems_affected = []
         record = {
             "Segment #": idx,
             "Mission ID": mission.id if mission else timeline.mission_id,
@@ -1297,6 +1312,8 @@ def _segment_rows(
                 mission.name if mission and mission.name else timeline.mission_id
             ),
             "Status": status_value,
+            "Call Posture": call_posture,
+            "Primary Reason": primary_reason,
             "Start Time": compose_time_block(start_utc, mission_start),
             "End Time": compose_time_block(end_utc, mission_start),
             "Duration": format_seconds_hms(duration_seconds),
@@ -1306,20 +1323,25 @@ def _segment_rows(
             TRANSPORT_DISPLAY[Transport.KA]: segment.ka_state.value.upper(),
             TRANSPORT_DISPLAY[Transport.KU]: segment.ku_state.value.upper(),
             "Impacted Transports": impacted_display,
+            "Systems Affected": ", ".join(systems_affected),
             "Reasons": ", ".join(segment.reasons),
+            "Notes / Source Events": notes_and_sources,
             "Metadata": (
                 json.dumps(segment.metadata, sort_keys=True) if segment.metadata else ""
             ),
         }
         rows.append((start_utc, 1, record))
 
-    rows.extend(_aar_block_rows(timeline, mission, mission_start))
+    # AAR/SOF blocks are incorporated by normalize_call_availability_timeline()
+    # above so the primary table stays chronological and non-overlapping.
 
     columns = [
         "Segment #",
         "Mission ID",
         "Mission Name",
         "Status",
+        "Call Posture",
+        "Primary Reason",
         "Start Time",
         "End Time",
         "Duration",
@@ -1327,7 +1349,9 @@ def _segment_rows(
         TRANSPORT_DISPLAY[Transport.KA],
         TRANSPORT_DISPLAY[Transport.KU],
         "Impacted Transports",
+        "Systems Affected",
         "Reasons",
+        "Notes / Source Events",
         "Metadata",
     ]
 
@@ -1394,6 +1418,28 @@ def _statistics_rows(timeline: MissionLegTimeline) -> pd.DataFrame:
             display_value = format_seconds_hms(value)
         rows.append({"Metric": display_name, "Value": display_value})
     return pd.DataFrame(rows, columns=["Metric", "Value"])
+
+
+def _format_notes_and_sources(notes: object, source_reasons: object) -> str:
+    """Format concise notes/source context for the availability table."""
+    values: list[str] = []
+    if isinstance(notes, list):
+        values.extend(str(note) for note in notes if str(note).strip())
+    elif isinstance(notes, str) and notes.strip():
+        values.append(notes)
+    if isinstance(source_reasons, list):
+        values.extend(str(reason) for reason in source_reasons if str(reason).strip())
+    elif isinstance(source_reasons, str) and source_reasons.strip():
+        values.append(source_reasons)
+
+    seen: set[str] = set()
+    unique_values: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        unique_values.append(value)
+    return "; ".join(unique_values)
 
 
 # Note: format_seconds_hms, humanize_metric_name, and compose_time_block are now

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -1303,7 +1303,6 @@ def _segment_rows(
         notes = metadata.get("notes") or []
         source_reasons = metadata.get("source_reasons") or segment.reasons
         notes_and_sources = _format_notes_and_sources(notes, source_reasons)
-        operational_markers = _format_marker_list(metadata.get("operational_markers"))
         impacted_display = serialize_transport_list(segment.impacted_transports)
         if warning_only:
             status_value = TimelineStatus.NOMINAL.value.upper()
@@ -1318,7 +1317,6 @@ def _segment_rows(
             "Status": status_value,
             "Call Posture": call_posture,
             "Primary Reason": primary_reason,
-            "Operational Markers": operational_markers,
             "Start Time": compose_time_block(start_utc, mission_start),
             "End Time": compose_time_block(end_utc, mission_start),
             "Duration": format_seconds_hms(duration_seconds),
@@ -1347,7 +1345,6 @@ def _segment_rows(
         "Status",
         "Call Posture",
         "Primary Reason",
-        "Operational Markers",
         "Start Time",
         "End Time",
         "Duration",

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -29,6 +29,7 @@ from app.mission.exporter.pptx_styling import (
     STATUS_DEGRADED,
     STATUS_NOMINAL,
     STATUS_SOF,
+    TEXT_BLACK,
     TEXT_WHITE,
     add_footer_bar,
     add_footer_text,
@@ -538,7 +539,7 @@ def _add_timeline_table(
                     cell.fill.solid()
                     cell.fill.fore_color.rgb = STATUS_DEGRADED
                     for paragraph in cell.text_frame.paragraphs:
-                        paragraph.font.color.rgb = RGBColor(255, 255, 255)
+                        paragraph.font.color.rgb = TEXT_BLACK
                         paragraph.font.bold = True
                 elif val_lower in ("nominal", "available"):
                     # Nominal status

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -299,7 +299,6 @@ def add_timeline_table_slides(
     columns_to_show = [
         "Segment #",
         "Status",
-        "Operational Markers",
         "Start Time",
         "End Time",
         "Duration",
@@ -453,7 +452,7 @@ def _add_timeline_table(
 
     # Set column widths (adjusted for wider times)
     # Total width 9 inches
-    col_weights = [0.5, 0.85, 1.1, 1.55, 1.55, 0.85, 0.85, 0.85, 0.85, 1.4]
+    col_weights = [0.5, 0.85, 1.55, 1.55, 0.85, 0.85, 0.85, 0.85, 1.4]
     total_weight = sum(col_weights)
     for i, weight in enumerate(col_weights):
         table.columns[i].width = int(width * (weight / total_weight))

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -511,9 +511,9 @@ def _add_timeline_table(
                 if "safety-of-flight" in reasons or "aar" in reasons:
                     is_sof = True
 
-                # Override Status text to "SOF" if it's a safety window
+                # Override advisory window status text for user-facing output.
                 if is_sof and val_lower in ("available", "nominal", "sof"):
-                    cell.text = "SOF"
+                    cell.text = "ADVISORY"
                     # Re-apply font size since setting text resets it
                     for paragraph in cell.text_frame.paragraphs:
                         paragraph.font.size = Pt(8)
@@ -534,8 +534,8 @@ def _add_timeline_table(
                     for paragraph in cell.text_frame.paragraphs:
                         paragraph.font.color.rgb = TEXT_BLACK
                         paragraph.font.bold = True
-                elif is_sof:
-                    # Safety of Flight
+                elif is_sof or val_lower == "advisory":
+                    # Advisory / Safety of Flight
                     cell.fill.solid()
                     cell.fill.fore_color.rgb = STATUS_SOF
                     for paragraph in cell.text_frame.paragraphs:

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -512,7 +512,7 @@ def _add_timeline_table(
                     is_sof = True
 
                 # Override Status text to "SOF" if it's a safety window
-                if is_sof and val_lower in ("available", "nominal", "warning"):
+                if is_sof and val_lower in ("available", "nominal", "sof"):
                     cell.text = "SOF"
                     # Re-apply font size since setting text resets it
                     for paragraph in cell.text_frame.paragraphs:
@@ -520,12 +520,19 @@ def _add_timeline_table(
                         paragraph.alignment = PP_ALIGN.LEFT
 
                 # Apply status badge colors
-                if is_critical_row and not is_sof:
+                if is_critical_row or val_lower == "critical":
                     # Critical status
                     cell.fill.solid()
                     cell.fill.fore_color.rgb = STATUS_CRITICAL
                     for paragraph in cell.text_frame.paragraphs:
                         paragraph.font.color.rgb = RGBColor(255, 255, 255)
+                        paragraph.font.bold = True
+                elif val_lower in ("degraded", "warning"):
+                    # Degraded status takes priority over SOF coloring
+                    cell.fill.solid()
+                    cell.fill.fore_color.rgb = STATUS_DEGRADED
+                    for paragraph in cell.text_frame.paragraphs:
+                        paragraph.font.color.rgb = TEXT_BLACK
                         paragraph.font.bold = True
                 elif is_sof:
                     # Safety of Flight
@@ -533,13 +540,6 @@ def _add_timeline_table(
                     cell.fill.fore_color.rgb = STATUS_SOF
                     for paragraph in cell.text_frame.paragraphs:
                         paragraph.font.color.rgb = RGBColor(255, 255, 255)
-                        paragraph.font.bold = True
-                elif val_lower in ("degraded", "warning"):
-                    # Degraded status
-                    cell.fill.solid()
-                    cell.fill.fore_color.rgb = STATUS_DEGRADED
-                    for paragraph in cell.text_frame.paragraphs:
-                        paragraph.font.color.rgb = TEXT_BLACK
                         paragraph.font.bold = True
                 elif val_lower in ("nominal", "available"):
                     # Nominal status

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -299,6 +299,7 @@ def add_timeline_table_slides(
     columns_to_show = [
         "Segment #",
         "Status",
+        "Operational Markers",
         "Start Time",
         "End Time",
         "Duration",
@@ -452,7 +453,7 @@ def _add_timeline_table(
 
     # Set column widths (adjusted for wider times)
     # Total width 9 inches
-    col_weights = [0.6, 1.0, 1.75, 1.75, 1.0, 1.0, 1.0, 1.0, 1.5]
+    col_weights = [0.5, 0.85, 1.1, 1.55, 1.55, 0.85, 0.85, 0.85, 0.85, 1.4]
     total_weight = sum(col_weights)
     for i, weight in enumerate(col_weights):
         table.columns[i].width = int(width * (weight / total_weight))

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -201,12 +201,18 @@ def add_route_map_slide(
 
     # Generate map image (with caching support)
     route_id = mission.route_id if mission else None
+    adjusted_departure = getattr(mission, "adjusted_departure_time", None)
+    map_cache_key = (
+        f"{route_id}|adjusted={adjusted_departure.isoformat()}"
+        if route_id and adjusted_departure
+        else route_id
+    )
     map_image_bytes = None
 
     # Check cache first
-    if route_id and map_cache is not None and route_id in map_cache:
-        map_image_bytes = map_cache[route_id]
-        logger.info(f"Cache hit for route {route_id}")
+    if map_cache_key and map_cache is not None and map_cache_key in map_cache:
+        map_image_bytes = map_cache[map_cache_key]
+        logger.info(f"Cache hit for route map {map_cache_key}")
     else:
         # Generate map
         try:
@@ -220,8 +226,8 @@ def add_route_map_slide(
             logger.info(f"Cache miss for route {route_id}, generated map")
 
             # Store in cache if available
-            if route_id and map_cache is not None:
-                map_cache[route_id] = map_image_bytes
+            if map_cache_key and map_cache is not None:
+                map_cache[map_cache_key] = map_image_bytes
         except Exception as e:
             logger.error("Failed to generate map: %s", e, exc_info=True)
 

--- a/backend/starlink-location/app/mission/exporter/pptx_builder.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_builder.py
@@ -505,15 +505,15 @@ def _add_timeline_table(
             if col_name == "Status":
                 val_lower = val.lower()
 
-                # Check for Safety-of-Flight in reasons
-                is_sof = False
-                reasons = str(row_data.get("Reasons", "")).lower()
-                if "safety-of-flight" in reasons or "aar" in reasons:
-                    is_sof = True
+                # Treat exported status as the source of truth. Compact operator
+                # markers such as "AAR End" may appear on nominal rows and must
+                # not recolor/relabel them as advisory.
+                is_sof = val_lower in ("sof", "advisory")
 
                 # Override advisory window status text for user-facing output.
-                if is_sof and val_lower in ("available", "nominal", "sof"):
+                if is_sof and val_lower in ("sof", "advisory"):
                     cell.text = "ADVISORY"
+                    val_lower = "advisory"
                     # Re-apply font size since setting text resets it
                     for paragraph in cell.text_frame.paragraphs:
                         paragraph.font.size = Pt(8)

--- a/backend/starlink-location/app/mission/exporter/pptx_styling.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_styling.py
@@ -6,7 +6,7 @@ PowerPoint presentations with consistent colors, layouts, and visual hierarchy.
 Color palette based on organizational branding standards:
 - Gold (RGB 212, 175, 55): Primary accent for headers and branding
 - Light gray (RGB 248, 249, 250): Content backgrounds
-- Status colors: Green (NOMINAL), Blue (SOF), Orange (DEGRADED), Red (CRITICAL)
+- Status colors: Green (NOMINAL), Blue (SOF), Yellow (DEGRADED), Red (CRITICAL)
 
 All functions accept `slide` objects from python-pptx and return created shapes
 or boolean success indicators.
@@ -35,7 +35,7 @@ CONTENT_GRAY = RGBColor(248, 249, 250)  # Light backgrounds
 # Status Colors
 STATUS_NOMINAL = RGBColor(22, 163, 74)  # Green
 STATUS_SOF = RGBColor(2, 132, 199)  # Blue
-STATUS_DEGRADED = RGBColor(234, 88, 12)  # Orange
+STATUS_DEGRADED = RGBColor(255, 255, 0)  # Yellow
 STATUS_CRITICAL = RGBColor(220, 38, 38)  # Red
 
 # Text Colors

--- a/backend/starlink-location/app/mission/exporter/pptx_styling.py
+++ b/backend/starlink-location/app/mission/exporter/pptx_styling.py
@@ -223,7 +223,8 @@ def add_status_badge(
     paragraph.alignment = PP_ALIGN.CENTER
     paragraph.font.size = Pt(11)
     paragraph.font.bold = True
-    paragraph.font.color.rgb = TEXT_WHITE
+    text_color = TEXT_BLACK if status == TimelineStatus.DEGRADED else TEXT_WHITE
+    paragraph.font.color.rgb = text_color
 
     return shape
 

--- a/backend/starlink-location/app/mission/exporter/transport_utils.py
+++ b/backend/starlink-location/app/mission/exporter/transport_utils.py
@@ -32,7 +32,7 @@ STATE_COLUMNS = [
 # Using standard traffic light colors for clear status indication
 STATUS_COLORS = {
     "nominal": "#2ecc71",  # Green
-    "degraded": "#f1c40f",  # Yellow/Orange
+    "degraded": "#ffff00",  # Yellow
     "critical": "#e74c3c",  # Red
     "unknown": "#95a5a6",  # Gray (fallback)
 }

--- a/backend/starlink-location/app/mission/exporter/transport_utils.py
+++ b/backend/starlink-location/app/mission/exporter/transport_utils.py
@@ -32,6 +32,7 @@ STATE_COLUMNS = [
 # Using standard traffic light colors for clear status indication
 STATUS_COLORS = {
     "nominal": "#2ecc71",  # Green
+    "sof": "#0284c7",  # Blue
     "degraded": "#ffff00",  # Yellow
     "critical": "#e74c3c",  # Red
     "unknown": "#95a5a6",  # Gray (fallback)

--- a/backend/starlink-location/app/mission/models.py
+++ b/backend/starlink-location/app/mission/models.py
@@ -45,6 +45,7 @@ class TimelineStatus(str, Enum):
     """Overall communication status during a timeline segment."""
 
     NOMINAL = "nominal"  # All transports available
+    SOF = "sof"  # Safety-of-flight advisory, no transport degrade
     DEGRADED = "degraded"  # One transport unavailable
     CRITICAL = "critical"  # Two or more transports unavailable
 

--- a/backend/starlink-location/app/mission/models.py
+++ b/backend/starlink-location/app/mission/models.py
@@ -169,6 +169,13 @@ class AARWindow(BaseModel):
         default=None,
         description="Optional pilot-projected AAR end override (UTC, ISO-8601)",
     )
+    override_start_elapsed: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional flight-deck mission elapsed AAR start override "
+            "using T+HH:MM or T+HH:MM:SS. The original AR duration is preserved."
+        ),
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/backend/starlink-location/app/mission/models.py
+++ b/backend/starlink-location/app/mission/models.py
@@ -161,6 +161,14 @@ class AARWindow(BaseModel):
         ...,
         description="Name of the ending waypoint (from KML) for AAR segment",
     )
+    override_start_time: Optional[datetime] = Field(
+        default=None,
+        description="Optional pilot-projected AAR start override (UTC, ISO-8601)",
+    )
+    override_end_time: Optional[datetime] = Field(
+        default=None,
+        description="Optional pilot-projected AAR end override (UTC, ISO-8601)",
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -178,6 +178,7 @@ def generate_mission_combined_pptx(
     # Import shared functions
     from pathlib import Path
 
+    from app.mission.exporter.__main__ import _cover_metadata_line
     from app.mission.exporter.pptx_builder import add_mission_slides_to_presentation
     from app.mission.exporter.pptx_styling import (
         TEXT_BLACK,
@@ -196,7 +197,6 @@ def generate_mission_combined_pptx(
     # Mission metadata
     mission_id = mission.id
     mission_name = mission.name
-    organization = mission.description if mission.description else "Organization"
     leg_count = len(mission.legs)
 
     # Title slide with styling
@@ -235,12 +235,12 @@ def generate_mission_combined_pptx(
     id_paragraph.font.size = Pt(14)
     id_paragraph.font.color.rgb = TEXT_BLACK
 
-    # Add leg count and organization
+    # Add leg count and mission metadata
     info_box = title_slide.shapes.add_textbox(
         Inches(1.5), Inches(3.5), Inches(7.0), Inches(0.5)
     )
     info_frame = info_box.text_frame
-    info_frame.text = f"{leg_count} Leg{'s' if leg_count != 1 else ''} | {organization}"
+    info_frame.text = _cover_metadata_line(mission, leg_count)
 
     info_paragraph = info_frame.paragraphs[0]
     info_paragraph.alignment = PP_ALIGN.CENTER

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -673,20 +673,14 @@ def export_mission_package(
         ├── exports/
         │   ├── mission/
         │   │   ├── mission-timeline.csv
-        │   │   ├── mission-timeline.xlsx
-        │   │   ├── mission-slides.pptx
-        │   │   └── mission-report.pdf
+        │   │   └── mission-slides.pptx
         │   └── legs/
         │       ├── {leg-id-1}/
         │       │   ├── timeline.csv
-        │       │   ├── timeline.xlsx
-        │       │   ├── slides.pptx
-        │       │   └── report.pdf
+        │       │   └── slides.pptx
         │       └── {leg-id-2}/
         │           ├── timeline.csv
-        │           ├── timeline.xlsx
-        │           ├── slides.pptx
-        │           └── report.pdf
+        │           └── slides.pptx
 
     Args:
         mission_id: Mission to export

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -14,8 +14,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
 
-from app.mission.models import Mission
-from app.mission.storage import load_mission_v2, load_mission_timeline
+from app.mission.models import Mission, MissionLeg, MissionLegTimeline
+from app.mission.storage import (
+    load_mission_v2,
+    load_mission_timeline,
+    save_mission_timeline,
+)
+from app.mission.timeline_service import build_mission_timeline
 from app.mission.exporter import (
     generate_timeline_export,
     TimelineExportFormat,
@@ -432,6 +437,40 @@ def _add_pois_to_zip(
         logger.error(f"Failed to add satellite POI data: {e}")
 
 
+def _load_export_timeline(
+    mission: Mission,
+    leg: MissionLeg,
+    route_manager: RouteManager | None,
+    poi_manager: POIManager | None,
+) -> MissionLegTimeline | None:
+    """Return a timeline for export, rebuilding from current leg settings first.
+
+    Persisted timelines are a cache. Rebuilding here ensures package/document
+    exports reflect planner edits such as adjusted departure times even if an
+    older cached timeline still exists on disk.
+    """
+    if route_manager and leg.route_id:
+        try:
+            timeline, _summary = build_mission_timeline(
+                mission=leg,
+                route_manager=route_manager,
+                poi_manager=poi_manager,
+                parent_mission_id=mission.id,
+            )
+            save_mission_timeline(leg.id, timeline)
+            return timeline
+        except Exception as exc:
+            logger.warning(
+                "Failed to rebuild timeline for leg %s during export; "
+                "falling back to cached timeline: %s",
+                leg.id,
+                exc,
+                exc_info=True,
+            )
+
+    return load_mission_timeline(leg.id)
+
+
 def _add_per_leg_exports_to_zip(
     zf: zipfile.ZipFile,
     mission: Mission,
@@ -451,8 +490,9 @@ def _add_per_leg_exports_to_zip(
         map_cache: Optional cache for generated maps (route_id -> bytes)
     """
     for leg in mission.legs:
-        # Load timeline for this specific leg
-        leg_timeline = load_mission_timeline(leg.id)
+        # Rebuild from the latest leg settings so adjusted departure times and
+        # derived AAR/event windows cannot be served from a stale timeline cache.
+        leg_timeline = _load_export_timeline(mission, leg, route_manager, poi_manager)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, skipping exports for this leg"

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -18,7 +18,6 @@ from app.mission.models import Mission, MissionLeg, MissionLegTimeline
 from app.mission.storage import (
     load_mission_v2,
     load_mission_timeline,
-    save_mission_timeline,
 )
 from app.mission.timeline_service import build_mission_timeline
 from app.mission.exporter import (
@@ -451,9 +450,10 @@ def _load_export_timeline(
 ) -> MissionLegTimeline | None:
     """Return a timeline for export, rebuilding from current leg settings first.
 
-    Persisted timelines are a cache. Rebuilding here ensures package/document
-    exports reflect planner edits such as adjusted departure times even if an
-    older cached timeline still exists on disk.
+    Persisted timelines are a cache, not an export target. Rebuilding here keeps
+    package/document exports aligned with planner edits such as adjusted
+    departure times without turning a read-only package export into another
+    timeline write path. If rebuild fails, fall back to the existing cache.
     """
     if route_manager and leg.route_id:
         try:
@@ -463,7 +463,6 @@ def _load_export_timeline(
                 poi_manager=poi_manager,
                 parent_mission_id=mission.id,
             )
-            save_mission_timeline(leg.id, timeline)
             return timeline
         except Exception as exc:
             logger.warning(

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -140,40 +140,6 @@ def generate_mission_combined_csv(
     return None
 
 
-def _load_timeline_for_export(
-    leg: MissionLeg,
-    route_manager: RouteManager | None = None,
-    poi_manager: POIManager | None = None,
-    parent_mission_id: str | None = None,
-) -> MissionLegTimeline | None:
-    """Return the timeline that should be used for export generation.
-
-    Cached timelines can be stale when planners adjust a leg's departure time
-    but export immediately from the mission package endpoint. For adjusted
-    legs, rebuild from the route at export time so relative events such as AAR
-    windows shift with the adjusted takeoff.
-    """
-    if leg.adjusted_departure_time is not None and route_manager and leg.route_id:
-        try:
-            timeline, _summary = build_mission_timeline(
-                mission=leg,
-                route_manager=route_manager,
-                poi_manager=poi_manager,
-                parent_mission_id=parent_mission_id,
-            )
-            return timeline
-        except Exception as e:
-            logger.warning(
-                "Failed to rebuild adjusted timeline for leg %s during export; "
-                "falling back to cached timeline: %s",
-                leg.id,
-                e,
-                exc_info=True,
-            )
-
-    return load_mission_timeline(leg.id)
-
-
 def generate_mission_combined_pptx(
     mission: Mission,
     route_manager: RouteManager | None = None,
@@ -277,8 +243,9 @@ def generate_mission_combined_pptx(
 
     # For each leg, generate slides using shared builder
     for leg_idx, leg in enumerate(mission.legs):
-        # Load timeline for this leg
-        leg_timeline = load_mission_timeline(leg.id)
+        # Rebuild from the latest leg settings so adjusted departure times and
+        # derived AAR/event windows cannot be served from a stale timeline cache.
+        leg_timeline = _load_export_timeline(mission, leg, route_manager, poi_manager)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, adding summary slide only"
@@ -603,7 +570,12 @@ def _add_combined_mission_exports_to_zip(
 
         # Combined CSV - stream to temp file
         with tempfile.NamedTemporaryFile(delete=True) as tmp_csv:
-            generate_mission_combined_csv(mission, output_path=tmp_csv.name)
+            generate_mission_combined_csv(
+                mission,
+                output_path=tmp_csv.name,
+                route_manager=route_manager,
+                poi_manager=poi_manager,
+            )
             zf.write(tmp_csv.name, "exports/mission/mission-timeline.csv")
             manifest_files["mission_exports"].append(
                 "exports/mission/mission-timeline.csv"

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -36,7 +36,10 @@ class ExportPackageError(RuntimeError):
 
 
 def generate_mission_combined_csv(
-    mission: Mission, output_path: str | None = None
+    mission: Mission,
+    output_path: str | None = None,
+    route_manager: RouteManager | None = None,
+    poi_manager: POIManager | None = None,
 ) -> bytes | None:
     """Generate combined CSV timeline for all legs in mission.
 
@@ -71,7 +74,9 @@ def generate_mission_combined_csv(
         for leg in mission.legs:
             try:
                 # Load timeline for this leg
-                timeline = load_mission_timeline(leg.id)
+                timeline = _load_export_timeline(
+                    mission, leg, route_manager, poi_manager
+                )
                 if not timeline:
                     continue
 
@@ -133,6 +138,40 @@ def generate_mission_combined_csv(
     if not output_path:
         return f.getvalue().encode("utf-8")
     return None
+
+
+def _load_timeline_for_export(
+    leg: MissionLeg,
+    route_manager: RouteManager | None = None,
+    poi_manager: POIManager | None = None,
+    parent_mission_id: str | None = None,
+) -> MissionLegTimeline | None:
+    """Return the timeline that should be used for export generation.
+
+    Cached timelines can be stale when planners adjust a leg's departure time
+    but export immediately from the mission package endpoint. For adjusted
+    legs, rebuild from the route at export time so relative events such as AAR
+    windows shift with the adjusted takeoff.
+    """
+    if leg.adjusted_departure_time is not None and route_manager and leg.route_id:
+        try:
+            timeline, _summary = build_mission_timeline(
+                mission=leg,
+                route_manager=route_manager,
+                poi_manager=poi_manager,
+                parent_mission_id=parent_mission_id,
+            )
+            return timeline
+        except Exception as e:
+            logger.warning(
+                "Failed to rebuild adjusted timeline for leg %s during export; "
+                "falling back to cached timeline: %s",
+                leg.id,
+                e,
+                exc_info=True,
+            )
+
+    return load_mission_timeline(leg.id)
 
 
 def generate_mission_combined_pptx(

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -66,7 +66,7 @@ def generate_mission_combined_csv(
         for leg in mission.legs:
             try:
                 # Load timeline for this leg
-                timeline = load_mission_timeline(leg.id)
+                timeline = load_mission_timeline(leg.id, parent_mission_id=mission.id)
                 if not timeline:
                     continue
 
@@ -234,7 +234,7 @@ def generate_mission_combined_pptx(
     # For each leg, generate slides using shared builder
     for leg_idx, leg in enumerate(mission.legs):
         # Load timeline for this leg
-        leg_timeline = load_mission_timeline(leg.id)
+        leg_timeline = load_mission_timeline(leg.id, parent_mission_id=mission.id)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, adding summary slide only"
@@ -452,7 +452,7 @@ def _add_per_leg_exports_to_zip(
     """
     for leg in mission.legs:
         # Load timeline for this specific leg
-        leg_timeline = load_mission_timeline(leg.id)
+        leg_timeline = load_mission_timeline(leg.id, parent_mission_id=mission.id)
         if not leg_timeline:
             logger.warning(
                 f"No timeline found for leg {leg.id}, skipping exports for this leg"

--- a/backend/starlink-location/app/mission/package/__main__.py
+++ b/backend/starlink-location/app/mission/package/__main__.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
 
-from app.mission.models import Mission, MissionLeg, MissionLegTimeline
+from app.mission.models import Mission, MissionLeg, MissionLegTimeline, TimelineStatus
 from app.mission.storage import (
     load_mission_v2,
     load_mission_timeline,
@@ -28,6 +28,14 @@ from app.services.route_manager import RouteManager
 from app.services.poi_manager import POIManager
 
 logger = logging.getLogger(__name__)
+
+
+def _display_status(status_value: str) -> str:
+    """Return user-facing timeline status text."""
+    normalized = status_value.strip().lower()
+    if normalized == TimelineStatus.SOF.value:
+        return "ADVISORY"
+    return normalized.upper()
 
 
 class ExportPackageError(RuntimeError):
@@ -101,7 +109,7 @@ def generate_mission_combined_csv(
                             leg.id,
                             leg.name,
                             start_time,
-                            segment.status.value,
+                            _display_status(segment.status.value),
                             f"States: X={segment.x_state.value}, Ka={segment.ka_state.value}, Ku={segment.ku_state.value} | Duration: {duration}s | Reasons: {reasons}",
                         ]
                     )

--- a/backend/starlink-location/app/mission/routes_v2.py
+++ b/backend/starlink-location/app/mission/routes_v2.py
@@ -94,7 +94,9 @@ async def create_mission(
                             coverage_sampler=_coverage_sampler,
                             parent_mission_id=mission.id,
                         )
-                        save_mission_timeline(leg.id, timeline, parent_mission_id=mission.id)
+                        save_mission_timeline(
+                            leg.id, timeline, parent_mission_id=mission.id
+                        )
                         logger.info(f"Timeline generated and saved for leg {leg.id}")
                     except Exception as e:
                         logger.error(
@@ -797,7 +799,9 @@ async def add_leg_to_mission(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg.id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg.id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(f"Timeline generated and saved for new leg {leg.id}")
                 except Exception as e:
                     logger.error(
@@ -918,7 +922,9 @@ async def update_leg(
                             f"ends at {last_end}, "
                             f"{len(timeline.segments)} segments"
                         )
-                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg_id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(f"Timeline saved to disk for leg {leg_id}")
                 except Exception as e:
                     logger.error(
@@ -1138,7 +1144,9 @@ async def activate_leg(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg_id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(f"Timeline generated and saved for leg {leg_id}")
                 except Exception as e:
                     logger.error(f"Failed to generate timeline for leg {leg_id}: {e}")
@@ -1494,7 +1502,9 @@ async def update_leg_route(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
+                    save_mission_timeline(
+                        leg_id, timeline, parent_mission_id=mission_id
+                    )
                     logger.info(
                         f"Timeline regenerated and saved for leg {leg_id} with new route"
                     )

--- a/backend/starlink-location/app/mission/routes_v2.py
+++ b/backend/starlink-location/app/mission/routes_v2.py
@@ -30,6 +30,8 @@ from app.mission.storage import (
     save_mission_v2,
     load_mission_v2,
     save_mission_timeline,
+    load_mission_timeline,
+    delete_mission_timeline,
     get_mission_lock,
     load_mission_metadata_v2,
 )
@@ -92,7 +94,7 @@ async def create_mission(
                             coverage_sampler=_coverage_sampler,
                             parent_mission_id=mission.id,
                         )
-                        save_mission_timeline(leg.id, timeline)
+                        save_mission_timeline(leg.id, timeline, parent_mission_id=mission.id)
                         logger.info(f"Timeline generated and saved for leg {leg.id}")
                     except Exception as e:
                         logger.error(
@@ -602,7 +604,7 @@ def _generate_timelines_for_imported_legs(
                     coverage_sampler=coverage_sampler,
                     parent_mission_id=mission.id,
                 )
-                save_mission_timeline(leg.id, timeline)
+                save_mission_timeline(leg.id, timeline, parent_mission_id=mission.id)
                 logger.info(f"Timeline generated and saved for imported leg {leg.id}")
             except Exception as e:
                 logger.error(
@@ -795,7 +797,7 @@ async def add_leg_to_mission(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg.id, timeline)
+                    save_mission_timeline(leg.id, timeline, parent_mission_id=mission_id)
                     logger.info(f"Timeline generated and saved for new leg {leg.id}")
                 except Exception as e:
                     logger.error(
@@ -916,7 +918,7 @@ async def update_leg(
                             f"ends at {last_end}, "
                             f"{len(timeline.segments)} segments"
                         )
-                    save_mission_timeline(leg_id, timeline)
+                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
                     logger.info(f"Timeline saved to disk for leg {leg_id}")
                 except Exception as e:
                     logger.error(
@@ -1048,6 +1050,10 @@ async def delete_leg(
                     logger.error(f"Failed to delete leg file {leg_file}: {e}")
                     raise
 
+            # 5. Delete leg timeline file
+            delete_mission_timeline(leg_id, parent_mission_id=mission_id)
+            logger.info(f"Deleted timeline for leg {leg_id}")
+
             logger.info(
                 f"Deleted leg {leg_id} from mission {mission_id} with route {route_id}"
             )
@@ -1132,7 +1138,7 @@ async def activate_leg(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline)
+                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
                     logger.info(f"Timeline generated and saved for leg {leg_id}")
                 except Exception as e:
                     logger.error(f"Failed to generate timeline for leg {leg_id}: {e}")
@@ -1488,7 +1494,7 @@ async def update_leg_route(
                         coverage_sampler=_coverage_sampler,
                         parent_mission_id=mission_id,
                     )
-                    save_mission_timeline(leg_id, timeline)
+                    save_mission_timeline(leg_id, timeline, parent_mission_id=mission_id)
                     logger.info(
                         f"Timeline regenerated and saved for leg {leg_id} with new route"
                     )
@@ -1523,8 +1529,6 @@ async def get_leg_timeline(mission_id: str, leg_id: str) -> dict:
         Timeline object with segments and metadata
     """
     try:
-        from app.mission.storage import load_mission_timeline
-
         # Load mission to verify it exists
         mission = load_mission_v2(mission_id)
         if not mission:
@@ -1542,7 +1546,7 @@ async def get_leg_timeline(mission_id: str, leg_id: str) -> dict:
             )
 
         # Load timeline for the leg
-        timeline = load_mission_timeline(leg_id)
+        timeline = load_mission_timeline(leg_id, parent_mission_id=mission_id)
         if not timeline:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -425,7 +425,7 @@ def save_mission_timeline(
     timeline_path.parent.mkdir(parents=True, exist_ok=True)
     with open(timeline_path, "w") as handle:
         json.dump(timeline.model_dump(), handle, indent=2, default=str)
-    logger.info("Saved mission timeline for %s", leg_id)
+    logger.info("Saved leg timeline for %s", leg_id)
     return timeline_path
 
 

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -54,7 +54,9 @@ def get_mission_checksum_path(mission_id: str) -> Path:
     return MISSIONS_DIR / f"{mission_id}.sha256"
 
 
-def get_mission_timeline_path(leg_id: str, parent_mission_id: str | None = None) -> Path:
+def get_mission_timeline_path(
+    leg_id: str, parent_mission_id: str | None = None
+) -> Path:
     """Get the file path for a leg's cached timeline.
 
     When parent_mission_id is provided the timeline is stored inside the
@@ -474,9 +476,7 @@ def delete_mission_timeline(
             try:
                 scoped_path.unlink()
             except OSError as exc:
-                logger.warning(
-                    "Failed to delete scoped timeline %s: %s", leg_id, exc
-                )
+                logger.warning("Failed to delete scoped timeline %s: %s", leg_id, exc)
 
     # Always attempt to remove the legacy flat file to prevent future pollution.
     legacy_path = get_mission_timeline_path(leg_id)
@@ -484,9 +484,7 @@ def delete_mission_timeline(
         try:
             legacy_path.unlink()
         except OSError as exc:
-            logger.warning(
-                "Failed to delete legacy timeline %s: %s", leg_id, exc
-            )
+            logger.warning("Failed to delete legacy timeline %s: %s", leg_id, exc)
 
 
 def mission_exists(mission_id: str) -> bool:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -54,9 +54,7 @@ def get_mission_checksum_path(mission_id: str) -> Path:
     return MISSIONS_DIR / f"{mission_id}.sha256"
 
 
-def get_mission_timeline_path(
-    leg_id: str, parent_mission_id: str | None = None
-) -> Path:
+def get_leg_timeline_path(leg_id: str, parent_mission_id: str | None = None) -> Path:
     """Get the file path for a leg's cached timeline.
 
     When parent_mission_id is provided the timeline is stored inside the
@@ -381,7 +379,7 @@ def delete_mission(mission_id: str) -> bool:
     """
     mission_path = get_mission_path(mission_id)
     checksum_path = get_mission_checksum_path(mission_id)
-    timeline_path = get_mission_timeline_path(mission_id)
+    timeline_path = get_leg_timeline_path(mission_id)
 
     deleted = False
 
@@ -423,7 +421,7 @@ def save_mission_timeline(
 ) -> Path:
     """Persist a leg timeline to disk."""
     ensure_missions_directory()
-    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
+    timeline_path = get_leg_timeline_path(leg_id, parent_mission_id)
     timeline_path.parent.mkdir(parents=True, exist_ok=True)
     with open(timeline_path, "w") as handle:
         json.dump(timeline.model_dump(), handle, indent=2, default=str)
@@ -441,23 +439,35 @@ def load_mission_timeline(
     legacy flat-file path so existing data continues to work after upgrades.
     """
     if parent_mission_id:
-        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
         if scoped_path.exists():
             with open(scoped_path, "r") as handle:
                 return MissionLegTimeline(**json.load(handle))
     # Legacy fallback: flat file written before the scoped-path fix.
     # Two missions whose legs share a slug will still collide here until each
-    # leg is re-saved (which writes the scoped file). Log so operators know.
-    legacy_path = get_mission_timeline_path(leg_id)
+    # leg is loaded at least once after the upgrade (auto-migration below).
+    legacy_path = get_leg_timeline_path(leg_id)
     if not legacy_path.exists():
         return None
     logger.warning(
-        "Loading timeline for leg %s from legacy flat-file path; "
-        "re-save the leg to migrate to the mission-scoped path.",
+        "Loading timeline for leg %s from legacy flat-file path; migrating now.",
         leg_id,
     )
     with open(legacy_path, "r") as handle:
-        return MissionLegTimeline(**json.load(handle))
+        timeline = MissionLegTimeline(**json.load(handle))
+    # Auto-migrate: write the scoped file and remove the flat one so future
+    # loads go through the per-mission path and the warning disappears.
+    if parent_mission_id:
+        try:
+            scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
+            scoped_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(scoped_path, "w") as handle:
+                json.dump(timeline.model_dump(), handle, indent=2, default=str)
+            legacy_path.unlink(missing_ok=True)
+            logger.info("Migrated timeline for leg %s to scoped path", leg_id)
+        except OSError as exc:
+            logger.warning("Failed to migrate timeline for leg %s: %s", leg_id, exc)
+    return timeline
 
 
 def delete_mission_timeline(
@@ -471,15 +481,17 @@ def delete_mission_timeline(
     that happen to share the same slug.
     """
     if parent_mission_id:
-        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
         if scoped_path.exists():
             try:
                 scoped_path.unlink()
             except OSError as exc:
-                logger.warning("Failed to delete scoped timeline %s: %s", leg_id, exc)
+                logger.warning(
+                    "Failed to delete scoped timeline %s: %s", scoped_path, exc
+                )
 
     # Always attempt to remove the legacy flat file to prevent future pollution.
-    legacy_path = get_mission_timeline_path(leg_id)
+    legacy_path = get_leg_timeline_path(leg_id)
     if legacy_path.exists():
         try:
             legacy_path.unlink()

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -54,9 +54,16 @@ def get_mission_checksum_path(mission_id: str) -> Path:
     return MISSIONS_DIR / f"{mission_id}.sha256"
 
 
-def get_mission_timeline_path(mission_id: str) -> Path:
-    """Get the file path for a mission's cached timeline."""
-    return MISSIONS_DIR / f"{mission_id}{TIMELINE_SUFFIX}"
+def get_mission_timeline_path(leg_id: str, parent_mission_id: str | None = None) -> Path:
+    """Get the file path for a leg's cached timeline.
+
+    When parent_mission_id is provided the timeline is stored inside the
+    mission directory alongside its leg file, preventing name collisions
+    between legs with the same name in different missions.
+    """
+    if parent_mission_id:
+        return get_mission_legs_dir(parent_mission_id) / f"{leg_id}{TIMELINE_SUFFIX}"
+    return MISSIONS_DIR / f"{leg_id}{TIMELINE_SUFFIX}"
 
 
 def get_mission_directory(mission_id: str) -> Path:
@@ -407,34 +414,54 @@ def delete_mission(mission_id: str) -> bool:
     return deleted
 
 
-def save_mission_timeline(mission_id: str, timeline: MissionLegTimeline) -> Path:
-    """Persist a mission timeline to disk."""
+def save_mission_timeline(
+    leg_id: str,
+    timeline: MissionLegTimeline,
+    parent_mission_id: str | None = None,
+) -> Path:
+    """Persist a leg timeline to disk."""
     ensure_missions_directory()
-    timeline_path = get_mission_timeline_path(mission_id)
+    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
+    timeline_path.parent.mkdir(parents=True, exist_ok=True)
     with open(timeline_path, "w") as handle:
         json.dump(timeline.model_dump(), handle, indent=2, default=str)
-    logger.info("Saved mission timeline for %s", mission_id)
+    logger.info("Saved mission timeline for %s", leg_id)
     return timeline_path
 
 
-def load_mission_timeline(mission_id: str) -> MissionLegTimeline | None:
-    """Load a previously computed mission timeline."""
-    timeline_path = get_mission_timeline_path(mission_id)
-    if not timeline_path.exists():
+def load_mission_timeline(
+    leg_id: str,
+    parent_mission_id: str | None = None,
+) -> MissionLegTimeline | None:
+    """Load a previously computed leg timeline.
+
+    Checks the mission-scoped path first (new layout), then falls back to the
+    legacy flat-file path so existing data continues to work.
+    """
+    if parent_mission_id:
+        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        if scoped_path.exists():
+            with open(scoped_path, "r") as handle:
+                return MissionLegTimeline(**json.load(handle))
+    # Legacy fallback: flat file written before this fix
+    legacy_path = get_mission_timeline_path(leg_id)
+    if not legacy_path.exists():
         return None
-    with open(timeline_path, "r") as handle:
-        data = json.load(handle)
-    return MissionLegTimeline(**data)
+    with open(legacy_path, "r") as handle:
+        return MissionLegTimeline(**json.load(handle))
 
 
-def delete_mission_timeline(mission_id: str) -> None:
-    """Remove cached mission timeline without touching mission data."""
-    timeline_path = get_mission_timeline_path(mission_id)
+def delete_mission_timeline(
+    leg_id: str,
+    parent_mission_id: str | None = None,
+) -> None:
+    """Remove a cached leg timeline without touching mission data."""
+    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
     if timeline_path.exists():
         try:
             timeline_path.unlink()
         except OSError as exc:
-            logger.warning("Failed to delete mission timeline %s: %s", mission_id, exc)
+            logger.warning("Failed to delete mission timeline %s: %s", leg_id, exc)
 
 
 def mission_exists(mission_id: str) -> bool:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -436,17 +436,24 @@ def load_mission_timeline(
     """Load a previously computed leg timeline.
 
     Checks the mission-scoped path first (new layout), then falls back to the
-    legacy flat-file path so existing data continues to work.
+    legacy flat-file path so existing data continues to work after upgrades.
     """
     if parent_mission_id:
         scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
         if scoped_path.exists():
             with open(scoped_path, "r") as handle:
                 return MissionLegTimeline(**json.load(handle))
-    # Legacy fallback: flat file written before this fix
+    # Legacy fallback: flat file written before the scoped-path fix.
+    # Two missions whose legs share a slug will still collide here until each
+    # leg is re-saved (which writes the scoped file). Log so operators know.
     legacy_path = get_mission_timeline_path(leg_id)
     if not legacy_path.exists():
         return None
+    logger.warning(
+        "Loading timeline for leg %s from legacy flat-file path; "
+        "re-save the leg to migrate to the mission-scoped path.",
+        leg_id,
+    )
     with open(legacy_path, "r") as handle:
         return MissionLegTimeline(**json.load(handle))
 
@@ -455,13 +462,31 @@ def delete_mission_timeline(
     leg_id: str,
     parent_mission_id: str | None = None,
 ) -> None:
-    """Remove a cached leg timeline without touching mission data."""
-    timeline_path = get_mission_timeline_path(leg_id, parent_mission_id)
-    if timeline_path.exists():
+    """Remove a cached leg timeline without touching mission data.
+
+    Deletes both the mission-scoped path (when parent_mission_id is given) and
+    the legacy flat-file path, so stale flat files can't bleed into future legs
+    that happen to share the same slug.
+    """
+    if parent_mission_id:
+        scoped_path = get_mission_timeline_path(leg_id, parent_mission_id)
+        if scoped_path.exists():
+            try:
+                scoped_path.unlink()
+            except OSError as exc:
+                logger.warning(
+                    "Failed to delete scoped timeline %s: %s", leg_id, exc
+                )
+
+    # Always attempt to remove the legacy flat file to prevent future pollution.
+    legacy_path = get_mission_timeline_path(leg_id)
+    if legacy_path.exists():
         try:
-            timeline_path.unlink()
+            legacy_path.unlink()
         except OSError as exc:
-            logger.warning("Failed to delete mission timeline %s: %s", leg_id, exc)
+            logger.warning(
+                "Failed to delete legacy timeline %s: %s", leg_id, exc
+            )
 
 
 def mission_exists(mission_id: str) -> bool:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -379,7 +379,6 @@ def delete_mission(mission_id: str) -> bool:
     """
     mission_path = get_mission_path(mission_id)
     checksum_path = get_mission_checksum_path(mission_id)
-    timeline_path = get_leg_timeline_path(mission_id)
 
     deleted = False
 
@@ -400,13 +399,10 @@ def delete_mission(mission_id: str) -> bool:
             logger.error(f"Failed to delete checksum file {checksum_path}: {e}")
             raise
 
-    if timeline_path.exists():
-        try:
-            timeline_path.unlink()
-            logger.info(f"Deleted timeline file {timeline_path}")
-        except OSError as e:
-            logger.error(f"Failed to delete timeline file {timeline_path}: {e}")
-            raise
+    # Scoped leg timelines live inside the mission directory and are removed
+    # automatically when the v2 delete endpoint calls shutil.rmtree(mission_dir).
+    # The old flat-file timeline ({mission_id}.timeline.json) never existed in
+    # practice because timelines were always keyed by leg_id, not mission_id.
 
     if not deleted:
         logger.warning(f"Mission {mission_id} not found for deletion")
@@ -437,6 +433,11 @@ def load_mission_timeline(
 
     Checks the mission-scoped path first (new layout), then falls back to the
     legacy flat-file path so existing data continues to work after upgrades.
+
+    Note: callers that omit parent_mission_id will never find a scoped file and
+    will only hit the legacy flat-file path.  After migration is complete (all
+    flat files removed) those call sites will always return None.  Pass
+    parent_mission_id whenever the mission context is available.
     """
     if parent_mission_id:
         scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
@@ -457,6 +458,8 @@ def load_mission_timeline(
         timeline = MissionLegTimeline(**json.load(handle))
     # Auto-migrate: write the scoped file and remove the flat one so future
     # loads go through the per-mission path and the warning disappears.
+    # Not atomic — a crash between the write and the unlink leaves both files,
+    # which is safe: the scoped path wins on the next load.
     if parent_mission_id:
         try:
             scoped_path = get_leg_timeline_path(leg_id, parent_mission_id)
@@ -491,6 +494,7 @@ def delete_mission_timeline(
                 )
 
     # Always attempt to remove the legacy flat file to prevent future pollution.
+    # TODO: remove this probe once all deployments have migrated to scoped paths.
     legacy_path = get_leg_timeline_path(leg_id)
     if legacy_path.exists():
         try:

--- a/backend/starlink-location/app/mission/storage.py
+++ b/backend/starlink-location/app/mission/storage.py
@@ -86,6 +86,14 @@ def get_mission_leg_file_path(mission_id: str, leg_id: str) -> Path:
     return get_mission_legs_dir(mission_id) / f"{leg_id}.json"
 
 
+def _iter_mission_leg_files(legs_dir: Path):
+    """Yield persisted mission leg JSON files, excluding cached timelines."""
+    for leg_file in sorted(legs_dir.glob("*.json")):
+        if leg_file.name.endswith(TIMELINE_SUFFIX):
+            continue
+        yield leg_file
+
+
 def compute_file_checksum(file_path: Path) -> str:
     """Compute SHA256 checksum of a file."""
     sha256 = hashlib.sha256()
@@ -209,7 +217,7 @@ def load_mission_v2(mission_id: str) -> Optional[Mission]:
     legs = []
 
     if legs_dir.exists():
-        for leg_file in sorted(legs_dir.glob("*.json")):
+        for leg_file in _iter_mission_leg_files(legs_dir):
             with open(leg_file, "r") as f:
                 leg_data = json.load(f)
                 legs.append(MissionLeg(**leg_data))
@@ -250,7 +258,7 @@ def load_mission_metadata_v2(mission_id: str) -> Optional[Mission]:
         leg_stubs = []
 
         if legs_dir.exists():
-            for leg_file in sorted(legs_dir.glob("*.json")):
+            for leg_file in _iter_mission_leg_files(legs_dir):
                 # Extract leg ID from filename (e.g., "leg-1.json" -> "leg-1")
                 leg_id = leg_file.stem
                 # Create minimal leg stub with only required fields

--- a/backend/starlink-location/app/mission/timeline_builder/__init__.py
+++ b/backend/starlink-location/app/mission/timeline_builder/__init__.py
@@ -15,6 +15,8 @@ from app.mission.timeline_builder.calculator import (
     RouteProjection,
     derive_mission_window,
     generate_timeline_samples,
+    route_takeoff_delta,
+    route_with_adjusted_departure,
     TIMELINE_SAMPLE_INTERVAL_SECONDS,
 )
 from app.mission.timeline_builder.coverage import (
@@ -63,6 +65,8 @@ __all__ = [
     "RouteProjection",
     "derive_mission_window",
     "generate_timeline_samples",
+    "route_takeoff_delta",
+    "route_with_adjusted_departure",
     "TIMELINE_SAMPLE_INTERVAL_SECONDS",
     # Coverage
     "RouteSample",

--- a/backend/starlink-location/app/mission/timeline_builder/aar.py
+++ b/backend/starlink-location/app/mission/timeline_builder/aar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from app.mission.models import MissionLeg
 from app.models.route import ParsedRoute
@@ -40,13 +40,36 @@ def resolve_aar_windows(
     waypoint_lookup = {wp.name: wp for wp in route.waypoints if wp.name}
 
     for idx, window in enumerate(mission.transports.aar_windows or []):
-        start_time = window.override_start_time
-        end_time = window.override_end_time
-        if start_time is None or end_time is None:
-            start_wp = waypoint_lookup.get(window.start_waypoint_name)
-            end_wp = waypoint_lookup.get(window.end_waypoint_name)
-            start_time = timestamp_for_waypoint(start_wp, projector)
-            end_time = timestamp_for_waypoint(end_wp, projector)
+        start_wp = waypoint_lookup.get(window.start_waypoint_name)
+        end_wp = waypoint_lookup.get(window.end_waypoint_name)
+        route_start_time = timestamp_for_waypoint(start_wp, projector)
+        route_end_time = timestamp_for_waypoint(end_wp, projector)
+        if window.override_start_elapsed:
+            if route_start_time is None or route_end_time is None:
+                logger.warning(
+                    "Skipping AAR window %s: T+ override requires route waypoint times",
+                    window.id or idx + 1,
+                )
+                continue
+            duration = ensure_timezone(route_end_time) - ensure_timezone(route_start_time)
+            try:
+                elapsed_offset = parse_elapsed_offset(window.override_start_elapsed)
+            except ValueError as exc:
+                logger.warning(
+                    "Skipping AAR window %s: invalid T+ override %r (%s)",
+                    window.id or idx + 1,
+                    window.override_start_elapsed,
+                    exc,
+                )
+                continue
+            start_time = ensure_timezone(projector.start_time) + elapsed_offset
+            end_time = start_time + duration
+        else:
+            start_time = window.override_start_time
+            end_time = window.override_end_time
+            if start_time is None or end_time is None:
+                start_time = route_start_time
+                end_time = route_end_time
         if not start_time or not end_time or end_time <= start_time:
             continue
         # Ensure times are timezone-aware for consistent comparison
@@ -61,6 +84,22 @@ def resolve_aar_windows(
         )
 
     return windows
+
+
+def parse_elapsed_offset(value: str) -> timedelta:
+    """Parse flight-deck mission elapsed values such as T+02:15."""
+
+    raw = value.strip().upper()
+    if raw.startswith("T+"):
+        raw = raw[2:]
+    parts = raw.split(":")
+    if len(parts) not in (2, 3):
+        raise ValueError("Elapsed AAR override must use T+HH:MM or T+HH:MM:SS")
+    hours, minutes = int(parts[0]), int(parts[1])
+    seconds = int(parts[2]) if len(parts) == 3 else 0
+    if hours < 0 or minutes < 0 or seconds < 0 or minutes >= 60 or seconds >= 60:
+        raise ValueError("Elapsed AAR override contains invalid time fields")
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
 
 
 def apply_x_transitions(

--- a/backend/starlink-location/app/mission/timeline_builder/aar.py
+++ b/backend/starlink-location/app/mission/timeline_builder/aar.py
@@ -51,7 +51,9 @@ def resolve_aar_windows(
                     window.id or idx + 1,
                 )
                 continue
-            duration = ensure_timezone(route_end_time) - ensure_timezone(route_start_time)
+            duration = ensure_timezone(route_end_time) - ensure_timezone(
+                route_start_time
+            )
             try:
                 elapsed_offset = parse_elapsed_offset(window.override_start_elapsed)
             except ValueError as exc:

--- a/backend/starlink-location/app/mission/timeline_builder/aar.py
+++ b/backend/starlink-location/app/mission/timeline_builder/aar.py
@@ -40,10 +40,13 @@ def resolve_aar_windows(
     waypoint_lookup = {wp.name: wp for wp in route.waypoints if wp.name}
 
     for idx, window in enumerate(mission.transports.aar_windows or []):
-        start_wp = waypoint_lookup.get(window.start_waypoint_name)
-        end_wp = waypoint_lookup.get(window.end_waypoint_name)
-        start_time = timestamp_for_waypoint(start_wp, projector)
-        end_time = timestamp_for_waypoint(end_wp, projector)
+        start_time = window.override_start_time
+        end_time = window.override_end_time
+        if start_time is None or end_time is None:
+            start_wp = waypoint_lookup.get(window.start_waypoint_name)
+            end_wp = waypoint_lookup.get(window.end_waypoint_name)
+            start_time = timestamp_for_waypoint(start_wp, projector)
+            end_time = timestamp_for_waypoint(end_wp, projector)
         if not start_time or not end_time or end_time <= start_time:
             continue
         # Ensure times are timezone-aware for consistent comparison

--- a/backend/starlink-location/app/mission/timeline_builder/calculator.py
+++ b/backend/starlink-location/app/mission/timeline_builder/calculator.py
@@ -44,6 +44,65 @@ class TimelineComputationError(RuntimeError):
     """Raised when mission timeline generation fails."""
 
 
+def route_takeoff_delta(
+    route: ParsedRoute, adjusted_departure_time: datetime | None = None
+) -> timedelta | None:
+    """Return the uniform route-time delta for an adjusted takeoff.
+
+    The route KML/timing profile is the source timeline. When planners adjust
+    takeoff, every derived event must move by the same delta: route points,
+    AAR waypoint windows, satellite transition projections, and landing.
+    """
+    if adjusted_departure_time is None or not route.timing_profile:
+        return None
+    if not route.timing_profile.departure_time:
+        return None
+
+    original_start = ensure_timezone(route.timing_profile.departure_time)
+    adjusted_start = ensure_timezone(adjusted_departure_time)
+    return adjusted_start - original_start
+
+
+def route_with_adjusted_departure(
+    route: ParsedRoute, adjusted_departure_time: datetime | None = None
+) -> ParsedRoute:
+    """Return a route copy with all embedded timeline timestamps shifted.
+
+    The input route is often cached by RouteManager, so this function never
+    mutates it in place. Only route-timeline fields are shifted; observed actual
+    departure/arrival timestamps remain untouched.
+    """
+    delta = route_takeoff_delta(route, adjusted_departure_time)
+    if delta is None or delta.total_seconds() == 0:
+        return route
+
+    shifted = route.model_copy(deep=True)
+
+    if shifted.timing_profile:
+        if shifted.timing_profile.departure_time:
+            shifted.timing_profile.departure_time = (
+                ensure_timezone(shifted.timing_profile.departure_time) + delta
+            )
+        if shifted.timing_profile.arrival_time:
+            shifted.timing_profile.arrival_time = (
+                ensure_timezone(shifted.timing_profile.arrival_time) + delta
+            )
+
+    for point in shifted.points:
+        if point.expected_arrival_time:
+            point.expected_arrival_time = (
+                ensure_timezone(point.expected_arrival_time) + delta
+            )
+
+    for waypoint in shifted.waypoints:
+        if waypoint.expected_arrival_time:
+            waypoint.expected_arrival_time = (
+                ensure_timezone(waypoint.expected_arrival_time) + delta
+            )
+
+    return shifted
+
+
 @dataclass
 class RouteProjection:
     """Projection of an arbitrary coordinate onto the route timeline."""
@@ -177,6 +236,8 @@ def derive_mission_window(
     Raises:
         TimelineComputationError: If route timing data is missing or invalid
     """
+    route = route_with_adjusted_departure(route, adjusted_departure_time)
+
     start_candidates: list[datetime] = []
     end_candidates: list[datetime] = []
 
@@ -206,27 +267,9 @@ def derive_mission_window(
     original_start = ensure_timezone(original_start)
     original_end = ensure_timezone(original_end)
 
-    # Apply time adjustment if provided
-    if adjusted_departure_time is not None:
-        # Ensure adjusted time is also timezone-aware
-        adjusted_departure_time = ensure_timezone(adjusted_departure_time)
-        offset_seconds = (adjusted_departure_time - original_start).total_seconds()
-        offset = timedelta(seconds=offset_seconds)
-        mission_start = original_start + offset
-        mission_end = original_end + offset
-        logger.info(
-            f"derive_mission_window: adjusted time provided. "
-            f"original_start={original_start}, "
-            f"adjusted_departure_time={adjusted_departure_time}, "
-            f"offset={offset_seconds}s, "
-            f"mission_start={mission_start}"
-        )
-    else:
-        mission_start = original_start
-        mission_end = original_end
-        logger.debug(
-            f"derive_mission_window: no adjustment. " f"mission_start={mission_start}"
-        )
+    mission_start = original_start
+    mission_end = original_end
+    logger.debug(f"derive_mission_window: mission_start={mission_start}")
 
     return mission_start, mission_end
 

--- a/backend/starlink-location/app/mission/timeline_builder/calculator.py
+++ b/backend/starlink-location/app/mission/timeline_builder/calculator.py
@@ -121,10 +121,27 @@ class RouteTemporalProjector:
         self.route = route
         self.start_time = start_time
         self.end_time = end_time
+        self.original_start_time = self._derive_original_start_time()
         self.duration_seconds = max((end_time - start_time).total_seconds(), 1.0)
         self.calculator = RouteETACalculator(route)
         self.cumulative_distances = self._build_cumulative_distances()
         self.total_distance = max(self.cumulative_distances[-1], 1.0)
+
+    def _derive_original_start_time(self) -> datetime:
+        """Return the unadjusted route start used to calculate time shifts."""
+        candidates: list[datetime] = []
+        if self.route.timing_profile and self.route.timing_profile.departure_time:
+            candidates.append(self.route.timing_profile.departure_time)
+        for point in self.route.points:
+            if point.expected_arrival_time:
+                candidates.append(point.expected_arrival_time)
+        if not candidates:
+            return self.start_time
+        return min(ensure_timezone(candidate) for candidate in candidates)
+
+    def shift_route_timestamp(self, timestamp: datetime) -> datetime:
+        """Shift a route-native timestamp by the projector's departure offset."""
+        return ensure_timezone(timestamp) + (self.start_time - self.original_start_time)
 
     def _build_cumulative_distances(self) -> list[float]:
         distances = [0.0]

--- a/backend/starlink-location/app/mission/timeline_builder/utils.py
+++ b/backend/starlink-location/app/mission/timeline_builder/utils.py
@@ -128,6 +128,6 @@ def timestamp_for_waypoint(
     if not waypoint:
         return None
     if waypoint.expected_arrival_time:
-        return waypoint.expected_arrival_time
+        return projector.shift_route_timestamp(waypoint.expected_arrival_time)
     projection = projector.project(waypoint.latitude, waypoint.longitude)
     return projection.timestamp

--- a/backend/starlink-location/app/mission/timeline_service.py
+++ b/backend/starlink-location/app/mission/timeline_service.py
@@ -21,6 +21,8 @@ from app.mission.timeline_builder.calculator import (
     RouteTemporalProjector,
     derive_mission_window,
     generate_timeline_samples,
+    route_takeoff_delta,
+    route_with_adjusted_departure,
     TIMELINE_SAMPLE_INTERVAL_SECONDS,
 )
 from app.mission.timeline_builder.coverage import analyze_ka_coverage
@@ -81,10 +83,8 @@ def build_mission_timeline(
     if not route:
         raise TimelineComputationError(f"Route {mission.route_id} not loaded")
 
-    # Pass adjusted_departure_time to derive_mission_window if set
-    mission_start, mission_end = derive_mission_window(
-        route, adjusted_departure_time=mission.adjusted_departure_time
-    )
+    route = route_with_adjusted_departure(route, mission.adjusted_departure_time)
+    mission_start, mission_end = derive_mission_window(route)
     projector = RouteTemporalProjector(route, mission_start, mission_end)
 
     resolved_sampler = coverage_sampler or _get_default_coverage_sampler()
@@ -248,4 +248,6 @@ __all__ = [
     "TimelineComputationError",
     "TimelineSummary",
     "RouteTemporalProjector",
+    "route_takeoff_delta",
+    "route_with_adjusted_departure",
 ]

--- a/backend/starlink-location/app/mission/timeline_service.py
+++ b/backend/starlink-location/app/mission/timeline_service.py
@@ -6,6 +6,7 @@ import logging
 import time
 from pathlib import Path
 
+from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.models import MissionLeg, MissionLegTimeline, Transport
 from app.mission.state import generate_transport_intervals
 from app.mission.timeline import assemble_mission_timeline
@@ -174,6 +175,7 @@ def build_mission_timeline(
         intervals=intervals,
     )
     annotate_aar_markers(timeline, events)
+    normalize_call_availability_timeline(timeline)
     attach_statistics(timeline, mission_start, mission_end)
 
     # Attach route samples if requested (for preview rendering)

--- a/backend/starlink-location/entrypoint.sh
+++ b/backend/starlink-location/entrypoint.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 
-# Ensure mounted data directories have correct permissions for appuser
-# This runs as root.
-# Try to change ownership, but don't fail if it's not permitted (e.g. specific bind mounts)
-chown -R appuser:appuser /app/data/missions 2>/dev/null || true
-chown -R appuser:appuser /app/data/satellites 2>/dev/null || true
-chown -R appuser:appuser /app/data/sat_coverage 2>/dev/null || true
-chown -R appuser:appuser /data/routes 2>/dev/null || true
-chown -R appuser:appuser /data/sim_routes 2>/dev/null || true
-chown -R appuser:appuser /data 2>/dev/null || true
-
-# Ensure they are writable by everyone (simplest fix for bind mount permission issues in dev)
-chmod -R 777 /app/data/sat_coverage
-chmod -R 777 /data
+# Ensure mounted data directories exist and have writable top-level permissions.
+# Do not recursively chown/chmod the volumes on every container start: route/POI
+# caches can grow large, and walking them makes startup look hung.
+for dir in \
+  /app/data/missions \
+  /app/data/satellites \
+  /app/data/sat_coverage \
+  /data/routes \
+  /data/sim_routes \
+  /data
+ do
+  mkdir -p "$dir" 2>/dev/null || true
+  chown appuser:appuser "$dir" 2>/dev/null || true
+  chmod 775 "$dir" 2>/dev/null || true
+ done
 
 # Execute the main command as appuser
 exec runuser -u appuser -- "$@"

--- a/backend/starlink-location/main.py
+++ b/backend/starlink-location/main.py
@@ -55,10 +55,10 @@ setup_logging(level=log_level, json_format=json_logs, log_file=log_file)
 logger = get_logger(__name__)
 
 # Global simulator instance
-_coordinator: SimulationCoordinator = None
+_coordinator: SimulationCoordinator | LiveCoordinator | None = None
 _background_task = None
 _simulation_config = None
-_route_manager: RouteManager = None
+_route_manager: RouteManager | None = None
 
 
 async def startup_event():
@@ -268,7 +268,7 @@ async def startup_event():
 
 async def shutdown_event():
     """Cleanup on shutdown."""
-    global _background_task
+    global _background_task, _route_manager
 
     try:
         logger.info_json("Shutting down Starlink Location Backend")
@@ -280,6 +280,12 @@ async def shutdown_event():
                 await _background_task
             except asyncio.CancelledError:
                 logger.info_json("Background task cancelled successfully")
+            _background_task = None
+
+        if _route_manager:
+            logger.info_json("Stopping Route Manager watcher")
+            _route_manager.stop_watching()
+            _route_manager = None
 
         # Shutdown ETA service
         logger.info_json("Shutting down ETA service")
@@ -323,10 +329,9 @@ async def _background_update_loop(poi_manager=None):
                         try:
                             # Extract active route for route-aware ETA calculations
                             active_route = None
-                            if hasattr(_coordinator, "route_manager"):
-                                active_route = (
-                                    _coordinator.route_manager.get_active_route()
-                                )
+                            route_manager = getattr(_coordinator, "route_manager", None)
+                            if route_manager is not None:
+                                active_route = route_manager.get_active_route()
 
                             update_metrics_from_telemetry(
                                 telemetry, _simulation_config, active_route, poi_manager

--- a/backend/starlink-location/tests/integration/test_mission_routes.py
+++ b/backend/starlink-location/tests/integration/test_mission_routes.py
@@ -739,10 +739,9 @@ class TestMissionExportEndpoint:
         for fmt, media in [
             ("csv", "text/csv"),
             (
-                "xlsx",
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "pptx",
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             ),
-            ("pdf", "application/pdf"),
         ]:
             response = client.post(
                 f"/api/missions/{test_mission.id}/export",

--- a/backend/starlink-location/tests/unit/test_adjusted_departure.py
+++ b/backend/starlink-location/tests/unit/test_adjusted_departure.py
@@ -5,13 +5,21 @@ from datetime import datetime, timezone, timedelta
 
 from app.mission.models import MissionLeg, TransportConfig
 from app.mission.timeline_builder.calculator import (
+    RouteTemporalProjector,
     derive_mission_window,
     TimelineComputationError,
 )
+from app.mission.timeline_builder.utils import timestamp_for_waypoint
 from app.mission.validation import (
     validate_adjusted_departure_time,
 )
-from app.models.route import ParsedRoute, RoutePoint, RouteTimingProfile, RouteMetadata
+from app.models.route import (
+    ParsedRoute,
+    RoutePoint,
+    RouteTimingProfile,
+    RouteMetadata,
+    RouteWaypoint,
+)
 
 
 class TestMissionLegTimeOffset:
@@ -201,6 +209,32 @@ class TestDeriveMissionWindow:
 
         adjusted_duration = (end - start).total_seconds()
         assert adjusted_duration == original_duration
+
+    def test_waypoint_timestamps_shift_with_adjusted_departure(self):
+        """Timed route waypoints should shift by the same departure delta."""
+        original_departure = datetime(2025, 10, 27, 16, 45, 0, tzinfo=timezone.utc)
+        original_arrival = datetime(2025, 10, 27, 22, 15, 0, tzinfo=timezone.utc)
+        waypoint_time = datetime(2025, 10, 27, 18, 0, 0, tzinfo=timezone.utc)
+        adjusted_departure = original_departure + timedelta(minutes=75)
+
+        route = self._create_test_route(original_departure, original_arrival)
+        route.waypoints = [
+            RouteWaypoint(
+                name="AAR-START",
+                latitude=35.25,
+                longitude=-120.25,
+                order=1,
+                expected_arrival_time=waypoint_time,
+            )
+        ]
+        start, end = derive_mission_window(
+            route, adjusted_departure_time=adjusted_departure
+        )
+        projector = RouteTemporalProjector(route, start, end)
+
+        assert timestamp_for_waypoint(route.waypoints[0], projector) == (
+            waypoint_time + timedelta(minutes=75)
+        )
 
     def test_large_offset(self):
         """Large offset (10 hours) is allowed and applied correctly."""

--- a/backend/starlink-location/tests/unit/test_main_lifespan.py
+++ b/backend/starlink-location/tests/unit/test_main_lifespan.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_shutdown_event_stops_route_manager_watcher():
+    route_manager = MagicMock()
+    original_route_manager = main._route_manager
+    original_background_task = main._background_task
+
+    try:
+        main._route_manager = route_manager
+        main._background_task = None
+
+        await main.shutdown_event()
+
+        route_manager.stop_watching.assert_called_once_with()
+    finally:
+        main._route_manager = original_route_manager
+        main._background_task = original_background_task

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -12,6 +12,7 @@ from app.mission.exporter import (
     TimelineExportFormat,
     generate_timeline_export,
 )
+from app.mission.exporter.__main__ import _compact_reason_label
 from app.mission.models import (
     MissionLeg,
     MissionLegTimeline,
@@ -164,7 +165,7 @@ class TestMissionTimelineExporters:
         assert row["X-Band"] == "AVAILABLE"
         assert row["StarShield"] == "AVAILABLE"
         assert row["Systems Affected"] == ""
-        assert row["Reasons"] == "X Band / Ku conflict — choose one transport"
+        assert row["Reasons"] == "X/Ku Conflict"
         assert "PACE" not in row["Reasons"]
 
     def test_aar_boundary_and_landing_markers_export_inline_in_reasons(self, mission):
@@ -200,10 +201,7 @@ class TestMissionTimelineExporters:
         assert "Operational Markers" not in df.columns
         aar_start = df[df["Start Time"].str.contains("18:42Z")].iloc[0]
         assert aar_start["Status"] == "ADVISORY"
-        assert aar_start["Reasons"] == (
-            "X Band / Ku conflict — choose one transport; "
-            "AAR Start; AAR window; Landing safety window"
-        )
+        assert aar_start["Reasons"] == "AAR Start"
 
     def test_aar_block_rows_normalize_primary_table_without_overlap(self, mission):
         start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
@@ -243,8 +241,111 @@ class TestMissionTimelineExporters:
             "Nominal calls",
         ]
         assert list(df["Primary Reason"]) == ["AAR window", "nominal window"]
-        assert list(df["Reasons"]) == [
-            "Safety-of-flight advised — AAR window; AAR Start",
-            "Nominal calls; AAR End",
-        ]
+        assert list(df["Reasons"]) == ["AAR Start", "AAR End"]
         assert df.iloc[0]["Systems Affected"] == ""
+
+    def test_takeoff_landing_sof_reasons_use_compact_labels(self, mission):
+        start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+        segments = [
+            TimelineSegment(
+                id="seg-takeoff",
+                start_time=start,
+                end_time=start + timedelta(minutes=15),
+                status=TimelineStatus.SOF,
+                x_state=TransportState.AVAILABLE,
+                ka_state=TransportState.AVAILABLE,
+                ku_state=TransportState.AVAILABLE,
+                reasons=["Safety-of-Flight (takeoff)"],
+                impacted_transports=[],
+                metadata={},
+            ),
+            TimelineSegment(
+                id="seg-landing",
+                start_time=start + timedelta(minutes=30),
+                end_time=start + timedelta(minutes=45),
+                status=TimelineStatus.SOF,
+                x_state=TransportState.AVAILABLE,
+                ka_state=TransportState.AVAILABLE,
+                ku_state=TransportState.AVAILABLE,
+                reasons=["Safety-of-Flight (landing)"],
+                impacted_transports=[],
+                metadata={},
+            ),
+        ]
+        timeline = MissionLegTimeline(
+            mission_leg_id=mission.id,
+            segments=segments,
+            advisories=[],
+            statistics={},
+        )
+
+        df = mission_exporter._segment_rows(timeline, mission)
+
+        assert list(df["Reasons"]) == ["Takeoff", "Landing"]
+
+    def test_satellite_swap_reason_uses_compact_transition_label(self, mission):
+        start = datetime(2025, 11, 5, 4, 38, tzinfo=timezone.utc)
+        segment = TimelineSegment(
+            id="seg-ka-swap",
+            start_time=start,
+            end_time=start + timedelta(minutes=30),
+            status=TimelineStatus.DEGRADED,
+            x_state=TransportState.AVAILABLE,
+            ka_state=TransportState.DEGRADED,
+            ku_state=TransportState.AVAILABLE,
+            reasons=["Degraded — Satellite swap: Ka transition POR → AOR"],
+            impacted_transports=[Transport.KA],
+            metadata={},
+        )
+        timeline = MissionLegTimeline(
+            mission_leg_id=mission.id,
+            segments=[segment],
+            advisories=[],
+            statistics={},
+        )
+
+        df = mission_exporter._segment_rows(timeline, mission)
+
+        assert df.iloc[0]["Reasons"] == "Ka POR => AOR"
+
+    def test_aar_window_without_boundary_uses_compact_label(self, mission):
+        start = datetime(2025, 11, 5, 0, 5, tzinfo=timezone.utc)
+        segment = TimelineSegment(
+            id="seg-aar-window",
+            start_time=start,
+            end_time=start + timedelta(minutes=10),
+            status=TimelineStatus.SOF,
+            x_state=TransportState.AVAILABLE,
+            ka_state=TransportState.AVAILABLE,
+            ku_state=TransportState.AVAILABLE,
+            reasons=["Safety-of-flight advised — AAR window"],
+            impacted_transports=[],
+            metadata={"operational_markers": ["AAR window"]},
+        )
+
+        assert _compact_reason_label(segment) == "AAR Window"
+
+    def test_x_satellite_swap_reason_uses_compact_transition_label(self, mission):
+        start = datetime(2025, 11, 5, 4, 38, tzinfo=timezone.utc)
+        segment = TimelineSegment(
+            id="seg-x-swap",
+            start_time=start,
+            end_time=start + timedelta(minutes=30),
+            status=TimelineStatus.DEGRADED,
+            x_state=TransportState.DEGRADED,
+            ka_state=TransportState.AVAILABLE,
+            ku_state=TransportState.AVAILABLE,
+            reasons=["Degraded — Satellite swap: X Transition to X-6"],
+            impacted_transports=[Transport.X],
+            metadata={},
+        )
+        timeline = MissionLegTimeline(
+            mission_leg_id=mission.id,
+            segments=[segment],
+            advisories=[],
+            statistics={},
+        )
+
+        df = mission_exporter._segment_rows(timeline, mission)
+
+        assert df.iloc[0]["Reasons"] == "X => X-6"

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -133,7 +133,9 @@ class TestMissionTimelineExporters:
         assert artifact.extension == "csv"
         assert artifact.media_type == "text/csv"
 
-    def test_x_ku_conflict_segments_render_as_warning(self, mission):
+    def test_x_ku_conflict_segments_render_as_transport_concurrency_advisory(
+        self, mission
+    ):
         start = datetime(2025, 11, 5, 2, 0, tzinfo=timezone.utc)
         warning_segment = TimelineSegment(
             id="seg-warning",
@@ -156,11 +158,16 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         row = df.iloc[0]
-        assert row["Status"] == "DEGRADED"
-        assert row["Call Posture"] == "Degraded"
+        assert row["Status"] == "SOF"
+        assert row["Call Posture"] == "Transport concurrency advisory"
         assert row["Primary Reason"] == "X Band / Ku conflict"
-        assert row["X-Band"] == "DEGRADED"
-        assert row["Systems Affected"] == "X"
+        assert row["X-Band"] == "AVAILABLE"
+        assert row["StarShield"] == "AVAILABLE"
+        assert row["Systems Affected"] == ""
+        assert row["Reasons"] == (
+            "Transport concurrency advisory: X Band / Ku conflict — choose one "
+            "transport; PACE preference Starlink > Comm Ka > X-Band"
+        )
 
     def test_aar_block_rows_normalize_primary_table_without_overlap(self, mission):
         start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -167,7 +167,7 @@ class TestMissionTimelineExporters:
         assert row["Reasons"] == "X Band / Ku conflict — choose one transport"
         assert "PACE" not in row["Reasons"]
 
-    def test_aar_boundary_and_landing_markers_export_in_dedicated_column(self, mission):
+    def test_aar_boundary_and_landing_markers_export_inline_in_reasons(self, mission):
         start = datetime(2025, 11, 5, 18, 34, tzinfo=timezone.utc)
         segment = TimelineSegment(
             id="seg-x-ku-aar",
@@ -197,11 +197,11 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
 
-        assert "Operational Markers" in df.columns
+        assert "Operational Markers" not in df.columns
         aar_start = df[df["Start Time"].str.contains("18:42Z")].iloc[0]
         assert aar_start["Status"] == "ADVISORY"
-        assert aar_start["Reasons"] == "X Band / Ku conflict — choose one transport"
-        assert aar_start["Operational Markers"] == (
+        assert aar_start["Reasons"] == (
+            "X Band / Ku conflict — choose one transport; "
             "AAR Start; AAR window; Landing safety window"
         )
 
@@ -244,7 +244,7 @@ class TestMissionTimelineExporters:
         ]
         assert list(df["Primary Reason"]) == ["AAR window", "nominal window"]
         assert list(df["Reasons"]) == [
-            "Safety-of-flight advised — AAR window",
-            "Nominal calls",
+            "Safety-of-flight advised — AAR window; AAR Start",
+            "Nominal calls; AAR End",
         ]
         assert df.iloc[0]["Systems Affected"] == ""

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -158,16 +158,14 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         row = df.iloc[0]
-        assert row["Status"] == "SOF"
+        assert row["Status"] == "ADVISORY"
         assert row["Call Posture"] == "Transport concurrency advisory"
         assert row["Primary Reason"] == "X Band / Ku conflict"
         assert row["X-Band"] == "AVAILABLE"
         assert row["StarShield"] == "AVAILABLE"
         assert row["Systems Affected"] == ""
-        assert row["Reasons"] == (
-            "Transport concurrency advisory: X Band / Ku conflict — choose one "
-            "transport; PACE preference Starlink > Comm Ka > X-Band"
-        )
+        assert row["Reasons"] == "X Band / Ku conflict — choose one transport"
+        assert "PACE" not in row["Reasons"]
 
     def test_aar_block_rows_normalize_primary_table_without_overlap(self, mission):
         start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
@@ -201,7 +199,7 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         assert "AAR" not in df["Segment #"].values
-        assert list(df["Status"]) == ["SOF", "NOMINAL"]
+        assert list(df["Status"]) == ["ADVISORY", "NOMINAL"]
         assert list(df["Call Posture"]) == [
             "Safety-of-flight advised",
             "Nominal calls",

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -158,7 +158,7 @@ class TestMissionTimelineExporters:
         row = df.iloc[0]
         assert row["Status"] == "DEGRADED"
         assert row["Call Posture"] == "Degraded"
-        assert row["Primary Reason"] == "Ku/X conflict"
+        assert row["Primary Reason"] == "X Band / Ku conflict"
         assert row["X-Band"] == "DEGRADED"
         assert row["Systems Affected"] == "X"
 
@@ -194,7 +194,13 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         assert "AAR" not in df["Segment #"].values
-        assert list(df["Call Posture"]) == ["Avoid calls", "Nominal calls"]
-        assert list(df["Primary Reason"]) == ["SOF AAR", "nominal window"]
-        assert list(df["Reasons"]) == ["Avoid calls — SOF AAR", "Nominal calls"]
+        assert list(df["Call Posture"]) == [
+            "Safety-of-flight advised",
+            "Nominal calls",
+        ]
+        assert list(df["Primary Reason"]) == ["AAR window", "nominal window"]
+        assert list(df["Reasons"]) == [
+            "Safety-of-flight advised — AAR window",
+            "Nominal calls",
+        ]
         assert df.iloc[0]["Systems Affected"] == ""

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -167,6 +167,44 @@ class TestMissionTimelineExporters:
         assert row["Reasons"] == "X Band / Ku conflict — choose one transport"
         assert "PACE" not in row["Reasons"]
 
+    def test_aar_boundary_and_landing_markers_export_in_dedicated_column(self, mission):
+        start = datetime(2025, 11, 5, 18, 34, tzinfo=timezone.utc)
+        segment = TimelineSegment(
+            id="seg-x-ku-aar",
+            start_time=start,
+            end_time=start + timedelta(minutes=104),
+            status=TimelineStatus.DEGRADED,
+            x_state=TransportState.DEGRADED,
+            ka_state=TransportState.AVAILABLE,
+            ku_state=TransportState.AVAILABLE,
+            reasons=["X Band / Ku conflict", "Safety-of-Flight (landing)"],
+            impacted_transports=[Transport.X],
+            metadata={},
+        )
+        timeline = MissionLegTimeline(
+            mission_leg_id=mission.id,
+            segments=[segment],
+            advisories=[],
+            statistics={
+                "_aar_blocks": [
+                    {
+                        "start": (start + timedelta(minutes=8)).isoformat(),
+                        "end": (start + timedelta(minutes=104)).isoformat(),
+                    }
+                ]
+            },
+        )
+
+        df = mission_exporter._segment_rows(timeline, mission)
+
+        assert "Operational Markers" in df.columns
+        aar_start = df[df["Start Time"].str.contains("18:42Z")].iloc[0]
+        assert aar_start["Status"] == "ADVISORY"
+        assert aar_start["Reasons"] == "X Band / Ku conflict — choose one transport"
+        assert aar_start["Operational Markers"] == (
+            "AAR Start; AAR window; Landing safety window"
+        )
+
     def test_aar_block_rows_normalize_primary_table_without_overlap(self, mission):
         start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
         segments = [

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from io import BytesIO
 
-import openpyxl
 import pytest
 
 import app.mission.exporter as mission_exporter
@@ -97,7 +95,7 @@ def _build_test_timeline(mission_id: str) -> MissionLegTimeline:
 class TestTimelineExportFormat:
     def test_from_string_accepts_mixed_casing(self):
         assert TimelineExportFormat.from_string("CSV") is TimelineExportFormat.CSV
-        assert TimelineExportFormat.from_string("Pdf") is TimelineExportFormat.PDF
+        assert TimelineExportFormat.from_string("Pptx") is TimelineExportFormat.PPTX
 
     def test_from_string_invalid_raises(self):
         with pytest.raises(ExportGenerationError):
@@ -124,22 +122,11 @@ class TestMissionTimelineExporters:
         assert "CommKa" in output
         assert "StarShield" in output
 
-    def test_generate_xlsx_creates_multiple_sheets(self, mission, timeline):
+    def test_generate_pptx_starts_with_zip_header(self, mission, timeline):
         output = generate_timeline_export(
-            TimelineExportFormat.XLSX, mission, timeline
+            TimelineExportFormat.PPTX, mission, timeline
         ).content
-        workbook = openpyxl.load_workbook(filename=BytesIO(output))
-        assert "Timeline" in workbook.sheetnames
-        assert workbook["Timeline"]["A2"].value == 1  # First segment number
-
-        # Advisories sheet should exist because we provided one
-        assert "Advisories" in workbook.sheetnames
-
-    def test_generate_pdf_starts_with_pdf_header(self, mission, timeline):
-        output = generate_timeline_export(
-            TimelineExportFormat.PDF, mission, timeline
-        ).content
-        assert output.startswith(b"%PDF")
+        assert output.startswith(b"PK")
 
     def test_generate_timeline_export_router(self, mission, timeline):
         artifact = generate_timeline_export(TimelineExportFormat.CSV, mission, timeline)
@@ -169,11 +156,13 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         row = df.iloc[0]
-        assert row["Status"] == "NOMINAL"
-        assert row["X-Band"] == "WARNING"
-        assert row["Impacted Transports"] == ""
+        assert row["Status"] == "DEGRADED"
+        assert row["Call Posture"] == "Degraded"
+        assert row["Primary Reason"] == "Ku/X conflict"
+        assert row["X-Band"] == "DEGRADED"
+        assert row["Systems Affected"] == "X"
 
-    def test_aar_block_rows_inserted(self, mission):
+    def test_aar_block_rows_normalize_primary_table_without_overlap(self, mission):
         start = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
         segments = [
             TimelineSegment(
@@ -204,11 +193,8 @@ class TestMissionTimelineExporters:
         )
 
         df = mission_exporter._segment_rows(timeline, mission)
-        assert "WARNING" in df["Status"].values
-        aar_rows = df[df["Segment #"] == "AAR"]
-        assert len(aar_rows) == 1
-        aar_row = aar_rows.iloc[0]
-        assert aar_row["Reasons"] == "AAR"
-        assert aar_row["X-Band"] == "AVAILABLE"
-        assert aar_row["CommKa"] == "AVAILABLE"
-        assert aar_row["StarShield"] == "AVAILABLE"
+        assert "AAR" not in df["Segment #"].values
+        assert list(df["Call Posture"]) == ["Avoid calls", "Nominal calls"]
+        assert list(df["Primary Reason"]) == ["SOF AAR", "nominal window"]
+        assert list(df["Reasons"]) == ["Avoid calls — SOF AAR", "Nominal calls"]
+        assert df.iloc[0]["Systems Affected"] == ""

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -194,6 +194,7 @@ class TestMissionTimelineExporters:
 
         df = mission_exporter._segment_rows(timeline, mission)
         assert "AAR" not in df["Segment #"].values
+        assert list(df["Status"]) == ["SOF", "NOMINAL"]
         assert list(df["Call Posture"]) == [
             "Safety-of-flight advised",
             "Nominal calls",

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -799,3 +799,31 @@ class TestTimelineStorage:
         delete_mission_timeline("leg-1", parent_mission_id="mission-a")
 
         assert not flat_path.exists()
+
+    def test_save_and_load_without_mission_id_uses_flat_path(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """save/load without parent_mission_id round-trips through the legacy flat path."""
+        save_mission_timeline("leg-1", sample_timeline)
+
+        flat = temp_missions_dir / "leg-1.timeline.json"
+        assert flat.exists()
+
+        loaded = load_mission_timeline("leg-1")
+        assert loaded is not None
+        assert loaded.mission_leg_id == "leg-1"
+
+    def test_legacy_fallback_auto_migrates_to_scoped_path(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """Loading a legacy flat file with parent_mission_id migrates it to the scoped path."""
+        import json as _json
+
+        flat_path = temp_missions_dir / "leg-1.timeline.json"
+        flat_path.write_text(_json.dumps(sample_timeline.model_dump(), default=str))
+
+        load_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        scoped = temp_missions_dir / "mission-a" / "legs" / "leg-1.timeline.json"
+        assert scoped.exists()
+        assert not flat_path.exists()

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -11,18 +11,22 @@ from app.mission.storage import (
     compute_file_checksum,
     compute_mission_checksum,
     delete_mission,
+    delete_mission_timeline,
     get_mission_checksum_path,
     get_mission_directory,
     get_mission_file_path,
     get_mission_leg_file_path,
     get_mission_legs_dir,
     get_mission_path,
+    get_mission_timeline_path,
     list_missions,
     load_mission,
+    load_mission_timeline,
     load_mission_v2,
     load_mission_metadata_v2,
     mission_exists,
     save_mission,
+    save_mission_timeline,
     save_mission_v2,
 )
 
@@ -708,3 +712,97 @@ class TestHierarchicalMissionStorageV2:
         assert loaded.id == "empty-mission"
         assert loaded.name == "Empty Mission"
         assert loaded.legs == []
+
+
+class TestTimelineStorage:
+    """Tests for mission-scoped leg timeline storage.
+
+    These tests encode the bug fixed in PR #34: slugified leg IDs colliding
+    across missions caused stale timeline data to bleed into unrelated exports.
+    """
+
+    @pytest.fixture
+    def sample_timeline(self):
+        from app.mission.models import MissionLegTimeline
+
+        return MissionLegTimeline(mission_leg_id="leg-1")
+
+    @pytest.fixture
+    def sample_timeline_b(self):
+        from app.mission.models import MissionLegTimeline
+
+        return MissionLegTimeline(mission_leg_id="leg-1-mission-b")
+
+    def test_scoped_path_used_when_mission_id_provided(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """Timeline is stored inside {mission_id}/legs/ when parent_mission_id is given."""
+        save_mission_timeline("leg-1", sample_timeline, parent_mission_id="mission-a")
+
+        scoped = temp_missions_dir / "mission-a" / "legs" / "leg-1.timeline.json"
+        flat = temp_missions_dir / "leg-1.timeline.json"
+
+        assert scoped.exists()
+        assert not flat.exists()
+
+    def test_legacy_fallback_reads_flat_file(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """load_mission_timeline falls back to the flat file for pre-fix data."""
+        # Write directly to the legacy flat path (simulating pre-fix data)
+        import json
+
+        flat_path = temp_missions_dir / "leg-1.timeline.json"
+        flat_path.write_text(
+            json.dumps(sample_timeline.model_dump(), default=str)
+        )
+
+        # Load with a mission ID whose scoped path doesn't exist
+        loaded = load_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        assert loaded is not None
+        assert loaded.mission_leg_id == "leg-1"
+
+    def test_cross_mission_collision_is_fixed(
+        self, sample_timeline, sample_timeline_b, temp_missions_dir
+    ):
+        """Two missions with the same leg slug use independent timeline files."""
+        save_mission_timeline("leg-1", sample_timeline, parent_mission_id="mission-a")
+        save_mission_timeline("leg-1", sample_timeline_b, parent_mission_id="mission-b")
+
+        loaded_a = load_mission_timeline("leg-1", parent_mission_id="mission-a")
+        loaded_b = load_mission_timeline("leg-1", parent_mission_id="mission-b")
+
+        assert loaded_a is not None
+        assert loaded_b is not None
+        assert loaded_a.mission_leg_id == "leg-1"
+        assert loaded_b.mission_leg_id == "leg-1-mission-b"
+
+    def test_delete_leg_removes_scoped_timeline(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """delete_mission_timeline removes the scoped timeline file."""
+        save_mission_timeline("leg-1", sample_timeline, parent_mission_id="mission-a")
+
+        scoped = temp_missions_dir / "mission-a" / "legs" / "leg-1.timeline.json"
+        assert scoped.exists()
+
+        delete_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        assert not scoped.exists()
+
+    def test_delete_also_removes_legacy_flat_file(
+        self, sample_timeline, temp_missions_dir
+    ):
+        """delete_mission_timeline cleans up legacy flat files to prevent future pollution."""
+        import json
+
+        # Simulate a legacy flat file left over from before the fix
+        flat_path = temp_missions_dir / "leg-1.timeline.json"
+        flat_path.write_text(
+            json.dumps(sample_timeline.model_dump(), default=str)
+        )
+
+        delete_mission_timeline("leg-1", parent_mission_id="mission-a")
+
+        assert not flat_path.exists()

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -730,6 +730,9 @@ class TestTimelineStorage:
     def sample_timeline_b(self):
         from app.mission.models import MissionLegTimeline
 
+        # Distinct mission_leg_id so test_cross_mission_collision_is_fixed can
+        # assert the two timelines didn't bleed into each other — both are stored
+        # under leg_id="leg-1" but in different mission directories.
         return MissionLegTimeline(mission_leg_id="leg-1-mission-b")
 
     def test_scoped_path_used_when_mission_id_provided(

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -18,7 +18,6 @@ from app.mission.storage import (
     get_mission_leg_file_path,
     get_mission_legs_dir,
     get_mission_path,
-    get_mission_timeline_path,
     list_missions,
     load_mission,
     load_mission_timeline,
@@ -745,17 +744,13 @@ class TestTimelineStorage:
         assert scoped.exists()
         assert not flat.exists()
 
-    def test_legacy_fallback_reads_flat_file(
-        self, sample_timeline, temp_missions_dir
-    ):
+    def test_legacy_fallback_reads_flat_file(self, sample_timeline, temp_missions_dir):
         """load_mission_timeline falls back to the flat file for pre-fix data."""
         # Write directly to the legacy flat path (simulating pre-fix data)
         import json
 
         flat_path = temp_missions_dir / "leg-1.timeline.json"
-        flat_path.write_text(
-            json.dumps(sample_timeline.model_dump(), default=str)
-        )
+        flat_path.write_text(json.dumps(sample_timeline.model_dump(), default=str))
 
         # Load with a mission ID whose scoped path doesn't exist
         loaded = load_mission_timeline("leg-1", parent_mission_id="mission-a")
@@ -799,9 +794,7 @@ class TestTimelineStorage:
 
         # Simulate a legacy flat file left over from before the fix
         flat_path = temp_missions_dir / "leg-1.timeline.json"
-        flat_path.write_text(
-            json.dumps(sample_timeline.model_dump(), default=str)
-        )
+        flat_path.write_text(json.dumps(sample_timeline.model_dump(), default=str))
 
         delete_mission_timeline("leg-1", parent_mission_id="mission-a")
 

--- a/backend/starlink-location/tests/unit/test_mission_storage.py
+++ b/backend/starlink-location/tests/unit/test_mission_storage.py
@@ -427,6 +427,42 @@ class TestHierarchicalMissionStorageV2:
         assert loaded.legs[1].name == "Leg 2"
         assert loaded.legs[1].route_id == "route-2"
 
+    def test_load_mission_v2_ignores_scoped_timeline_files(
+        self, sample_mission_with_legs, temp_missions_dir
+    ):
+        """Timeline cache files in legs/ must not be parsed as MissionLegs."""
+        from app.mission.models import MissionLegTimeline
+
+        save_mission_v2(sample_mission_with_legs)
+        save_mission_timeline(
+            "leg-1",
+            MissionLegTimeline(mission_leg_id="leg-1", segments=[]),
+            parent_mission_id="operation-falcon",
+        )
+
+        loaded = load_mission_v2("operation-falcon")
+
+        assert loaded is not None
+        assert [leg.id for leg in loaded.legs] == ["leg-1", "leg-2"]
+
+    def test_load_mission_metadata_v2_ignores_scoped_timeline_files(
+        self, sample_mission_with_legs, temp_missions_dir
+    ):
+        """Metadata loads should count only actual leg JSON files."""
+        from app.mission.models import MissionLegTimeline
+
+        save_mission_v2(sample_mission_with_legs)
+        save_mission_timeline(
+            "leg-1",
+            MissionLegTimeline(mission_leg_id="leg-1", segments=[]),
+            parent_mission_id="operation-falcon",
+        )
+
+        loaded = load_mission_metadata_v2("operation-falcon")
+
+        assert loaded is not None
+        assert [leg.id for leg in loaded.legs] == ["leg-1", "leg-2"]
+
     def test_load_mission_v2_preserves_leg_order(
         self, sample_mission_with_legs, temp_missions_dir
     ):

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -3,15 +3,19 @@
 from datetime import datetime, timedelta, timezone
 
 from app.mission.models import (
+    AARWindow,
+    MissionLeg,
     MissionLegTimeline,
     TimelineSegment,
     TimelineStatus,
     Transport,
+    TransportConfig,
     TransportState,
 )
 from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.state import TransportInterval
 from app.mission.timeline import build_timeline_segments
+from app.mission.timeline_builder.aar import resolve_aar_windows
 from app.mission.timeline_builder.stats import annotate_aar_markers
 from app.satellites.rules import EventType, MissionEvent
 
@@ -284,7 +288,7 @@ def test_call_availability_priority_aar_advisory_not_outage():
     assert labels == [
         "Nominal calls",
         "Safety-of-flight advised — AAR window",
-        "Unavailable — system outage",
+        "Unavailable — Ka outage",
         "Safety-of-flight advised — AAR window",
         "Nominal calls",
     ]
@@ -500,7 +504,7 @@ def test_call_availability_priority_critical_over_sof():
 
     assert timeline.segments[0].status == TimelineStatus.CRITICAL
     assert timeline.segments[0].metadata["call_posture"] == "Unavailable"
-    assert timeline.segments[0].metadata["primary_reason"] == "system outage"
+    assert timeline.segments[0].metadata["primary_reason"] == "Ka outage; Ku outage"
 
 
 def test_call_availability_source_status_priority_order_is_explicit():
@@ -621,7 +625,121 @@ def test_call_availability_rows_are_sorted_and_non_overlapping():
     assert [s.metadata["availability_label"] for s in timeline.segments] == [
         "Nominal calls",
         "Other activity conflict",
-        "Degraded — X Band / AAR conflict",
-        "Other activity conflict",
+        "Degraded — X Band / AAR conflict; AAR Start",
+        "Other activity conflict; AAR End",
         "Nominal calls",
     ]
+
+
+def test_call_availability_keeps_aar_start_boundary_during_existing_degrade():
+    degraded = _segment(
+        "seg-ka-gap",
+        0,
+        30,
+        TimelineStatus.DEGRADED,
+        reasons=["Ka coverage gap"],
+    )
+    degraded.ka_state = TransportState.DEGRADED
+    degraded.impacted_transports = [Transport.KA]
+    timeline = _timeline_from_segments(
+        [degraded],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=10)).isoformat(),
+                    "end": (BASE + timedelta(minutes=20)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert [(s.start_time, s.end_time) for s in timeline.segments] == [
+        (BASE, BASE + timedelta(minutes=10)),
+        (BASE + timedelta(minutes=10), BASE + timedelta(minutes=20)),
+        (BASE + timedelta(minutes=20), BASE + timedelta(minutes=30)),
+    ]
+    assert timeline.segments[1].status == TimelineStatus.DEGRADED
+    assert timeline.segments[1].metadata["boundary_markers"] == ["AAR Start"]
+    assert "AAR Start" in timeline.segments[1].metadata["availability_label"]
+
+
+def test_call_availability_lists_multiple_critical_degrade_causes():
+    critical = _segment(
+        "seg-critical",
+        0,
+        10,
+        TimelineStatus.CRITICAL,
+        reasons=["Ka transition AOR → POR", "Ku outage"],
+    )
+    critical.ka_state = TransportState.OFFLINE
+    critical.ku_state = TransportState.OFFLINE
+    critical.impacted_transports = [Transport.KA, Transport.KU]
+    timeline = _timeline_from_segments([critical])
+
+    normalize_call_availability_timeline(timeline)
+
+    label = timeline.segments[0].metadata["availability_label"]
+    assert timeline.segments[0].status == TimelineStatus.CRITICAL
+    assert "Ka transition AOR → POR" in label
+    assert "Ku outage" in label
+
+
+def test_call_availability_coalesces_adjacent_same_reason_degraded_blocks():
+    segments = []
+    for idx, (start, end) in enumerate(((0, 10), (10, 20), (20, 30)), start=1):
+        segment = _segment(
+            f"seg-swap-{idx}",
+            start,
+            end,
+            TimelineStatus.DEGRADED,
+            reasons=["X Transition to X-6"],
+        )
+        segment.x_state = TransportState.DEGRADED
+        segment.impacted_transports = [Transport.X]
+        segments.append(segment)
+    timeline = _timeline_from_segments(segments)
+
+    normalize_call_availability_timeline(timeline)
+
+    assert len(timeline.segments) == 1
+    assert timeline.segments[0].start_time == BASE
+    assert timeline.segments[0].end_time == BASE + timedelta(minutes=30)
+    assert timeline.segments[0].metadata["source_segment_ids"] == [
+        "seg-swap-1",
+        "seg-swap-2",
+        "seg-swap-3",
+    ]
+
+
+def test_resolve_aar_windows_uses_manual_time_overrides_without_route_waypoints():
+    override_start = BASE + timedelta(minutes=12)
+    override_end = BASE + timedelta(minutes=42)
+    mission = MissionLeg(
+        id="mission-override",
+        name="Mission override",
+        route_id="route-1",
+        transports=TransportConfig(
+            initial_x_satellite_id="X-1",
+            aar_windows=[
+                AARWindow(
+                    id="aar-1",
+                    start_waypoint_name="ARIP",
+                    end_waypoint_name="AREX",
+                    override_start_time=override_start,
+                    override_end_time=override_end,
+                )
+            ],
+        ),
+    )
+
+    windows = resolve_aar_windows(
+        mission,
+        route=type("Route", (), {"waypoints": []})(),
+        projector=object(),
+    )
+
+    assert len(windows) == 1
+    assert windows[0].start_time == override_start
+    assert windows[0].end_time == override_end

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -625,9 +625,16 @@ def test_call_availability_rows_are_sorted_and_non_overlapping():
     assert [s.metadata["availability_label"] for s in timeline.segments] == [
         "Nominal calls",
         "Other activity conflict",
-        "Degraded — X Band / AAR conflict; AAR Start",
-        "Other activity conflict; AAR End",
+        "Degraded — X Band / AAR conflict",
+        "Other activity conflict",
         "Nominal calls",
+    ]
+    assert [s.metadata.get("operational_markers") for s in timeline.segments] == [
+        [],
+        [],
+        ["AAR Start", "AAR window"],
+        ["AAR End"],
+        [],
     ]
 
 
@@ -662,7 +669,47 @@ def test_call_availability_keeps_aar_start_boundary_during_existing_degrade():
     ]
     assert timeline.segments[1].status == TimelineStatus.DEGRADED
     assert timeline.segments[1].metadata["boundary_markers"] == ["AAR Start"]
-    assert "AAR Start" in timeline.segments[1].metadata["availability_label"]
+    assert timeline.segments[1].metadata["operational_markers"] == [
+        "AAR Start",
+        "AAR window",
+    ]
+    assert "AAR Start" not in timeline.segments[1].metadata["availability_label"]
+
+
+def test_call_availability_exposes_aar_start_as_operational_marker_not_reason_suffix():
+    conflict = _segment(
+        "seg-x-ku",
+        0,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["X Band / Ku conflict"],
+    )
+    conflict.x_state = TransportState.DEGRADED
+    conflict.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [conflict],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=10)).isoformat(),
+                    "end": (BASE + timedelta(minutes=20)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    aar_start_segment = timeline.segments[1]
+    assert aar_start_segment.status == TimelineStatus.SOF
+    assert aar_start_segment.metadata["availability_label"] == (
+        "X Band / Ku conflict — choose one transport"
+    )
+    assert aar_start_segment.metadata["operational_markers"] == [
+        "AAR Start",
+        "AAR window",
+    ]
+    assert "AAR Start" not in aar_start_segment.reasons[0]
 
 
 def test_call_availability_lists_multiple_critical_degrade_causes():
@@ -710,6 +757,30 @@ def test_call_availability_coalesces_adjacent_same_reason_degraded_blocks():
         "seg-swap-1",
         "seg-swap-2",
         "seg-swap-3",
+    ]
+
+
+def test_call_availability_landing_marker_survives_x_ku_advisory_overlap():
+    x_ku = _segment(
+        "seg-x-ku-landing",
+        0,
+        15,
+        TimelineStatus.DEGRADED,
+        reasons=["X Band / Ku conflict", "Safety-of-Flight (landing)"],
+    )
+    x_ku.x_state = TransportState.DEGRADED
+    x_ku.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments([x_ku])
+
+    normalize_call_availability_timeline(timeline)
+
+    assert len(timeline.segments) == 1
+    assert timeline.segments[0].status == TimelineStatus.SOF
+    assert timeline.segments[0].metadata["availability_label"] == (
+        "X Band / Ku conflict — choose one transport"
+    )
+    assert timeline.segments[0].metadata["operational_markers"] == [
+        "Landing safety window"
     ]
 
 

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -550,6 +550,42 @@ def test_call_availability_merges_adjacent_only_when_labels_match():
     assert timeline.segments[1].metadata["notes"] == ["handoff"]
 
 
+def test_call_availability_normalization_is_idempotent_for_labels():
+    swap = _segment(
+        "seg-swap",
+        0,
+        10,
+        TimelineStatus.DEGRADED,
+        reasons=["Ka transition IOR → POR"],
+    )
+    swap.ka_state = TransportState.DEGRADED
+    swap.impacted_transports = [Transport.KA]
+    timeline = _timeline_from_segments(
+        [
+            _segment(
+                "seg-sof",
+                10,
+                20,
+                TimelineStatus.SOF,
+                reasons=["Safety-of-Flight (landing)"],
+            ),
+            swap,
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+    normalize_call_availability_timeline(timeline)
+
+    assert [s.metadata["availability_label"] for s in timeline.segments] == [
+        "Degraded — Satellite swap: Ka transition IOR → POR",
+        "Avoid calls — Safety-of-Flight (landing)",
+    ]
+    assert [s.reasons for s in timeline.segments] == [
+        ["Degraded — Satellite swap: Ka transition IOR → POR"],
+        ["Avoid calls — Safety-of-Flight (landing)"],
+    ]
+
+
 def test_call_availability_rows_are_sorted_and_non_overlapping():
     conflict = _segment(
         "seg-conflict",

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -290,7 +290,7 @@ def test_call_availability_priority_aar_advisory_not_outage():
     ]
 
 
-def test_call_availability_ku_x_conflict_is_degraded_block():
+def test_call_availability_ku_x_conflict_is_advisory_not_degraded():
     conflict = _segment(
         "seg-conflict",
         15,
@@ -310,13 +310,40 @@ def test_call_availability_ku_x_conflict_is_degraded_block():
 
     normalize_call_availability_timeline(timeline)
 
-    assert timeline.segments[1].metadata["call_posture"] == "Degraded"
-    assert timeline.segments[1].metadata["primary_reason"] == "X Band / Ku conflict"
-    assert (
-        timeline.segments[1].metadata["availability_label"]
-        == "Degraded — X Band / Ku conflict"
+    advisory = timeline.segments[1]
+    assert advisory.status == TimelineStatus.SOF
+    assert advisory.x_state == TransportState.AVAILABLE
+    assert advisory.ku_state == TransportState.AVAILABLE
+    assert advisory.impacted_transports == []
+    assert advisory.metadata["call_posture"] == "Transport concurrency advisory"
+    assert advisory.metadata["primary_reason"] == "X Band / Ku conflict"
+    assert advisory.metadata["availability_label"] == (
+        "Transport concurrency advisory: X Band / Ku conflict — choose one "
+        "transport; PACE preference Starlink > Comm Ka > X-Band"
     )
-    assert timeline.segments[1].impacted_transports == [Transport.X]
+
+
+def test_call_availability_ku_x_conflict_preserves_separate_degradation():
+    conflict_with_outage = _segment(
+        "seg-conflict-outage",
+        15,
+        25,
+        TimelineStatus.DEGRADED,
+        reasons=["X-Ku Conflict az=180° el=20°", "Ka coverage gap"],
+    )
+    conflict_with_outage.x_state = TransportState.DEGRADED
+    conflict_with_outage.ka_state = TransportState.DEGRADED
+    conflict_with_outage.impacted_transports = [Transport.X, Transport.KA]
+    timeline = _timeline_from_segments([conflict_with_outage])
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[0].status == TimelineStatus.DEGRADED
+    assert timeline.segments[0].metadata["call_posture"] == "Degraded"
+    assert timeline.segments[0].metadata["primary_reason"] == "Ka coverage gap"
+    assert timeline.segments[0].impacted_transports == [Transport.KA]
+    assert timeline.segments[0].x_state == TransportState.AVAILABLE
+    assert timeline.segments[0].ka_state == TransportState.DEGRADED
 
 
 def test_call_availability_satellite_swap_reason_is_specific():

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -317,10 +317,11 @@ def test_call_availability_ku_x_conflict_is_advisory_not_degraded():
     assert advisory.impacted_transports == []
     assert advisory.metadata["call_posture"] == "Transport concurrency advisory"
     assert advisory.metadata["primary_reason"] == "X Band / Ku conflict"
-    assert advisory.metadata["availability_label"] == (
-        "Transport concurrency advisory: X Band / Ku conflict — choose one "
-        "transport; PACE preference Starlink > Comm Ka > X-Band"
+    assert (
+        advisory.metadata["availability_label"]
+        == "X Band / Ku conflict — choose one transport"
     )
+    assert "PACE" not in advisory.metadata["availability_label"]
 
 
 def test_call_availability_ku_x_conflict_preserves_separate_degradation():

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -9,6 +9,7 @@ from app.mission.models import (
     Transport,
     TransportState,
 )
+from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.state import TransportInterval
 from app.mission.timeline import build_timeline_segments
 from app.mission.timeline_builder.stats import annotate_aar_markers
@@ -195,3 +196,185 @@ def test_annotate_aar_markers_appends_reasons():
     expected_end = (BASE + timedelta(minutes=45)).isoformat()
     assert block["start"] == expected_start
     assert block["end"] == expected_end
+
+
+def _timeline_from_segments(segments, statistics=None):
+    return MissionLegTimeline(
+        mission_leg_id="mission-1",
+        segments=segments,
+        advisories=[],
+        statistics=statistics or {},
+    )
+
+
+def _segment(seg_id, start_offset, end_offset, status, reasons=None, metadata=None):
+    return TimelineSegment(
+        id=seg_id,
+        start_time=BASE + timedelta(minutes=start_offset),
+        end_time=BASE + timedelta(minutes=end_offset),
+        status=status,
+        x_state=TransportState.AVAILABLE,
+        ka_state=TransportState.AVAILABLE,
+        ku_state=TransportState.AVAILABLE,
+        reasons=reasons or [],
+        impacted_transports=[],
+        metadata=metadata or {},
+    )
+
+
+def test_call_availability_sof_carves_hole_out_of_nominal_window():
+    timeline = _timeline_from_segments(
+        [_segment("seg-1", 0, 60, TimelineStatus.NOMINAL)],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=20)).isoformat(),
+                    "end": (BASE + timedelta(minutes=40)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert [(s.start_time, s.end_time) for s in timeline.segments] == [
+        (BASE, BASE + timedelta(minutes=20)),
+        (BASE + timedelta(minutes=20), BASE + timedelta(minutes=40)),
+        (BASE + timedelta(minutes=40), BASE + timedelta(minutes=60)),
+    ]
+    assert [s.metadata["call_posture"] for s in timeline.segments] == [
+        "Nominal calls",
+        "Avoid calls",
+        "Nominal calls",
+    ]
+    assert timeline.segments[1].metadata["primary_reason"] == "SOF AAR"
+    assert timeline.segments[1].reasons == ["Avoid calls — SOF AAR"]
+
+
+def test_call_availability_priority_sof_wins_over_nominal_but_not_outage():
+    outage = _segment(
+        "seg-outage",
+        10,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["Ka outage"],
+    )
+    outage.ka_state = TransportState.OFFLINE
+    outage.impacted_transports = [Transport.KA]
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-nominal-a", 0, 10, TimelineStatus.NOMINAL),
+            outage,
+            _segment("seg-nominal-b", 20, 30, TimelineStatus.NOMINAL),
+        ],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=5)).isoformat(),
+                    "end": (BASE + timedelta(minutes=25)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    labels = [s.metadata["availability_label"] for s in timeline.segments]
+    assert labels == [
+        "Nominal calls",
+        "Avoid calls — SOF AAR",
+        "Unavailable — system outage",
+        "Avoid calls — SOF AAR",
+        "Nominal calls",
+    ]
+
+
+def test_call_availability_ku_x_conflict_is_degraded_block():
+    conflict = _segment(
+        "seg-conflict",
+        15,
+        25,
+        TimelineStatus.DEGRADED,
+        reasons=["X-Ku Conflict az=180° el=20°"],
+    )
+    conflict.x_state = TransportState.DEGRADED
+    conflict.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-a", 0, 15, TimelineStatus.NOMINAL),
+            conflict,
+            _segment("seg-b", 25, 40, TimelineStatus.NOMINAL),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[1].metadata["call_posture"] == "Degraded"
+    assert timeline.segments[1].metadata["primary_reason"] == "Ku/X conflict"
+    assert (
+        timeline.segments[1].metadata["availability_label"]
+        == "Degraded — Ku/X conflict"
+    )
+    assert timeline.segments[1].impacted_transports == [Transport.X]
+
+
+def test_call_availability_merges_adjacent_only_when_labels_match():
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-a", 0, 10, TimelineStatus.NOMINAL),
+            _segment("seg-b", 10, 20, TimelineStatus.NOMINAL),
+            _segment(
+                "seg-c", 20, 30, TimelineStatus.NOMINAL, metadata={"note": "handoff"}
+            ),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert [(s.start_time, s.end_time) for s in timeline.segments] == [
+        (BASE, BASE + timedelta(minutes=20)),
+        (BASE + timedelta(minutes=20), BASE + timedelta(minutes=30)),
+    ]
+    assert timeline.segments[0].metadata["source_segment_ids"] == ["seg-a", "seg-b"]
+    assert timeline.segments[1].metadata["notes"] == ["handoff"]
+
+
+def test_call_availability_rows_are_sorted_and_non_overlapping():
+    conflict = _segment(
+        "seg-conflict",
+        5,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["Other activity conflict"],
+    )
+    conflict.x_state = TransportState.DEGRADED
+    conflict.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [
+            conflict,
+            _segment("seg-nominal", 0, 5, TimelineStatus.NOMINAL),
+            _segment("seg-tail", 20, 30, TimelineStatus.NOMINAL),
+        ],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=10)).isoformat(),
+                    "end": (BASE + timedelta(minutes=15)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    starts = [s.start_time for s in timeline.segments]
+    assert starts == sorted(starts)
+    for prev, nxt in zip(timeline.segments, timeline.segments[1:]):
+        assert prev.end_time <= nxt.start_time
+    assert [s.metadata["availability_label"] for s in timeline.segments] == [
+        "Nominal calls",
+        "Activity conflict",
+        "Avoid calls — SOF AAR",
+        "Activity conflict",
+        "Nominal calls",
+    ]

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -247,7 +247,7 @@ def test_call_availability_aar_advisory_carves_hole_without_degrading():
         "Safety-of-flight advised",
         "Nominal calls",
     ]
-    assert timeline.segments[1].status == TimelineStatus.NOMINAL
+    assert timeline.segments[1].status == TimelineStatus.SOF
     assert timeline.segments[1].metadata["primary_reason"] == "AAR window"
     assert timeline.segments[1].reasons == ["Safety-of-flight advised — AAR window"]
 
@@ -405,14 +405,14 @@ def test_call_availability_takeoff_landing_sof_periods_are_distinct():
             _segment(
                 "seg-takeoff",
                 0,
-                10,
+                15,
                 TimelineStatus.NOMINAL,
                 reasons=["Safety-of-Flight (takeoff)"],
             ),
-            _segment("seg-cruise", 10, 50, TimelineStatus.NOMINAL),
+            _segment("seg-cruise", 15, 45, TimelineStatus.NOMINAL),
             _segment(
                 "seg-landing",
-                50,
+                45,
                 60,
                 TimelineStatus.NOMINAL,
                 reasons=["Safety-of-Flight (landing)"],
@@ -428,10 +428,77 @@ def test_call_availability_takeoff_landing_sof_periods_are_distinct():
         "Avoid calls — Safety-of-Flight (landing)",
     ]
     assert [s.status for s in timeline.segments] == [
-        TimelineStatus.DEGRADED,
+        TimelineStatus.SOF,
         TimelineStatus.NOMINAL,
-        TimelineStatus.DEGRADED,
+        TimelineStatus.SOF,
     ]
+
+
+def test_call_availability_priority_degraded_over_sof():
+    degraded_sof = _segment(
+        "seg-degraded-sof",
+        0,
+        15,
+        TimelineStatus.NOMINAL,
+        reasons=["Safety-of-Flight (takeoff)", "X transition to X-2"],
+    )
+    degraded_sof.x_state = TransportState.DEGRADED
+    degraded_sof.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments([degraded_sof])
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[0].status == TimelineStatus.DEGRADED
+    assert timeline.segments[0].metadata["call_posture"] == "Degraded"
+    assert timeline.segments[0].metadata["primary_reason"] == (
+        "Satellite swap: X transition to X-2"
+    )
+
+
+def test_call_availability_priority_critical_over_sof():
+    critical_sof = _segment(
+        "seg-critical-sof",
+        45,
+        60,
+        TimelineStatus.NOMINAL,
+        reasons=["Safety-of-Flight (landing)", "Ka outage", "Ku outage"],
+    )
+    critical_sof.ka_state = TransportState.OFFLINE
+    critical_sof.ku_state = TransportState.OFFLINE
+    critical_sof.impacted_transports = [Transport.KA, Transport.KU]
+    timeline = _timeline_from_segments([critical_sof])
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[0].status == TimelineStatus.CRITICAL
+    assert timeline.segments[0].metadata["call_posture"] == "Unavailable"
+    assert timeline.segments[0].metadata["primary_reason"] == "system outage"
+
+
+def test_call_availability_source_status_priority_order_is_explicit():
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-sof", 0, 10, TimelineStatus.SOF),
+            _segment("seg-degraded", 0, 10, TimelineStatus.DEGRADED),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[0].status == TimelineStatus.DEGRADED
+
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-nominal", 0, 10, TimelineStatus.NOMINAL),
+            _segment("seg-sof", 0, 10, TimelineStatus.SOF),
+            _segment("seg-degraded", 0, 10, TimelineStatus.DEGRADED),
+            _segment("seg-critical", 0, 10, TimelineStatus.CRITICAL),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[0].status == TimelineStatus.CRITICAL
 
 
 def test_call_availability_merges_adjacent_only_when_labels_match():

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -253,7 +253,9 @@ def test_call_availability_aar_advisory_carves_hole_without_degrading():
     ]
     assert timeline.segments[1].status == TimelineStatus.SOF
     assert timeline.segments[1].metadata["primary_reason"] == "AAR window"
-    assert timeline.segments[1].reasons == ["Safety-of-flight advised — AAR window; AAR Start"]
+    assert timeline.segments[1].reasons == [
+        "Safety-of-flight advised — AAR window; AAR Start"
+    ]
 
 
 def test_call_availability_priority_aar_advisory_not_outage():
@@ -412,7 +414,6 @@ def test_call_availability_x_aar_conflict_is_specific_degrade():
     ]
     assert degraded
     assert degraded[0].metadata["call_posture"] == "Degraded"
-
 
 
 def test_call_availability_aar_reason_with_unrelated_x_is_not_x_aar_conflict():

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -15,7 +15,7 @@ from app.mission.models import (
 from app.mission.call_availability import normalize_call_availability_timeline
 from app.mission.state import TransportInterval
 from app.mission.timeline import build_timeline_segments
-from app.mission.timeline_builder.aar import resolve_aar_windows
+from app.mission.timeline_builder.aar import parse_elapsed_offset, resolve_aar_windows
 from app.mission.timeline_builder.stats import annotate_aar_markers
 from app.satellites.rules import EventType, MissionEvent
 
@@ -253,7 +253,7 @@ def test_call_availability_aar_advisory_carves_hole_without_degrading():
     ]
     assert timeline.segments[1].status == TimelineStatus.SOF
     assert timeline.segments[1].metadata["primary_reason"] == "AAR window"
-    assert timeline.segments[1].reasons == ["Safety-of-flight advised — AAR window"]
+    assert timeline.segments[1].reasons == ["Safety-of-flight advised — AAR window; AAR Start"]
 
 
 def test_call_availability_priority_aar_advisory_not_outage():
@@ -287,10 +287,10 @@ def test_call_availability_priority_aar_advisory_not_outage():
     labels = [s.metadata["availability_label"] for s in timeline.segments]
     assert labels == [
         "Nominal calls",
+        "Safety-of-flight advised — AAR window; AAR Start",
+        "Unavailable — Ka outage; AAR window",
         "Safety-of-flight advised — AAR window",
-        "Unavailable — Ka outage",
-        "Safety-of-flight advised — AAR window",
-        "Nominal calls",
+        "Nominal calls; AAR End",
     ]
 
 
@@ -455,9 +455,9 @@ def test_call_availability_takeoff_landing_sof_periods_are_distinct():
     normalize_call_availability_timeline(timeline)
 
     assert [s.metadata["availability_label"] for s in timeline.segments] == [
-        "Avoid calls — Safety-of-Flight (takeoff)",
+        "Avoid calls — Safety-of-Flight (takeoff); Takeoff safety window",
         "Nominal calls",
-        "Avoid calls — Safety-of-Flight (landing)",
+        "Avoid calls — Safety-of-Flight (landing); Landing safety window",
     ]
     assert [s.status for s in timeline.segments] == [
         TimelineStatus.SOF,
@@ -582,11 +582,11 @@ def test_call_availability_normalization_is_idempotent_for_labels():
 
     assert [s.metadata["availability_label"] for s in timeline.segments] == [
         "Degraded — Satellite swap: Ka transition IOR → POR",
-        "Avoid calls — Safety-of-Flight (landing)",
+        "Avoid calls — Safety-of-Flight (landing); Landing safety window",
     ]
     assert [s.reasons for s in timeline.segments] == [
         ["Degraded — Satellite swap: Ka transition IOR → POR"],
-        ["Avoid calls — Safety-of-Flight (landing)"],
+        ["Avoid calls — Safety-of-Flight (landing); Landing safety window"],
     ]
 
 
@@ -625,8 +625,8 @@ def test_call_availability_rows_are_sorted_and_non_overlapping():
     assert [s.metadata["availability_label"] for s in timeline.segments] == [
         "Nominal calls",
         "Other activity conflict",
-        "Degraded — X Band / AAR conflict",
-        "Other activity conflict",
+        "Degraded — X Band / AAR conflict; AAR Start; AAR window",
+        "Other activity conflict; AAR End",
         "Nominal calls",
     ]
     assert [s.metadata.get("operational_markers") for s in timeline.segments] == [
@@ -673,10 +673,11 @@ def test_call_availability_keeps_aar_start_boundary_during_existing_degrade():
         "AAR Start",
         "AAR window",
     ]
-    assert "AAR Start" not in timeline.segments[1].metadata["availability_label"]
+    assert "AAR Start" in timeline.segments[1].metadata["availability_label"]
+    assert "AAR Start" in timeline.segments[1].reasons[0]
 
 
-def test_call_availability_exposes_aar_start_as_operational_marker_not_reason_suffix():
+def test_call_availability_exposes_aar_start_inline_in_reason_text():
     conflict = _segment(
         "seg-x-ku",
         0,
@@ -703,13 +704,15 @@ def test_call_availability_exposes_aar_start_as_operational_marker_not_reason_su
     aar_start_segment = timeline.segments[1]
     assert aar_start_segment.status == TimelineStatus.SOF
     assert aar_start_segment.metadata["availability_label"] == (
-        "X Band / Ku conflict — choose one transport"
+        "X Band / Ku conflict — choose one transport; AAR Start; AAR window"
     )
     assert aar_start_segment.metadata["operational_markers"] == [
         "AAR Start",
         "AAR window",
     ]
-    assert "AAR Start" not in aar_start_segment.reasons[0]
+    assert aar_start_segment.reasons[0] == (
+        "X Band / Ku conflict — choose one transport; AAR Start; AAR window"
+    )
 
 
 def test_call_availability_lists_multiple_critical_degrade_causes():
@@ -777,7 +780,7 @@ def test_call_availability_landing_marker_survives_x_ku_advisory_overlap():
     assert len(timeline.segments) == 1
     assert timeline.segments[0].status == TimelineStatus.SOF
     assert timeline.segments[0].metadata["availability_label"] == (
-        "X Band / Ku conflict — choose one transport"
+        "X Band / Ku conflict — choose one transport; Landing safety window"
     )
     assert timeline.segments[0].metadata["operational_markers"] == [
         "Landing safety window"
@@ -814,3 +817,54 @@ def test_resolve_aar_windows_uses_manual_time_overrides_without_route_waypoints(
     assert len(windows) == 1
     assert windows[0].start_time == override_start
     assert windows[0].end_time == override_end
+
+
+def test_elapsed_aar_override_preserves_route_duration_and_shifts_end_time():
+    original_start = BASE + timedelta(minutes=15)
+    original_end = BASE + timedelta(minutes=75)
+    mission = MissionLeg(
+        id="mission-elapsed-override",
+        name="Mission elapsed override",
+        route_id="route-1",
+        transports=TransportConfig(
+            initial_x_satellite_id="X-1",
+            aar_windows=[
+                AARWindow(
+                    id="aar-1",
+                    start_waypoint_name="ARIP",
+                    end_waypoint_name="AREX",
+                    override_start_elapsed="T+00:30",
+                )
+            ],
+        ),
+    )
+    waypoint_type = type("Waypoint", (), {})
+    arip = waypoint_type()
+    arip.name = "ARIP"
+    arip.expected_arrival_time = original_start
+    arip.latitude = 0.0
+    arip.longitude = 0.0
+    arex = waypoint_type()
+    arex.name = "AREX"
+    arex.expected_arrival_time = original_end
+    arex.latitude = 0.0
+    arex.longitude = 0.0
+    projector = type(
+        "Projector",
+        (),
+        {
+            "start_time": BASE,
+            "shift_route_timestamp": lambda self, timestamp: timestamp,
+        },
+    )()
+
+    windows = resolve_aar_windows(
+        mission,
+        route=type("Route", (), {"waypoints": [arip, arex]})(),
+        projector=projector,
+    )
+
+    assert parse_elapsed_offset("T+00:30") == timedelta(minutes=30)
+    assert len(windows) == 1
+    assert windows[0].start_time == BASE + timedelta(minutes=30)
+    assert windows[0].end_time == BASE + timedelta(minutes=90)

--- a/backend/starlink-location/tests/unit/test_mission_timeline.py
+++ b/backend/starlink-location/tests/unit/test_mission_timeline.py
@@ -222,7 +222,7 @@ def _segment(seg_id, start_offset, end_offset, status, reasons=None, metadata=No
     )
 
 
-def test_call_availability_sof_carves_hole_out_of_nominal_window():
+def test_call_availability_aar_advisory_carves_hole_without_degrading():
     timeline = _timeline_from_segments(
         [_segment("seg-1", 0, 60, TimelineStatus.NOMINAL)],
         statistics={
@@ -244,14 +244,15 @@ def test_call_availability_sof_carves_hole_out_of_nominal_window():
     ]
     assert [s.metadata["call_posture"] for s in timeline.segments] == [
         "Nominal calls",
-        "Avoid calls",
+        "Safety-of-flight advised",
         "Nominal calls",
     ]
-    assert timeline.segments[1].metadata["primary_reason"] == "SOF AAR"
-    assert timeline.segments[1].reasons == ["Avoid calls — SOF AAR"]
+    assert timeline.segments[1].status == TimelineStatus.NOMINAL
+    assert timeline.segments[1].metadata["primary_reason"] == "AAR window"
+    assert timeline.segments[1].reasons == ["Safety-of-flight advised — AAR window"]
 
 
-def test_call_availability_priority_sof_wins_over_nominal_but_not_outage():
+def test_call_availability_priority_aar_advisory_not_outage():
     outage = _segment(
         "seg-outage",
         10,
@@ -282,9 +283,9 @@ def test_call_availability_priority_sof_wins_over_nominal_but_not_outage():
     labels = [s.metadata["availability_label"] for s in timeline.segments]
     assert labels == [
         "Nominal calls",
-        "Avoid calls — SOF AAR",
+        "Safety-of-flight advised — AAR window",
         "Unavailable — system outage",
-        "Avoid calls — SOF AAR",
+        "Safety-of-flight advised — AAR window",
         "Nominal calls",
     ]
 
@@ -310,12 +311,127 @@ def test_call_availability_ku_x_conflict_is_degraded_block():
     normalize_call_availability_timeline(timeline)
 
     assert timeline.segments[1].metadata["call_posture"] == "Degraded"
-    assert timeline.segments[1].metadata["primary_reason"] == "Ku/X conflict"
+    assert timeline.segments[1].metadata["primary_reason"] == "X Band / Ku conflict"
     assert (
         timeline.segments[1].metadata["availability_label"]
-        == "Degraded — Ku/X conflict"
+        == "Degraded — X Band / Ku conflict"
     )
     assert timeline.segments[1].impacted_transports == [Transport.X]
+
+
+def test_call_availability_satellite_swap_reason_is_specific():
+    swap = _segment(
+        "seg-swap",
+        10,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["X Transition to X-2"],
+    )
+    swap.x_state = TransportState.DEGRADED
+    swap.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-a", 0, 10, TimelineStatus.NOMINAL),
+            swap,
+            _segment("seg-b", 20, 30, TimelineStatus.NOMINAL),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[1].metadata["call_posture"] == "Degraded"
+    assert timeline.segments[1].metadata["primary_reason"] == (
+        "Satellite swap: X Transition to X-2"
+    )
+
+
+def test_call_availability_x_aar_conflict_is_specific_degrade():
+    conflict = _segment(
+        "seg-conflict",
+        10,
+        20,
+        TimelineStatus.DEGRADED,
+        reasons=["X-Band azimuth conflict during AAR window"],
+    )
+    conflict.x_state = TransportState.DEGRADED
+    conflict.impacted_transports = [Transport.X]
+    timeline = _timeline_from_segments(
+        [
+            _segment("seg-a", 0, 10, TimelineStatus.NOMINAL),
+            conflict,
+            _segment("seg-b", 20, 30, TimelineStatus.NOMINAL),
+        ],
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": (BASE + timedelta(minutes=5)).isoformat(),
+                    "end": (BASE + timedelta(minutes=25)).isoformat(),
+                }
+            ]
+        },
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    degraded = [
+        segment
+        for segment in timeline.segments
+        if segment.metadata["primary_reason"] == "X Band / AAR conflict"
+    ]
+    assert degraded
+    assert degraded[0].metadata["call_posture"] == "Degraded"
+
+
+
+def test_call_availability_aar_reason_with_unrelated_x_is_not_x_aar_conflict():
+    aar_exercise = _segment(
+        "seg-aar-exercise",
+        10,
+        20,
+        TimelineStatus.NOMINAL,
+        reasons=["AAR exercise window"],
+    )
+    timeline = _timeline_from_segments([aar_exercise])
+
+    normalize_call_availability_timeline(timeline)
+
+    assert timeline.segments[0].metadata["call_posture"] == "Nominal calls"
+    assert timeline.segments[0].metadata["primary_reason"] == "nominal window"
+
+
+def test_call_availability_takeoff_landing_sof_periods_are_distinct():
+    timeline = _timeline_from_segments(
+        [
+            _segment(
+                "seg-takeoff",
+                0,
+                10,
+                TimelineStatus.NOMINAL,
+                reasons=["Safety-of-Flight (takeoff)"],
+            ),
+            _segment("seg-cruise", 10, 50, TimelineStatus.NOMINAL),
+            _segment(
+                "seg-landing",
+                50,
+                60,
+                TimelineStatus.NOMINAL,
+                reasons=["Safety-of-Flight (landing)"],
+            ),
+        ]
+    )
+
+    normalize_call_availability_timeline(timeline)
+
+    assert [s.metadata["availability_label"] for s in timeline.segments] == [
+        "Avoid calls — Safety-of-Flight (takeoff)",
+        "Nominal calls",
+        "Avoid calls — Safety-of-Flight (landing)",
+    ]
+    assert [s.status for s in timeline.segments] == [
+        TimelineStatus.DEGRADED,
+        TimelineStatus.NOMINAL,
+        TimelineStatus.DEGRADED,
+    ]
 
 
 def test_call_availability_merges_adjacent_only_when_labels_match():
@@ -373,8 +489,8 @@ def test_call_availability_rows_are_sorted_and_non_overlapping():
         assert prev.end_time <= nxt.start_time
     assert [s.metadata["availability_label"] for s in timeline.segments] == [
         "Nominal calls",
-        "Activity conflict",
-        "Avoid calls — SOF AAR",
-        "Activity conflict",
+        "Other activity conflict",
+        "Degraded — X Band / AAR conflict",
+        "Other activity conflict",
         "Nominal calls",
     ]

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -248,7 +248,7 @@ def test_adjusted_takeoff_delta_shifts_transition_aar_and_landing_times():
     transition_segments = [
         segment
         for segment in timeline.segments
-        if "X Transition to X-2" in segment.reasons
+        if "X Transition to X-2" in segment.metadata.get("source_reasons", [])
     ]
     assert transition_segments
     assert min(segment.start_time for segment in transition_segments) == (

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from app.mission.models import (
+    AARWindow,
     Mission,
     MissionLeg,
     MissionLegTimeline,
@@ -15,8 +16,18 @@ from app.mission.models import (
     Transport,
     TransportConfig,
     TransportState,
+    XTransition,
 )
 from app.mission.package.__main__ import generate_mission_combined_csv
+from app.mission.timeline_builder.calculator import route_with_adjusted_departure
+from app.mission.timeline_service import build_mission_timeline
+from app.models.route import (
+    ParsedRoute,
+    RouteMetadata,
+    RoutePoint,
+    RouteTimingProfile,
+    RouteWaypoint,
+)
 
 
 def _timeline_at(start: datetime) -> MissionLegTimeline:
@@ -48,6 +59,70 @@ def _timeline_at(start: datetime) -> MissionLegTimeline:
             )
         ],
         statistics={},
+    )
+
+
+def _timed_route(start: datetime) -> ParsedRoute:
+    return ParsedRoute(
+        metadata=RouteMetadata(
+            name="Timed Route",
+            file_path="timed-route.kml",
+            point_count=5,
+        ),
+        points=[
+            RoutePoint(
+                latitude=0.0,
+                longitude=0.0,
+                sequence=0,
+                expected_arrival_time=start,
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=0.5,
+                sequence=1,
+                expected_arrival_time=start + timedelta(minutes=30),
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=1.0,
+                sequence=2,
+                expected_arrival_time=start + timedelta(hours=1),
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=1.5,
+                sequence=3,
+                expected_arrival_time=start + timedelta(minutes=90),
+            ),
+            RoutePoint(
+                latitude=0.0,
+                longitude=2.0,
+                sequence=4,
+                expected_arrival_time=start + timedelta(hours=2),
+            ),
+        ],
+        waypoints=[
+            RouteWaypoint(
+                name="AAR-START",
+                latitude=0.0,
+                longitude=0.5,
+                order=1,
+                expected_arrival_time=start + timedelta(minutes=30),
+            ),
+            RouteWaypoint(
+                name="AAR-END",
+                latitude=0.0,
+                longitude=1.5,
+                order=2,
+                expected_arrival_time=start + timedelta(minutes=90),
+            ),
+        ],
+        timing_profile=RouteTimingProfile(
+            departure_time=start,
+            arrival_time=start + timedelta(hours=2),
+            has_timing_data=True,
+            segment_count_with_timing=5,
+        ),
     )
 
 
@@ -90,3 +165,92 @@ def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_tim
     assert "2025-11-05T00:50:00+00:00" in output
     assert "2025-11-05T00:00:00+00:00" not in output
     assert "2025-11-05T00:10:00+00:00" not in output
+
+
+def test_route_time_shift_applies_uniform_delta_to_every_timed_route_point():
+    original_takeoff = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+    delta = timedelta(minutes=40)
+    route = _timed_route(original_takeoff)
+
+    shifted = route_with_adjusted_departure(route, original_takeoff + delta)
+
+    assert shifted is not route
+    assert shifted.timing_profile is not None
+    assert route.timing_profile is not None
+    assert shifted.timing_profile.departure_time == original_takeoff + delta
+    assert (
+        shifted.timing_profile.arrival_time
+        == original_takeoff + timedelta(hours=2) + delta
+    )
+    assert [point.expected_arrival_time for point in shifted.points] == [
+        point.expected_arrival_time + delta
+        for point in route.points
+        if point.expected_arrival_time is not None
+    ]
+    assert [waypoint.expected_arrival_time for waypoint in shifted.waypoints] == [
+        waypoint.expected_arrival_time + delta
+        for waypoint in route.waypoints
+        if waypoint.expected_arrival_time is not None
+    ]
+    assert route.timing_profile.departure_time == original_takeoff
+    assert route.points[0].expected_arrival_time == original_takeoff
+
+
+def test_adjusted_takeoff_delta_shifts_transition_aar_and_landing_times():
+    original_takeoff = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+    adjusted_takeoff = original_takeoff + timedelta(minutes=40)
+    route = _timed_route(original_takeoff)
+    route_manager = MagicMock()
+    route_manager.get_route.return_value = route
+    leg = MissionLeg(
+        id="leg-adjusted",
+        name="Adjusted Leg",
+        route_id="route-1",
+        adjusted_departure_time=adjusted_takeoff,
+        transports=TransportConfig(
+            initial_x_satellite_id="X-1",
+            x_transitions=[
+                XTransition(
+                    id="transition-1",
+                    latitude=0.0,
+                    longitude=1.0,
+                    target_satellite_id="X-2",
+                )
+            ],
+            aar_windows=[
+                AARWindow(
+                    id="aar-1",
+                    start_waypoint_name="AAR-START",
+                    end_waypoint_name="AAR-END",
+                )
+            ],
+        ),
+    )
+
+    timeline, summary = build_mission_timeline(
+        leg,
+        route_manager=route_manager,
+        coverage_sampler=None,
+    )
+
+    assert summary.mission_start == adjusted_takeoff
+    assert summary.mission_end == adjusted_takeoff + timedelta(hours=2)
+    assert timeline.segments[-1].end_time == adjusted_takeoff + timedelta(hours=2)
+    assert timeline.statistics["_aar_blocks"] == [
+        {
+            "start": (adjusted_takeoff + timedelta(minutes=30)).isoformat(),
+            "end": (adjusted_takeoff + timedelta(minutes=90)).isoformat(),
+        }
+    ]
+    transition_segments = [
+        segment
+        for segment in timeline.segments
+        if "X Transition to X-2" in segment.reasons
+    ]
+    assert transition_segments
+    assert min(segment.start_time for segment in transition_segments) == (
+        adjusted_takeoff + timedelta(minutes=45)
+    )
+    assert max(segment.end_time for segment in transition_segments) == (
+        adjusted_takeoff + timedelta(minutes=75)
+    )

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -150,7 +150,9 @@ def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_tim
             "app.mission.package.__main__.build_mission_timeline",
             return_value=(adjusted_timeline, MagicMock()),
         ) as mock_build,
-        patch("app.mission.package.__main__.save_mission_timeline"),
+        patch(
+            "app.mission.package.__main__.save_mission_timeline", create=True
+        ) as mock_save,
     ):
         csv_bytes = generate_mission_combined_csv(
             mission,
@@ -161,6 +163,7 @@ def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_tim
     assert csv_bytes is not None
     output = csv_bytes.decode("utf-8")
     mock_build.assert_called_once()
+    mock_save.assert_not_called()
     assert "2025-11-05T00:40:00+00:00" in output
     assert "2025-11-05T00:50:00+00:00" in output
     assert "2025-11-05T00:00:00+00:00" not in output

--- a/backend/starlink-location/tests/unit/test_package_adjusted_export.py
+++ b/backend/starlink-location/tests/unit/test_package_adjusted_export.py
@@ -1,0 +1,92 @@
+"""Regression tests for adjusted takeoff times in mission package exports."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from app.mission.models import (
+    Mission,
+    MissionLeg,
+    MissionLegTimeline,
+    TimelineAdvisory,
+    TimelineSegment,
+    TimelineStatus,
+    Transport,
+    TransportConfig,
+    TransportState,
+)
+from app.mission.package.__main__ import generate_mission_combined_csv
+
+
+def _timeline_at(start: datetime) -> MissionLegTimeline:
+    return MissionLegTimeline(
+        mission_leg_id="leg-adjusted",
+        segments=[
+            TimelineSegment(
+                id="seg-1",
+                start_time=start,
+                end_time=start + timedelta(minutes=30),
+                status=TimelineStatus.NOMINAL,
+                x_state=TransportState.AVAILABLE,
+                ka_state=TransportState.AVAILABLE,
+                ku_state=TransportState.AVAILABLE,
+                reasons=[],
+                impacted_transports=[],
+                metadata={},
+            )
+        ],
+        advisories=[
+            TimelineAdvisory(
+                id="aar-1",
+                timestamp=start + timedelta(minutes=10),
+                event_type="aar_window",
+                transport=Transport.X,
+                severity="warning",
+                message="AAR window active",
+                metadata={},
+            )
+        ],
+        statistics={},
+    )
+
+
+def test_combined_csv_rebuilds_adjusted_leg_timeline_instead_of_cached_stale_times():
+    original_takeoff = datetime(2025, 11, 5, 0, 0, tzinfo=timezone.utc)
+    adjusted_takeoff = original_takeoff + timedelta(minutes=40)
+    leg = MissionLeg(
+        id="leg-adjusted",
+        name="Adjusted Leg",
+        route_id="route-1",
+        adjusted_departure_time=adjusted_takeoff,
+        transports=TransportConfig(initial_x_satellite_id="X-1"),
+    )
+    mission = Mission(id="mission-adjusted", name="Adjusted Mission", legs=[leg])
+
+    stale_timeline = _timeline_at(original_takeoff)
+    adjusted_timeline = _timeline_at(adjusted_takeoff)
+
+    with (
+        patch(
+            "app.mission.package.__main__.load_mission_timeline",
+            return_value=stale_timeline,
+        ),
+        patch(
+            "app.mission.package.__main__.build_mission_timeline",
+            return_value=(adjusted_timeline, MagicMock()),
+        ) as mock_build,
+        patch("app.mission.package.__main__.save_mission_timeline"),
+    ):
+        csv_bytes = generate_mission_combined_csv(
+            mission,
+            route_manager=MagicMock(),
+            poi_manager=MagicMock(),
+        )
+
+    assert csv_bytes is not None
+    output = csv_bytes.decode("utf-8")
+    mock_build.assert_called_once()
+    assert "2025-11-05T00:40:00+00:00" in output
+    assert "2025-11-05T00:50:00+00:00" in output
+    assert "2025-11-05T00:00:00+00:00" not in output
+    assert "2025-11-05T00:10:00+00:00" not in output

--- a/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
+++ b/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
@@ -47,7 +47,9 @@ def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
             ]
         },
     )
-    artifact = ExportArtifact(content=b"export", media_type="text/plain", extension="txt")
+    artifact = ExportArtifact(
+        content=b"export", media_type="text/plain", extension="txt"
+    )
 
     with (
         patch(

--- a/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
+++ b/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
@@ -1,0 +1,89 @@
+"""Regression tests for mission package exports with adjusted takeoff times."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from app.mission.exporter import ExportArtifact
+from app.mission.models import Mission, MissionLeg, MissionLegTimeline, TransportConfig
+from app.mission.package.__main__ import _add_per_leg_exports_to_zip
+
+
+def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
+    """Package exports must not use stale cached AAR/event times after takeoff edits."""
+    leg = MissionLeg(
+        id="leg-1",
+        name="Leg 1",
+        route_id="route-1",
+        adjusted_departure_time=datetime(2025, 10, 27, 12, 0, tzinfo=timezone.utc),
+        transports=TransportConfig(
+            initial_x_satellite_id="X-1",
+            initial_ka_satellite_ids=["AOR", "POR", "IOR"],
+            x_transitions=[],
+            ka_outages=[],
+            aar_windows=[],
+            ku_overrides=[],
+        ),
+    )
+    mission = Mission(id="mission-1", name="Mission 1", legs=[leg])
+    stale_timeline = MissionLegTimeline(
+        mission_leg_id="leg-1",
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": "2025-10-27T10:00:00+00:00",
+                    "end": "2025-10-27T10:30:00+00:00",
+                }
+            ]
+        },
+    )
+    rebuilt_timeline = MissionLegTimeline(
+        mission_leg_id="leg-1",
+        statistics={
+            "_aar_blocks": [
+                {
+                    "start": "2025-10-27T12:00:00+00:00",
+                    "end": "2025-10-27T12:30:00+00:00",
+                }
+            ]
+        },
+    )
+    artifact = ExportArtifact(content=b"export", media_type="text/plain", extension="txt")
+
+    with (
+        patch(
+            "app.mission.package.__main__.build_mission_timeline",
+            return_value=(rebuilt_timeline, MagicMock()),
+        ) as mock_build,
+        patch("app.mission.package.__main__.save_mission_timeline") as mock_save,
+        patch(
+            "app.mission.package.__main__.load_mission_timeline",
+            return_value=stale_timeline,
+        ) as mock_load,
+        patch(
+            "app.mission.package.__main__.generate_timeline_export",
+            return_value=artifact,
+        ) as mock_generate,
+    ):
+        manifest_files = {"per_leg_exports": []}
+        _add_per_leg_exports_to_zip(
+            zf=MagicMock(),
+            mission=mission,
+            route_manager=MagicMock(),
+            poi_manager=MagicMock(),
+            manifest_files=manifest_files,
+        )
+
+    mock_build.assert_called_once()
+    mock_save.assert_called_once_with("leg-1", rebuilt_timeline)
+    mock_load.assert_not_called()
+    assert mock_generate.call_count == 2
+    assert all(
+        call.kwargs["timeline"] is rebuilt_timeline
+        for call in mock_generate.call_args_list
+    )
+    assert stale_timeline.statistics["_aar_blocks"][0]["start"] == (
+        "2025-10-27T10:00:00+00:00"
+    )
+    assert rebuilt_timeline.statistics["_aar_blocks"][0]["start"] == (
+        "2025-10-27T12:00:00+00:00"
+    )

--- a/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
+++ b/backend/starlink-location/tests/unit/test_package_export_adjusted_times.py
@@ -56,7 +56,7 @@ def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
             "app.mission.package.__main__.build_mission_timeline",
             return_value=(rebuilt_timeline, MagicMock()),
         ) as mock_build,
-        patch("app.mission.package.__main__.save_mission_timeline") as mock_save,
+        patch("app.mission.storage.save_mission_timeline") as mock_save,
         patch(
             "app.mission.package.__main__.load_mission_timeline",
             return_value=stale_timeline,
@@ -76,7 +76,7 @@ def test_per_leg_exports_rebuild_timeline_before_using_cached_aar_blocks():
         )
 
     mock_build.assert_called_once()
-    mock_save.assert_called_once_with("leg-1", rebuilt_timeline)
+    mock_save.assert_not_called()
     mock_load.assert_not_called()
     assert mock_generate.call_count == 2
     assert all(

--- a/backend/starlink-location/tests/unit/test_package_exporter.py
+++ b/backend/starlink-location/tests/unit/test_package_exporter.py
@@ -1,9 +1,18 @@
-import pytest
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
-from app.mission.models import Mission, MissionLeg
-from app.mission.package.__main__ import generate_mission_combined_xlsx
+
+import pytest
+
+from app.mission.models import (
+    Mission,
+    MissionLeg,
+    MissionLegTimeline,
+    TimelineSegment,
+    TimelineStatus,
+    TransportState,
+)
+from app.mission.package.__main__ import generate_mission_combined_csv
 from app.mission.package import export_mission_package
-from app.mission.exporter import ExportGenerationError
 
 
 @pytest.fixture
@@ -21,37 +30,43 @@ def mock_mission():
     return Mission(id="mission1", name="Test Mission", legs=[leg1, leg2])
 
 
-@patch("app.mission.package.__main__.load_mission_timeline")
-@patch("app.mission.package.__main__.generate_timeline_export")
-@patch("openpyxl.load_workbook")
-def test_generate_mission_combined_xlsx_export_error(
-    mock_load_workbook, mock_generate_export, mock_load_timeline, mock_mission
-):
-    # Setup
-    mock_load_timeline.return_value = MagicMock()  # Return a dummy timeline
+def _sample_timeline(leg_id: str, status: TimelineStatus) -> MissionLegTimeline:
+    start = datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 30, 12, 5, tzinfo=timezone.utc)
+    return MissionLegTimeline(
+        mission_leg_id=leg_id,
+        segments=[
+            TimelineSegment(
+                id=f"{leg_id}-segment-1",
+                start_time=start,
+                end_time=end,
+                status=status,
+                x_state=TransportState.AVAILABLE,
+                ka_state=TransportState.AVAILABLE,
+                ku_state=TransportState.AVAILABLE,
+                reasons=["sof_demo"] if status == TimelineStatus.SOF else [],
+            )
+        ],
+    )
 
-    # Simulate ExportGenerationError for the first leg
-    mock_generate_export.side_effect = [
-        ExportGenerationError("Simulated export failure"),
-        MagicMock(content=b"fake_xlsx_content"),  # Second leg succeeds
+
+@patch("app.mission.package.__main__.load_mission_timeline")
+def test_generate_mission_combined_csv_continues_after_leg_error(
+    mock_load_timeline, mock_mission
+):
+    mock_load_timeline.side_effect = [
+        RuntimeError("Simulated timeline load failure"),
+        _sample_timeline("leg2", TimelineStatus.SOF),
     ]
 
-    # Mock load_workbook for the second leg
-    mock_wb = MagicMock()
-    mock_wb.sheetnames = ["Summary", "Timeline"]
-    mock_sheet = MagicMock()
-    mock_wb.__getitem__.return_value = mock_sheet
-    mock_load_workbook.return_value = mock_wb
+    csv_bytes = generate_mission_combined_csv(mock_mission)
 
-    # Execute
-    xlsx_bytes = generate_mission_combined_xlsx(mock_mission)
-
-    # Verify
-    assert xlsx_bytes is not None
-    assert len(xlsx_bytes) > 0
-
-    # Verify that generate_timeline_export was called for both legs
-    assert mock_generate_export.call_count == 2
+    assert csv_bytes is not None
+    csv_text = csv_bytes.decode("utf-8")
+    assert "Leg 2" in csv_text
+    assert "ADVISORY" in csv_text
+    assert "sof_demo" in csv_text
+    assert mock_load_timeline.call_count == 2
 
 
 @patch("app.mission.package.__main__.load_mission_v2")
@@ -89,40 +104,48 @@ def test_export_mission_package_returns_file_object(mock_load_mission, mock_miss
 
 
 @patch("app.mission.package.__main__.load_mission_v2")
-@patch("app.mission.package.__main__.generate_mission_combined_xlsx")
-def test_export_mission_package_uses_temp_files_for_large_exports(
-    mock_gen_xlsx, mock_load_mission, mock_mission
+@patch("app.mission.package.__main__.generate_mission_combined_pptx")
+@patch("app.mission.package.__main__.generate_mission_combined_csv")
+def test_export_mission_package_uses_temp_files_for_mission_exports(
+    mock_gen_csv, mock_gen_pptx, mock_load_mission, mock_mission
 ):
-    # Setup
     mock_load_mission.return_value = mock_mission
     mock_route_manager = MagicMock()
     mock_poi_manager = MagicMock()
 
-    # Mock generate_mission_combined_xlsx to write to the path it's given
-    def side_effect(mission, output_path=None, **kwargs):
+    def csv_side_effect(mission, output_path=None, **kwargs):
         if output_path:
-            with open(output_path, "w") as f:
-                f.write("dummy xlsx content")
+            with open(output_path, "w", encoding="utf-8") as f:
+                f.write("dummy csv content")
         return None
 
-    mock_gen_xlsx.side_effect = side_effect
+    def pptx_side_effect(mission, output_path=None, **kwargs):
+        if output_path:
+            with open(output_path, "wb") as f:
+                f.write(b"dummy pptx content")
+        return None
 
-    # Execute
+    mock_gen_csv.side_effect = csv_side_effect
+    mock_gen_pptx.side_effect = pptx_side_effect
+
     zip_file = export_mission_package("mission1", mock_route_manager, mock_poi_manager)
 
     try:
-        # Verify
         import zipfile
 
         with zipfile.ZipFile(zip_file, "r") as zf:
-            assert "exports/mission/mission-timeline.xlsx" in zf.namelist()
-            content = zf.read("exports/mission/mission-timeline.xlsx")
-            assert content == b"dummy xlsx content"
+            assert "exports/mission/mission-timeline.csv" in zf.namelist()
+            assert "exports/mission/mission-slides.pptx" in zf.namelist()
+            assert "exports/mission/mission-timeline.xlsx" not in zf.namelist()
+            assert zf.read("exports/mission/mission-timeline.csv") == b"dummy csv content"
+            assert zf.read("exports/mission/mission-slides.pptx") == b"dummy pptx content"
 
-        # Verify generate_mission_combined_xlsx was called with an output_path
-        assert mock_gen_xlsx.called
-        call_args = mock_gen_xlsx.call_args
-        assert "output_path" in call_args.kwargs or len(call_args.args) > 1
+        assert mock_gen_csv.called
+        assert mock_gen_pptx.called
+        csv_call_args = mock_gen_csv.call_args
+        pptx_call_args = mock_gen_pptx.call_args
+        assert "output_path" in csv_call_args.kwargs or len(csv_call_args.args) > 1
+        assert "output_path" in pptx_call_args.kwargs or len(pptx_call_args.args) > 1
 
     finally:
         zip_file.close()

--- a/backend/starlink-location/tests/unit/test_package_exporter.py
+++ b/backend/starlink-location/tests/unit/test_package_exporter.py
@@ -137,8 +137,12 @@ def test_export_mission_package_uses_temp_files_for_mission_exports(
             assert "exports/mission/mission-timeline.csv" in zf.namelist()
             assert "exports/mission/mission-slides.pptx" in zf.namelist()
             assert "exports/mission/mission-timeline.xlsx" not in zf.namelist()
-            assert zf.read("exports/mission/mission-timeline.csv") == b"dummy csv content"
-            assert zf.read("exports/mission/mission-slides.pptx") == b"dummy pptx content"
+            assert (
+                zf.read("exports/mission/mission-timeline.csv") == b"dummy csv content"
+            )
+            assert (
+                zf.read("exports/mission/mission-slides.pptx") == b"dummy pptx content"
+            )
 
         assert mock_gen_csv.called
         assert mock_gen_pptx.called

--- a/backend/starlink-location/tests/unit/test_pptx_builder.py
+++ b/backend/starlink-location/tests/unit/test_pptx_builder.py
@@ -2,11 +2,16 @@
 
 from unittest.mock import Mock, patch
 
+from pptx import Presentation
 
 from app.mission.exporter.__main__ import _cover_metadata_line
 from app.mission.exporter.pptx_builder import _get_footer_metadata
-from app.mission.exporter.pptx_styling import STATUS_DEGRADED, TEXT_BLACK
-from app.mission.models import Mission, MissionLeg, TransportConfig
+from app.mission.exporter.pptx_styling import (
+    STATUS_DEGRADED,
+    TEXT_BLACK,
+    add_status_badge,
+)
+from app.mission.models import Mission, MissionLeg, TimelineStatus, TransportConfig
 
 
 def test_degraded_status_uses_yellow_with_black_text_palette():
@@ -17,6 +22,18 @@ def test_degraded_status_uses_yellow_with_black_text_palette():
         0,
     )
     assert (TEXT_BLACK[0], TEXT_BLACK[1], TEXT_BLACK[2]) == (0, 0, 0)
+
+
+def test_degraded_status_badge_uses_black_text_on_yellow_background():
+    """Actual degraded status badges should render readable black text."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    badge = add_status_badge(slide, TimelineStatus.DEGRADED, 0, 0, 1, 0.3)
+    paragraph = badge.text_frame.paragraphs[0]
+
+    assert badge.fill.fore_color.rgb == STATUS_DEGRADED
+    assert paragraph.font.color.rgb == TEXT_BLACK
 
 
 def test_title_slide_cover_metadata_prefers_mission_revision_fields():

--- a/backend/starlink-location/tests/unit/test_pptx_builder.py
+++ b/backend/starlink-location/tests/unit/test_pptx_builder.py
@@ -4,7 +4,18 @@ from unittest.mock import Mock, patch
 
 
 from app.mission.exporter.pptx_builder import _get_footer_metadata
+from app.mission.exporter.pptx_styling import STATUS_DEGRADED, TEXT_BLACK
 from app.mission.models import Mission, MissionLeg, TransportConfig
+
+
+def test_degraded_status_uses_yellow_with_black_text_palette():
+    """Degraded PPT styling should be yellow, not orange, with black text."""
+    assert (STATUS_DEGRADED[0], STATUS_DEGRADED[1], STATUS_DEGRADED[2]) == (
+        255,
+        255,
+        0,
+    )
+    assert (TEXT_BLACK[0], TEXT_BLACK[1], TEXT_BLACK[2]) == (0, 0, 0)
 
 
 class TestGetFooterMetadata:

--- a/backend/starlink-location/tests/unit/test_pptx_builder.py
+++ b/backend/starlink-location/tests/unit/test_pptx_builder.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 
+from app.mission.exporter.__main__ import _cover_metadata_line
 from app.mission.exporter.pptx_builder import _get_footer_metadata
 from app.mission.exporter.pptx_styling import STATUS_DEGRADED, TEXT_BLACK
 from app.mission.models import Mission, MissionLeg, TransportConfig
@@ -16,6 +17,19 @@ def test_degraded_status_uses_yellow_with_black_text_palette():
         0,
     )
     assert (TEXT_BLACK[0], TEXT_BLACK[1], TEXT_BLACK[2]) == (0, 0, 0)
+
+
+def test_title_slide_cover_metadata_prefers_mission_revision_fields():
+    """Cover metadata should not reuse stale Rev text from descriptions."""
+    mission = Mission(
+        id="mission-26-07",
+        name="Mission 26-07",
+        description="1 Leg | Rev 2",
+        legs=[],
+        metadata={"mission_number": "26-07", "revision": "5"},
+    )
+
+    assert _cover_metadata_line(mission, leg_count=1) == "1 Leg | Mission 26-07 | Rev 5"
 
 
 class TestGetFooterMetadata:

--- a/backend/starlink-location/tests/unit/test_satellite_rules.py
+++ b/backend/starlink-location/tests/unit/test_satellite_rules.py
@@ -213,6 +213,13 @@ class TestRuleEngine:
         assert any("Safety-of-Flight" in e.reason for e in takeoff_events)
         assert any("Safety-of-Flight" in e.reason for e in landing_events)
 
+        takeoff_start = min(e.timestamp for e in takeoff_events)
+        takeoff_end = max(e.timestamp for e in takeoff_events)
+        landing_start = min(e.timestamp for e in landing_events)
+        landing_end = max(e.timestamp for e in landing_events)
+        assert takeoff_end - takeoff_start == timedelta(minutes=15)
+        assert landing_end - landing_start == timedelta(minutes=15)
+
     def test_add_aar_window_events(self):
         """Test adding AAR window events."""
         engine = RuleEngine()

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,6 +13,8 @@
 
 - **[Workflow](./workflow.md)**: Development workflow, git practices, and Docker
   rebuild process for Python backend changes
+- **[Release Policy](./release-policy.md)**: `dev` integration branch policy,
+  semantic versioning, and release flow
 - **[Contributing](../../CONTRIBUTING.md)**: Contribution guidelines, standards,
   and code review process
 

--- a/docs/development/release-policy.md
+++ b/docs/development/release-policy.md
@@ -1,0 +1,39 @@
+# Release Policy
+
+**Purpose**: Define branch usage, semantic versioning, and release discipline for Starlink Dashboard.
+**Audience**: Contributors, release managers, mission operators.
+
+## Branch Policy
+
+- `main` is the stable mission branch. Keep it usable for active aircraft/mission operations.
+- `dev` is the long-lived integration branch for enhancements and fixes that need aircraft or mission validation before they are promoted.
+- Feature and fix branches should target `dev` by default unless the change is an urgent stable-branch hotfix.
+- Do not merge experimental timeline/export work directly to `main`. Integrate and test it on `dev` first.
+
+## Semantic Versioning
+
+Starlink Dashboard releases follow semantic versioning (`MAJOR.MINOR.PATCH`):
+
+- **Patch** (`x.y.Z`): bug fixes that preserve existing output formats, APIs, and operator workflows.
+- **Minor** (`x.Y.z`): behavior-compatible feature additions or improvements that do not require consumers to change.
+- **Major** (`X.y.z`): incompatible API, output, export-schema, or operator-workflow changes.
+
+When in doubt, choose the larger version bump. Silent incompatibility is a rather tiresome gift to future us.
+
+## Lightweight Release Flow
+
+1. Merge and test changes on `dev`.
+2. Validate mission-critical behavior on aircraft or representative mission data.
+3. Prepare release notes or changelog entries that call out operator-visible behavior, export/API changes, fixes, and manual validation performed.
+4. Promote validated changes from `dev` to `main` with a reviewed PR.
+5. Tag releases from `main` only after mission validation passes.
+6. Keep `dev` open for the next integration cycle after the release tag is cut.
+
+## Hotfixes
+
+Urgent fixes for active mission use may branch from `main`, then merge back into both `main` and `dev` after review. Record the patch version and the reason for bypassing the normal `dev` validation path in the release notes.
+
+## Related Documentation
+
+- [Development Workflow](./workflow.md)
+- [Contributing](../../CONTRIBUTING.md)

--- a/docs/development/release-policy.md
+++ b/docs/development/release-policy.md
@@ -1,37 +1,50 @@
 # Release Policy
 
-**Purpose**: Define branch usage, semantic versioning, and release discipline for Starlink Dashboard.
+**Purpose**: Define branch usage, semantic versioning, and release discipline
+for Starlink Dashboard.
 **Audience**: Contributors, release managers, mission operators.
 
 ## Branch Policy
 
-- `main` is the stable mission branch. Keep it usable for active aircraft/mission operations.
-- `dev` is the long-lived integration branch for enhancements and fixes that need aircraft or mission validation before they are promoted.
-- Feature and fix branches should target `dev` by default unless the change is an urgent stable-branch hotfix.
-- Do not merge experimental timeline/export work directly to `main`. Integrate and test it on `dev` first.
+- `main` is the stable mission branch. Keep it usable for active
+  aircraft/mission operations.
+- `dev` is the long-lived integration branch for enhancements and fixes that
+  need aircraft or mission validation before they are promoted.
+- Feature and fix branches should target `dev` by default unless the change is
+  an urgent stable-branch hotfix.
+- Do not merge experimental timeline/export work directly to `main`. Integrate
+  and test it on `dev` first.
 
 ## Semantic Versioning
 
 Starlink Dashboard releases follow semantic versioning (`MAJOR.MINOR.PATCH`):
 
-- **Patch** (`x.y.Z`): bug fixes that preserve existing output formats, APIs, and operator workflows.
-- **Minor** (`x.Y.z`): behavior-compatible feature additions or improvements that do not require consumers to change.
-- **Major** (`X.y.z`): incompatible API, output, export-schema, or operator-workflow changes.
+- **Patch** (`x.y.Z`): bug fixes that preserve existing output formats, APIs,
+  and operator workflows.
+- **Minor** (`x.Y.z`): behavior-compatible feature additions or improvements
+  that do not require consumers to change.
+- **Major** (`X.y.z`): incompatible API, output, export-schema, or
+  operator-workflow changes.
 
-When in doubt, choose the larger version bump. Silent incompatibility is a rather tiresome gift to future us.
+When in doubt, choose the larger version bump. Silent incompatibility is a
+rather tiresome gift to future us.
 
 ## Lightweight Release Flow
 
 1. Merge and test changes on `dev`.
-2. Validate mission-critical behavior on aircraft or representative mission data.
-3. Prepare release notes or changelog entries that call out operator-visible behavior, export/API changes, fixes, and manual validation performed.
+2. Validate mission-critical behavior on aircraft or representative mission
+   data.
+3. Prepare release notes or changelog entries that call out operator-visible
+   behavior, export/API changes, fixes, and manual validation performed.
 4. Promote validated changes from `dev` to `main` with a reviewed PR.
 5. Tag releases from `main` only after mission validation passes.
 6. Keep `dev` open for the next integration cycle after the release tag is cut.
 
 ## Hotfixes
 
-Urgent fixes for active mission use may branch from `main`, then merge back into both `main` and `dev` after review. Record the patch version and the reason for bypassing the normal `dev` validation path in the release notes.
+Urgent fixes for active mission use may branch from `main`, then merge back
+into both `main` and `dev` after review. Record the patch version and the
+reason for bypassing the normal `dev` validation path in the release notes.
 
 ## Related Documentation
 

--- a/docs/development/workflow.md
+++ b/docs/development/workflow.md
@@ -5,9 +5,16 @@ request guidelines for the Starlink Dashboard project.
 
 ## Git Workflow
 
-### 1. Create a Feature Branch
+### 1. Choose the Base Branch
+
+Use `dev` as the default base for enhancements and non-urgent fixes. Keep `main`
+reserved for stable mission use and release tags. Branch from `main` only for
+urgent hotfixes that must reach active mission users before the next `dev`
+validation cycle.
 
 ```bash
+git checkout dev
+git pull origin dev
 git checkout -b feat/your-feature-name
 ```
 

--- a/frontend/mission-planner/src/components/aar/AARSegmentEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/AARSegmentEditor.tsx
@@ -24,6 +24,17 @@ interface AARSegmentEditorProps {
   availableWaypoints: string[];
 }
 
+const ELAPSED_PATTERN = /^T\+\d{1,3}:\d{2}(?::\d{2})?$/i;
+
+function normalizeElapsedInput(value: string) {
+  const trimmed = value.trim().toUpperCase();
+  if (!trimmed) {
+    return null;
+  }
+  const withPrefix = trimmed.startsWith('T+') ? trimmed : `T+${trimmed}`;
+  return ELAPSED_PATTERN.test(withPrefix) ? withPrefix : trimmed;
+}
+
 export function AARSegmentEditor({
   segments,
   onSegmentsChange,
@@ -31,30 +42,17 @@ export function AARSegmentEditor({
 }: AARSegmentEditorProps) {
   const [newSegment, setNewSegment] = useState<Partial<AARSegment>>({});
 
-  const formatOverrideForInput = (value?: string | null) => {
-    if (!value) {
-      return '';
-    }
-    const normalized = value.endsWith('Z') ? value : `${value}Z`;
-    return normalized.slice(0, 16);
-  };
-
-  const toUtcOverride = (value: string) => {
-    if (!value) {
-      return null;
-    }
-    return `${value}:00Z`;
-  };
-
-  const updateSegmentOverride = (
-    index: number,
-    field: 'override_start_time' | 'override_end_time',
-    value: string
-  ) => {
+  const updateSegmentElapsedOverride = (index: number, value: string) => {
+    const normalized = normalizeElapsedInput(value);
     onSegmentsChange(
       segments.map((segment, segmentIndex) =>
         segmentIndex === index
-          ? { ...segment, [field]: toUtcOverride(value) }
+          ? {
+              ...segment,
+              override_start_elapsed: normalized,
+              override_start_time: null,
+              override_end_time: null,
+            }
           : segment
       )
     );
@@ -66,6 +64,7 @@ export function AARSegmentEditor({
         segmentIndex === index
           ? {
               ...segment,
+              override_start_elapsed: null,
               override_start_time: null,
               override_end_time: null,
             }
@@ -114,73 +113,72 @@ export function AARSegmentEditor({
       <div>
         <h3 className="text-sm font-medium mb-2">AAR Segments</h3>
         <p className="mb-3 text-xs text-muted-foreground">
-          Optional UTC overrides let operators enter wind-adjusted,
-          pilot-projected AR start/end times. Saving the leg persists these
-          times and regenerates the preview/export from the adjusted boundaries.
+          Enter flight-deck AR timing as a mission-elapsed start value such as
+          T+07:12. The original AR duration is preserved automatically, so AREX
+          shifts by the same delta when the ARIP override changes.
         </p>
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>Start Waypoint</TableHead>
               <TableHead>End Waypoint</TableHead>
-              <TableHead>Override Start (UTC)</TableHead>
-              <TableHead>Override End (UTC)</TableHead>
+              <TableHead>Override AR Start (T+HH:MM)</TableHead>
               <TableHead>Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {segments.map((segment, index) => (
-              <TableRow key={segment.id}>
-                <TableCell>{segment.start_waypoint_name}</TableCell>
-                <TableCell>{segment.end_waypoint_name}</TableCell>
-                <TableCell>
-                  <Input
-                    type="datetime-local"
-                    value={formatOverrideForInput(segment.override_start_time)}
-                    onChange={(event) =>
-                      updateSegmentOverride(
-                        index,
-                        'override_start_time',
-                        event.target.value
-                      )
-                    }
-                    aria-label={`Override start time for ${segment.start_waypoint_name}`}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Input
-                    type="datetime-local"
-                    value={formatOverrideForInput(segment.override_end_time)}
-                    onChange={(event) =>
-                      updateSegmentOverride(
-                        index,
-                        'override_end_time',
-                        event.target.value
-                      )
-                    }
-                    aria-label={`Override end time for ${segment.end_waypoint_name}`}
-                  />
-                </TableCell>
-                <TableCell>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => clearSegmentOverrides(index)}
-                    >
-                      Clear Times
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => handleRemoveSegment(index)}
-                    >
-                      Remove
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
+            {segments.map((segment, index) => {
+              const elapsedValue = segment.override_start_elapsed ?? '';
+              const elapsedIsValid =
+                !elapsedValue || ELAPSED_PATTERN.test(elapsedValue);
+              return (
+                <TableRow key={segment.id}>
+                  <TableCell>{segment.start_waypoint_name}</TableCell>
+                  <TableCell>{segment.end_waypoint_name}</TableCell>
+                  <TableCell>
+                    <div className="space-y-1">
+                      <Input
+                        placeholder="T+00:00"
+                        value={elapsedValue}
+                        onChange={(event) =>
+                          updateSegmentElapsedOverride(
+                            index,
+                            event.target.value
+                          )
+                        }
+                        aria-label={`Mission elapsed AR start for ${segment.start_waypoint_name}`}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Preserves AR duration and shifts AREX automatically.
+                      </p>
+                      {!elapsedIsValid && (
+                        <p className="text-xs text-destructive">
+                          Use T+HH:MM or T+HH:MM:SS.
+                        </p>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => clearSegmentOverrides(index)}
+                      >
+                        Clear T+
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleRemoveSegment(index)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
             <TableRow>
               <TableCell>
                 <Select
@@ -227,12 +225,7 @@ export function AARSegmentEditor({
               </TableCell>
               <TableCell>
                 <span className="text-xs text-muted-foreground">
-                  Uses waypoint time unless set after adding.
-                </span>
-              </TableCell>
-              <TableCell>
-                <span className="text-xs text-muted-foreground">
-                  Uses waypoint time unless set after adding.
+                  Optional after adding; defaults to waypoint timing.
                 </span>
               </TableCell>
               <TableCell>

--- a/frontend/mission-planner/src/components/aar/AARSegmentEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/AARSegmentEditor.tsx
@@ -8,6 +8,7 @@ import {
   TableRow,
 } from '../ui/table';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 import {
   Select,
   SelectContent,
@@ -29,6 +30,49 @@ export function AARSegmentEditor({
   availableWaypoints,
 }: AARSegmentEditorProps) {
   const [newSegment, setNewSegment] = useState<Partial<AARSegment>>({});
+
+  const formatOverrideForInput = (value?: string | null) => {
+    if (!value) {
+      return '';
+    }
+    const normalized = value.endsWith('Z') ? value : `${value}Z`;
+    return normalized.slice(0, 16);
+  };
+
+  const toUtcOverride = (value: string) => {
+    if (!value) {
+      return null;
+    }
+    return `${value}:00Z`;
+  };
+
+  const updateSegmentOverride = (
+    index: number,
+    field: 'override_start_time' | 'override_end_time',
+    value: string
+  ) => {
+    onSegmentsChange(
+      segments.map((segment, segmentIndex) =>
+        segmentIndex === index
+          ? { ...segment, [field]: toUtcOverride(value) }
+          : segment
+      )
+    );
+  };
+
+  const clearSegmentOverrides = (index: number) => {
+    onSegmentsChange(
+      segments.map((segment, segmentIndex) =>
+        segmentIndex === index
+          ? {
+              ...segment,
+              override_start_time: null,
+              override_end_time: null,
+            }
+          : segment
+      )
+    );
+  };
 
   // Calculate available end waypoints (only those after the start waypoint)
   const getAvailableEndWaypoints = () => {
@@ -69,11 +113,18 @@ export function AARSegmentEditor({
     <div className="space-y-4">
       <div>
         <h3 className="text-sm font-medium mb-2">AAR Segments</h3>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Optional UTC overrides let operators enter wind-adjusted,
+          pilot-projected AR start/end times. Saving the leg persists these
+          times and regenerates the preview/export from the adjusted boundaries.
+        </p>
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>Start Waypoint</TableHead>
               <TableHead>End Waypoint</TableHead>
+              <TableHead>Override Start (UTC)</TableHead>
+              <TableHead>Override End (UTC)</TableHead>
               <TableHead>Actions</TableHead>
             </TableRow>
           </TableHeader>
@@ -83,13 +134,50 @@ export function AARSegmentEditor({
                 <TableCell>{segment.start_waypoint_name}</TableCell>
                 <TableCell>{segment.end_waypoint_name}</TableCell>
                 <TableCell>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => handleRemoveSegment(index)}
-                  >
-                    Remove
-                  </Button>
+                  <Input
+                    type="datetime-local"
+                    value={formatOverrideForInput(segment.override_start_time)}
+                    onChange={(event) =>
+                      updateSegmentOverride(
+                        index,
+                        'override_start_time',
+                        event.target.value
+                      )
+                    }
+                    aria-label={`Override start time for ${segment.start_waypoint_name}`}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="datetime-local"
+                    value={formatOverrideForInput(segment.override_end_time)}
+                    onChange={(event) =>
+                      updateSegmentOverride(
+                        index,
+                        'override_end_time',
+                        event.target.value
+                      )
+                    }
+                    aria-label={`Override end time for ${segment.end_waypoint_name}`}
+                  />
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => clearSegmentOverrides(index)}
+                    >
+                      Clear Times
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleRemoveSegment(index)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
                 </TableCell>
               </TableRow>
             ))}
@@ -136,6 +224,16 @@ export function AARSegmentEditor({
                     ))}
                   </SelectContent>
                 </Select>
+              </TableCell>
+              <TableCell>
+                <span className="text-xs text-muted-foreground">
+                  Uses waypoint time unless set after adding.
+                </span>
+              </TableCell>
+              <TableCell>
+                <span className="text-xs text-muted-foreground">
+                  Uses waypoint time unless set after adding.
+                </span>
               </TableCell>
               <TableCell>
                 <Button onClick={handleAddSegment}>Add</Button>

--- a/frontend/mission-planner/src/components/common/RouteMap/ColorCodedRoute.tsx
+++ b/frontend/mission-planner/src/components/common/RouteMap/ColorCodedRoute.tsx
@@ -11,9 +11,14 @@ interface ColorCodedRouteProps {
 const STATUS_COLORS: Record<string, string> = {
   nominal: '#2ecc71', // Green
   sof: '#0284c7', // Blue
+  advisory: '#0284c7', // Blue
   degraded: '#ffff00', // Yellow
   critical: '#e74c3c', // Red
 };
+
+function displayStatus(status: string): string {
+  return status.toLowerCase() === 'sof' ? 'ADVISORY' : status.toUpperCase();
+}
 
 interface SegmentPolyline {
   coordinates: LatLngExpression[];
@@ -102,7 +107,7 @@ export const ColorCodedRoute: React.FC<ColorCodedRouteProps> = ({
           <Popup>
             <div className="text-sm">
               <div className="font-semibold capitalize">
-                Status: {polyline.segment.status}
+                Status: {displayStatus(polyline.segment.status)}
               </div>
               <div className="text-xs text-gray-600">
                 {new Date(polyline.segment.start_time).toLocaleTimeString(

--- a/frontend/mission-planner/src/components/common/RouteMap/ColorCodedRoute.tsx
+++ b/frontend/mission-planner/src/components/common/RouteMap/ColorCodedRoute.tsx
@@ -10,6 +10,7 @@ interface ColorCodedRouteProps {
 
 const STATUS_COLORS: Record<string, string> = {
   nominal: '#2ecc71', // Green
+  sof: '#0284c7', // Blue
   degraded: '#ffff00', // Yellow
   critical: '#e74c3c', // Red
 };

--- a/frontend/mission-planner/src/components/common/RouteMap/ColorCodedRoute.tsx
+++ b/frontend/mission-planner/src/components/common/RouteMap/ColorCodedRoute.tsx
@@ -10,7 +10,7 @@ interface ColorCodedRouteProps {
 
 const STATUS_COLORS: Record<string, string> = {
   nominal: '#2ecc71', // Green
-  degraded: '#f1c40f', // Yellow
+  degraded: '#ffff00', // Yellow
   critical: '#e74c3c', // Red
 };
 

--- a/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
+++ b/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
@@ -8,7 +8,7 @@ interface TimelineTableProps {
 
 const STATUS_COLORS: Record<string, string> = {
   nominal: 'bg-green-100 text-green-800',
-  degraded: 'bg-yellow-100 text-yellow-800',
+  degraded: 'bg-yellow-200 text-black',
   critical: 'bg-red-100 text-red-800',
 };
 
@@ -158,20 +158,20 @@ export const TimelineTable: React.FC<TimelineTableProps> = ({
         <tbody className="divide-y">
           {displaySegments.map((segment: TimelineSegment, index: number) => {
             const sourceNotes = notesAndSources(segment);
+            const statusKey = segment.status.toLowerCase();
+            const bodyTextClass =
+              statusKey === 'degraded' ? 'text-black' : 'text-gray-700';
             return (
               <tr
                 key={segment.id || index}
-                className={`hover:bg-gray-50 ${
-                  STATUS_COLORS[segment.status.toLowerCase()] || ''
-                }`}
+                className={`hover:bg-gray-50 ${STATUS_COLORS[statusKey] || ''}`}
               >
-                <td className="px-4 py-2 text-gray-700">{index + 1}</td>
+                <td className={`px-4 py-2 ${bodyTextClass}`}>{index + 1}</td>
                 <td className="px-4 py-2">
                   <div className="flex items-center gap-2">
                     <div
                       className={`w-3 h-3 rounded-full ${
-                        STATUS_BADGE_COLORS[segment.status.toLowerCase()] ||
-                        'bg-gray-400'
+                        STATUS_BADGE_COLORS[statusKey] || 'bg-gray-400'
                       }`}
                     ></div>
                     <span className="font-medium">
@@ -182,7 +182,7 @@ export const TimelineTable: React.FC<TimelineTableProps> = ({
                     {callPosture(segment)}
                   </div>
                 </td>
-                <td className="px-4 py-2 text-xs text-gray-700">
+                <td className={`px-4 py-2 text-xs ${bodyTextClass}`}>
                   {primaryReason(segment)}
                 </td>
                 <td className="px-4 py-2 font-mono text-xs">

--- a/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
+++ b/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
@@ -9,6 +9,7 @@ interface TimelineTableProps {
 const STATUS_COLORS: Record<string, string> = {
   nominal: 'bg-green-100 text-green-800',
   sof: 'bg-blue-100 text-blue-800',
+  advisory: 'bg-blue-100 text-blue-800',
   degraded: 'bg-yellow-200 text-black',
   critical: 'bg-red-100 text-red-800',
 };
@@ -16,6 +17,7 @@ const STATUS_COLORS: Record<string, string> = {
 const STATUS_BADGE_COLORS: Record<string, string> = {
   nominal: 'bg-green-500',
   sof: 'bg-blue-500',
+  advisory: 'bg-blue-500',
   degraded: 'bg-yellow-500',
   critical: 'bg-red-500',
 };
@@ -71,8 +73,8 @@ function metadataStringList(segment: TimelineSegment, key: string): string[] {
   return [];
 }
 
-function availabilityLabel(segment: TimelineSegment): string {
-  return metadataString(segment, 'availability_label') || segment.status;
+function displayStatus(status: string): string {
+  return status.toLowerCase() === 'sof' ? 'ADVISORY' : status.toUpperCase();
 }
 
 function callPosture(segment: TimelineSegment): string {
@@ -177,7 +179,7 @@ export const TimelineTable: React.FC<TimelineTableProps> = ({
                       }`}
                     ></div>
                     <span className="font-medium">
-                      {availabilityLabel(segment)}
+                      {displayStatus(segment.status)}
                     </span>
                   </div>
                   <div className="text-xs text-gray-600">

--- a/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
+++ b/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
@@ -50,6 +50,51 @@ function calculateDuration(start: string, end: string): string {
   }
 }
 
+function metadataString(segment: TimelineSegment, key: string): string | null {
+  const value = segment.metadata?.[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function metadataStringList(segment: TimelineSegment, key: string): string[] {
+  const value = segment.metadata?.[key];
+  if (Array.isArray(value)) {
+    return value.filter(
+      (item): item is string =>
+        typeof item === 'string' && item.trim().length > 0
+    );
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [value];
+  }
+  return [];
+}
+
+function availabilityLabel(segment: TimelineSegment): string {
+  return metadataString(segment, 'availability_label') || segment.status;
+}
+
+function callPosture(segment: TimelineSegment): string {
+  return metadataString(segment, 'call_posture') || segment.status;
+}
+
+function primaryReason(segment: TimelineSegment): string {
+  return (
+    metadataString(segment, 'primary_reason') || segment.reasons?.[0] || '—'
+  );
+}
+
+function systemsAffected(segment: TimelineSegment): string {
+  const systems = metadataStringList(segment, 'systems_affected');
+  return systems.length > 0 ? systems.join(', ') : '—';
+}
+
+function notesAndSources(segment: TimelineSegment): string[] {
+  const notes = metadataStringList(segment, 'notes');
+  const sources = metadataStringList(segment, 'source_reasons');
+  const values = [...notes, ...sources];
+  return values.filter((item, index) => values.indexOf(item) === index);
+}
+
 export const TimelineTable: React.FC<TimelineTableProps> = ({
   timeline,
   isLoading = false,
@@ -88,88 +133,94 @@ export const TimelineTable: React.FC<TimelineTableProps> = ({
               Segment
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Status
+              Call Posture
+            </th>
+            <th className="px-4 py-2 text-left font-semibold text-gray-700">
+              Primary Reason
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
               Start Time (UTC)
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
+              End Time (UTC)
+            </th>
+            <th className="px-4 py-2 text-left font-semibold text-gray-700">
               Duration
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              X State
+              Systems Affected
             </th>
             <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Ka State
-            </th>
-            <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Ku State
-            </th>
-            <th className="px-4 py-2 text-left font-semibold text-gray-700">
-              Reasons
+              Notes / Source Events
             </th>
           </tr>
         </thead>
         <tbody className="divide-y">
-          {displaySegments.map((segment: TimelineSegment, index: number) => (
-            <tr
-              key={segment.id || index}
-              className={`hover:bg-gray-50 ${
-                STATUS_COLORS[segment.status.toLowerCase()] || ''
-              }`}
-            >
-              <td className="px-4 py-2 text-gray-700">{index + 1}</td>
-              <td className="px-4 py-2">
-                <div className="flex items-center gap-2">
-                  <div
-                    className={`w-3 h-3 rounded-full ${
-                      STATUS_BADGE_COLORS[segment.status.toLowerCase()] ||
-                      'bg-gray-400'
-                    }`}
-                  ></div>
-                  <span className="font-medium capitalize">
-                    {segment.status}
-                  </span>
-                </div>
-              </td>
-              <td className="px-4 py-2 font-mono text-xs">
-                {formatTime(segment.start_time)}
-              </td>
-              <td className="px-4 py-2">
-                {calculateDuration(segment.start_time, segment.end_time)}
-              </td>
-              <td className="px-4 py-2 capitalize text-xs">
-                {segment.x_state || 'unknown'}
-              </td>
-              <td className="px-4 py-2 capitalize text-xs">
-                {segment.ka_state || 'unknown'}
-              </td>
-              <td className="px-4 py-2 capitalize text-xs">
-                {segment.ku_state || 'unknown'}
-              </td>
-              <td className="px-4 py-2 text-xs">
-                {segment.reasons && segment.reasons.length > 0 ? (
-                  <div className="space-y-1">
-                    {segment.reasons.slice(0, 2).map((reason, i) => (
-                      <div
-                        key={i}
-                        className="bg-gray-200 px-2 py-1 rounded text-gray-700"
-                      >
-                        {reason}
-                      </div>
-                    ))}
-                    {segment.reasons.length > 2 && (
-                      <div className="text-gray-500">
-                        +{segment.reasons.length - 2} more
-                      </div>
-                    )}
+          {displaySegments.map((segment: TimelineSegment, index: number) => {
+            const sourceNotes = notesAndSources(segment);
+            return (
+              <tr
+                key={segment.id || index}
+                className={`hover:bg-gray-50 ${
+                  STATUS_COLORS[segment.status.toLowerCase()] || ''
+                }`}
+              >
+                <td className="px-4 py-2 text-gray-700">{index + 1}</td>
+                <td className="px-4 py-2">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={`w-3 h-3 rounded-full ${
+                        STATUS_BADGE_COLORS[segment.status.toLowerCase()] ||
+                        'bg-gray-400'
+                      }`}
+                    ></div>
+                    <span className="font-medium">
+                      {availabilityLabel(segment)}
+                    </span>
                   </div>
-                ) : (
-                  '-'
-                )}
-              </td>
-            </tr>
-          ))}
+                  <div className="text-xs text-gray-600">
+                    {callPosture(segment)}
+                  </div>
+                </td>
+                <td className="px-4 py-2 text-xs text-gray-700">
+                  {primaryReason(segment)}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs">
+                  {formatTime(segment.start_time)}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs">
+                  {formatTime(segment.end_time)}
+                </td>
+                <td className="px-4 py-2">
+                  {calculateDuration(segment.start_time, segment.end_time)}
+                </td>
+                <td className="px-4 py-2 text-xs">
+                  {systemsAffected(segment)}
+                </td>
+                <td className="px-4 py-2 text-xs">
+                  {sourceNotes.length > 0 ? (
+                    <div className="space-y-1">
+                      {sourceNotes.slice(0, 2).map((note, i) => (
+                        <div
+                          key={i}
+                          className="bg-gray-200 px-2 py-1 rounded text-gray-700"
+                        >
+                          {note}
+                        </div>
+                      ))}
+                      {sourceNotes.length > 2 && (
+                        <div className="text-gray-500">
+                          +{sourceNotes.length - 2} more
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
+++ b/frontend/mission-planner/src/components/timeline/TimelineTable.tsx
@@ -8,12 +8,14 @@ interface TimelineTableProps {
 
 const STATUS_COLORS: Record<string, string> = {
   nominal: 'bg-green-100 text-green-800',
+  sof: 'bg-blue-100 text-blue-800',
   degraded: 'bg-yellow-200 text-black',
   critical: 'bg-red-100 text-red-800',
 };
 
 const STATUS_BADGE_COLORS: Record<string, string> = {
   nominal: 'bg-green-500',
+  sof: 'bg-blue-500',
   degraded: 'bg-yellow-500',
   critical: 'bg-red-500',
 };

--- a/frontend/mission-planner/src/pages/LegDetailPage.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage.tsx
@@ -67,6 +67,8 @@ export function LegDetailPage() {
           id: s.id,
           start_waypoint_name: s.start_waypoint_name,
           end_waypoint_name: s.end_waypoint_name,
+          override_start_time: s.override_start_time,
+          override_end_time: s.override_end_time,
         })),
         ku_overrides: satelliteConfig.ku_outages.map((k) => ({
           id: k.id,

--- a/frontend/mission-planner/src/pages/LegDetailPage.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage.tsx
@@ -69,6 +69,7 @@ export function LegDetailPage() {
           end_waypoint_name: s.end_waypoint_name,
           override_start_time: s.override_start_time,
           override_end_time: s.override_end_time,
+          override_start_elapsed: s.override_start_elapsed,
         })),
         ku_overrides: satelliteConfig.ku_outages.map((k) => ({
           id: k.id,

--- a/frontend/mission-planner/src/services/timeline.ts
+++ b/frontend/mission-planner/src/services/timeline.ts
@@ -51,6 +51,7 @@ export interface TimelinePreviewRequest {
       end_waypoint_name: string;
       override_start_time?: string | null;
       override_end_time?: string | null;
+      override_start_elapsed?: string | null;
     }>;
     ku_overrides: Array<Record<string, unknown>>;
   };

--- a/frontend/mission-planner/src/services/timeline.ts
+++ b/frontend/mission-planner/src/services/timeline.ts
@@ -49,6 +49,8 @@ export interface TimelinePreviewRequest {
       id: string;
       start_waypoint_name: string;
       end_waypoint_name: string;
+      override_start_time?: string | null;
+      override_end_time?: string | null;
     }>;
     ku_overrides: Array<Record<string, unknown>>;
   };

--- a/frontend/mission-planner/src/types/aar.ts
+++ b/frontend/mission-planner/src/types/aar.ts
@@ -2,6 +2,8 @@ export interface AARSegment {
   id: string;
   start_waypoint_name: string;
   end_waypoint_name: string;
+  override_start_time?: string | null;
+  override_end_time?: string | null;
 }
 
 export interface AARConfig {

--- a/frontend/mission-planner/src/types/aar.ts
+++ b/frontend/mission-planner/src/types/aar.ts
@@ -4,6 +4,7 @@ export interface AARSegment {
   end_waypoint_name: string;
   override_start_time?: string | null;
   override_end_time?: string | null;
+  override_start_elapsed?: string | null;
 }
 
 export interface AARConfig {


### PR DESCRIPTION
## Summary
- Promote validated `dev` integration work toward `main` for the approved aircraft/mission release candidate.
- Includes compact mission timeline reason labels for PPT/CSV artifacts, including the reviewed Leg 2 Rev 5 regenerated export.
- Keeps the mission package export manifest aligned with currently supported timeline artifacts (`csv` and `pptx`) and adds shutdown cleanup for the route watcher.

## Release notes
- Aircraft-test timeline exports now use compact reason labels in mission PPT/CSV output for cleaner operator review.
- Leg 2 Rev 5 artifact was regenerated and reviewed by Brian as good before this promotion pass.
- Mission package documentation/tests now reflect supported export files: `mission-timeline.csv` and `mission-slides.pptx`; stale `xlsx`/`pdf` package expectations were removed.
- Backend shutdown now stops the `RouteManager` watcher so the route observer is not left running across lifecycle teardown.

## Verification
- `ruff check .` in `backend/starlink-location` passed.
- `pytest tests/unit/test_package_exporter.py -q` passed.
- `pytest tests/integration/test_mission_routes.py::TestMissionExportEndpoint::test_export_supports_multiple_formats -q` passed.
- `pytest tests/unit/test_main_lifespan.py::test_shutdown_event_stops_route_manager_watcher -q` passed.
- `npm run lint` in `frontend/mission-planner` passed.
- `npm run build` in `frontend/mission-planner` passed.
- Required Docker rebuild sequence completed: `docker compose down && docker compose build --no-cache`, then `docker compose up -d`; `docker compose ps` showed services up and `starlink-location` healthy.
- `curl -fsS http://localhost:8000/health` returned simulation-mode health payload.

## Known release-readiness note
- Full backend `pytest tests -q` currently fails on the performance threshold test `tests/performance/test_benchmark.py::TestTimelineBenchmark::test_10_concurrent_missions_under_1s` in this worker environment, with observed timings around `1.073s` to `1.196s` against a hard `1.0s` benchmark target. Functional/unit/integration checks above pass; treat this as a release risk to review rather than quietly sweeping it under the rug, which would be vulgar.

## Next release action
- Review this PR, decide whether the local performance benchmark risk is acceptable for this promotion, then merge to `main` if approved.
- Per `docs/development/release-policy.md`, cut/tag a release from `main` only after mission validation passes; this PR does not tag or publish a release.
