### PR TITLE
fix: default fullscreen HCX overlay off

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -759,7 +759,7 @@
               }
             },
             "name": "CommKaOverlay",
-            "opacity": 1,
+            "opacity": 0,
             "tooltip": true,
             "type": "geojson"
           }

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_PATH = (
+    REPO_ROOT
+    / "monitoring"
+    / "grafana"
+    / "provisioning"
+    / "dashboards"
+    / "fullscreen-overview.json"
+)
+CORE_MAP_LAYERS = {
+    "Current Position",
+    "Planned Route (KML) - Western Hemisphere",
+    "Planned Route (KML) - Eastern Hemisphere",
+    "MissionEvents",
+    "Satellites",
+}
+HCX_COMM_LAYERS = {"CommKaOverlay"}
+
+
+def _fullscreen_overview_dashboard() -> dict:
+    return json.loads(DASHBOARD_PATH.read_text())
+
+
+def _current_position_layers() -> list[dict]:
+    dashboard = _fullscreen_overview_dashboard()
+    geomap_panels = [
+        panel
+        for panel in dashboard["panels"]
+        if panel.get("type") == "geomap"
+        and panel.get("title") == "Current Position"
+    ]
+    assert len(geomap_panels) == 1
+    return geomap_panels[0]["options"]["layers"]
+
+
+def _layers_by_name() -> dict[str, dict]:
+    return {layer["name"]: layer for layer in _current_position_layers()}
+
+
+def test_fullscreen_overview_dashboard_json_is_valid() -> None:
+    dashboard = _fullscreen_overview_dashboard()
+
+    assert dashboard["uid"] == "starlink-fullscreen"
+    assert dashboard["title"] == "Fullscreen Overview"
+
+
+def test_fullscreen_overview_keeps_core_map_layers_visible_by_default() -> None:
+    layers = _layers_by_name()
+
+    assert CORE_MAP_LAYERS <= layers.keys()
+    for layer_name in CORE_MAP_LAYERS:
+        assert layers[layer_name].get("opacity", 1) > 0
+
+
+def test_fullscreen_overview_hcx_comm_overlay_is_disabled_but_preserved() -> None:
+    layers = _layers_by_name()
+
+    assert HCX_COMM_LAYERS <= layers.keys()
+    for layer_name in HCX_COMM_LAYERS:
+        layer = layers[layer_name]
+        assert layer["type"] == "geojson"
+        assert layer["opacity"] == 0
+        assert layer["config"]["src"].endswith(
+            "/data/sat_coverage/commka.geojson"
+        )
+        assert layer["config"]["style"].get("opacity", 0) > 0


### PR DESCRIPTION
## Summary
- Default the fullscreen overview `CommKaOverlay` geomap layer to opacity `0` so HCX/Comm coverage is disabled on fresh load.
- Preserve the GeoJSON layer configuration and style opacity so the overlay can still be enabled manually from Grafana layer options.
- Add dashboard JSON regression tests covering valid fullscreen dashboard metadata, visible core map layers, and preserved-but-disabled HCX/Comm overlay configuration.

Closes #43

## Verification
- `pytest tools/tests/test_fullscreen_overview_dashboard.py -q`
- `python -m json.tool monitoring/grafana/provisioning/dashboards/fullscreen-overview.json >/tmp/fullscreen-overview.validated.json`
- Browser/Grafana check: imported a temporary copy of the dashboard into the existing local Grafana at `http://127.0.0.1:3000`, confirmed via API that core layers report opacity `1` while `CommKaOverlay` reports opacity `0`, and visually confirmed the map loads without visible blue HCX/Comm coverage overlay. Temporary dashboard copy was deleted afterward.

## Notes
- No Python backend files changed, so the repository's no-cache Docker rebuild sequence was not applicable.
- A broader `pytest tools/tests -q` run still has pre-existing docs link failures for missing `CLAUDE.md`/other docs targets; unrelated to this dashboard change.
