### PR TITLE
fix: remove fullscreen CommKa overlay

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -696,48 +696,6 @@
             "name": "Current Position",
             "tooltip": true,
             "type": "markers"
-          },
-          {
-            "config": {
-              "rules": [],
-              "src": "http://localhost:8000/data/sat_coverage/commka.geojson",
-              "style": {
-                "color": {
-                  "fixed": "#8AB8FF"
-                },
-                "opacity": 0.1,
-                "rotation": {
-                  "fixed": 0,
-                  "max": 360,
-                  "min": -360,
-                  "mode": "mod"
-                },
-                "size": {
-                  "fixed": 5,
-                  "max": 15,
-                  "min": 2
-                },
-                "symbol": {
-                  "fixed": "build/img/icons/marker/circle.svg",
-                  "mode": "fixed"
-                },
-                "symbolAlign": {
-                  "horizontal": "center",
-                  "vertical": "center"
-                },
-                "textConfig": {
-                  "fontSize": 12,
-                  "offsetX": 0,
-                  "offsetY": 0,
-                  "textAlign": "center",
-                  "textBaseline": "middle"
-                }
-              }
-            },
-            "name": "CommKaOverlay",
-            "opacity": 0,
-            "tooltip": true,
-            "type": "geojson"
           }
         ],
         "tooltip": {

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -18,7 +18,8 @@ CORE_MAP_LAYERS = {
     "MissionEvents",
     "Satellites",
 }
-HCX_COMM_LAYERS = {"CommKaOverlay"}
+HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
+HCX_COMM_LAYER_SOURCES = {"commka.geojson"}
 
 
 def _fullscreen_overview_dashboard() -> dict:
@@ -75,15 +76,16 @@ def test_fullscreen_overview_keeps_core_map_layers_visible_by_default() -> None:
         assert layers[layer_name].get("opacity", 1) > 0
 
 
-def test_fullscreen_overview_hcx_comm_overlay_is_disabled_but_preserved() -> None:
-    layers = _layers_by_name()
+def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:
+    layers = _current_position_layers()
 
-    assert HCX_COMM_LAYERS <= layers.keys()
-    for layer_name in HCX_COMM_LAYERS:
-        layer = layers[layer_name]
-        assert layer["type"] == "geojson"
-        assert layer["opacity"] == 0
-        assert layer["config"]["src"].endswith(
-            "/data/sat_coverage/commka.geojson"
-        )
-        assert layer["config"]["style"].get("opacity", 0) > 0
+    layer_names = {layer["name"] for layer in layers}
+    for token in HCX_COMM_LAYER_TOKENS:
+        assert all(token not in name for name in layer_names)
+
+    layer_sources = {
+        Path(layer.get("config", {}).get("src", "")).name
+        for layer in layers
+        if layer.get("type") == "geojson"
+    }
+    assert HCX_COMM_LAYER_SOURCES.isdisjoint(layer_sources)


### PR DESCRIPTION
## Summary
- Removes the CommKaOverlay geojson layer from the fullscreen overview dashboard JSON entirely.
- Updates the fullscreen overview regression test to assert no CommKa/HCX layer name or commka.geojson source remains.
- Verifies the intended core map layers still exist.

Closes #50

## Test Plan
- [x] `python -m pytest tools/tests/test_fullscreen_overview_dashboard.py -q`
- [x] `python -m json.tool monitoring/grafana/provisioning/dashboards/fullscreen-overview.json >/tmp/fullscreen-overview-json-validated.json`
- [x] Custom JSON assertion for core layers and absence of CommKa/HCX tokens in fullscreen overview layers
- [ ] Browser/Grafana hover check not completed: local Grafana is mounted from `/home/brian/.hermes/kanban/worktrees/starlink-dashboard-dev`, not this feature worktree, so reloading provisioning kept the old CommKaOverlay layer. I did not mutate the mounted dev worktree just to make the demo lie convincingly.

## Notes
- `python -m pytest tools/tests -q` currently reports 14 unrelated docs-link failures for missing `CLAUDE.md` / stale docs paths; targeted dashboard tests pass.
