### PR TITLE
fix: simplify fullscreen overview links

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -23,30 +23,6 @@
     {
       "asDropdown": false,
       "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Toggle Kiosk Mode",
-      "tooltip": "Click to toggle fullscreen kiosk mode",
-      "type": "link",
-      "url": "/d/starlink-fullscreen/fullscreen-overview?kiosk"
-    },
-    {
-      "asDropdown": false,
-      "icon": "home",
-      "includeVars": false,
-      "keepTime": false,
-      "tags": [],
-      "targetBlank": false,
-      "title": "All Dashboards",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
       "includeVars": false,
       "keepTime": false,
       "tags": [],
@@ -54,7 +30,7 @@
       "title": "Mission Planner",
       "tooltip": "Open Mission Planner",
       "type": "link",
-      "url": "http://localhost:8000/ui/mission-planner"
+      "url": "http://localhost:5173/missions"
     }
   ],
   "liveNow": true,

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -48,6 +48,25 @@ def test_fullscreen_overview_dashboard_json_is_valid() -> None:
     assert dashboard["title"] == "Fullscreen Overview"
 
 
+def test_fullscreen_overview_has_only_mission_planner_link() -> None:
+    dashboard = _fullscreen_overview_dashboard()
+
+    assert dashboard["links"] == [
+        {
+            "asDropdown": False,
+            "icon": "external link",
+            "includeVars": False,
+            "keepTime": False,
+            "tags": [],
+            "targetBlank": True,
+            "title": "Mission Planner",
+            "tooltip": "Open Mission Planner",
+            "type": "link",
+            "url": "http://localhost:5173/missions",
+        }
+    ]
+
+
 def test_fullscreen_overview_keeps_core_map_layers_visible_by_default() -> None:
     layers = _layers_by_name()
 


### PR DESCRIPTION
## Summary
- Simplifies the fullscreen overview dashboard links to exactly one Mission Planner operator link.
- Updates Mission Planner to `http://localhost:5173/missions`.
- Adds a dashboard fixture test to prevent the kiosk/dashboard-list links from returning.

Closes #44

## Verification
- `pytest tools/tests/test_fullscreen_overview_dashboard.py::test_fullscreen_overview_has_only_mission_planner_link -v` (RED before implementation; failed on existing kiosk/dashboard links and old Mission Planner URL)
- `pytest tools/tests/test_fullscreen_overview_dashboard.py -v` (pass)
- `python -m json.tool monitoring/grafana/provisioning/dashboards/fullscreen-overview.json >/tmp/fullscreen-overview.validated.json` (pass)
- `python - <<'PY' ...` dashboard link assertion (pass)
- `pytest tools/tests -q` (fails on 14 pre-existing documentation link errors to missing `CLAUDE.md`, `docs/missions/data/models.md`, and `.specify/memory/constitution.md`; unrelated to this dashboard change)

## Self-review
- Diff is limited to `monitoring/grafana/provisioning/dashboards/fullscreen-overview.json` and `tools/tests/test_fullscreen_overview_dashboard.py`.
- PR targets `dev` only.
- No backend runtime code changed; Docker rebuild sequence not applicable.