### PR TITLE
fix: make fullscreen map refit to aircraft position

### DIFF
--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -63,7 +63,30 @@ The main dashboard providing a high-level view of terminal operations:
 
 ---
 
-### 2. Network Metrics (Detailed Network Performance)
+### 2. Fullscreen Overview (Operator Display)
+
+**UID:** `starlink-fullscreen`
+
+The fullscreen overview is intended for mission-monitoring displays where the map
+should keep the aircraft visible while preserving enough context for route and
+mission-event awareness.
+
+#### Aircraft Follow Behavior
+
+- Grafana Geomap does not provide true continuous auto-follow for a moving marker
+  in this provisioned dashboard; there is no native follow/track-camera option.
+- The dashboard uses Geomap **Fit to data** scoped to the `Current Position`
+  layer, with `lastOnly` enabled. When panel data refreshes, Grafana refits the
+  view to the latest aircraft position.
+- A capped zoom and padding keep nearby route/history context visible in common
+  mission-monitoring cases, while the planned route, position history, POI,
+  satellite, and mission-event layers remain enabled and usable.
+- Operators can still manually pan/zoom for full-route inspection; the view will
+  refit back to the aircraft on the next data refresh.
+
+---
+
+### 3. Network Metrics (Detailed Network Performance)
 
 **UID:** `starlink-network`
 
@@ -95,7 +118,7 @@ All panels include min/max/mean statistics in legends for quick reference.
 
 ---
 
-### 3. Position & Movement (Detailed Positioning)
+### 4. Position & Movement (Detailed Positioning)
 
 **UID:** `starlink-position`
 

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -77,12 +77,13 @@ mission-event awareness.
   in this provisioned dashboard; there is no native follow/track-camera option.
 - The dashboard uses Geomap **Fit to data** scoped to the `Current Position`
   layer, with `lastOnly` enabled. When panel data refreshes, Grafana refits the
-  view to the latest aircraft position.
-- A capped zoom and padding keep nearby route/history context visible in common
-  mission-monitoring cases, while the planned route, position history, POI,
-  satellite, and mission-event layers remain enabled and usable.
-- Operators can still manually pan/zoom for full-route inspection; the view will
-  refit back to the aircraft on the next data refresh.
+  view to the latest aircraft position without setting a fixed zoom level.
+- Grafana's native follow/refit behavior still recenters on refresh, so manual
+  pan/zoom is best treated as a free-pan mode: pause dashboard refresh while
+  inspecting the wider route or nearby context, then resume refresh to recenter
+  on the aircraft.
+- Planned route, position history, POI, satellite, and mission-event layers
+  remain enabled and usable.
 
 ---
 

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -328,6 +328,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
+      "description": "Grafana Geomap does not support true continuous auto-follow for a moving marker in this provisioned dashboard. The map uses Fit to data on the Current Position layer, last value only, so each data refresh refits to the latest Current Position while preserving route, history, POI, satellite, and mission-event layers for operator context.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -703,14 +704,13 @@
         },
         "view": {
           "allLayers": false,
-          "fit": true,
-          "id": "zero",
-          "initialZoom": 4,
-          "lat": 0,
-          "lon": 0,
+          "id": "fit",
+          "lastOnly": true,
+          "layer": "Current Position",
           "noRepeat": false,
+          "padding": 25,
           "shared": false,
-          "zoom": 1
+          "zoom": 6
         }
       },
       "pluginVersion": "12.2.1",

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -328,7 +328,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Grafana Geomap does not support true continuous auto-follow for a moving marker in this provisioned dashboard. The map uses Fit to data on the Current Position layer, last value only, so each data refresh refits to the latest Current Position while preserving route, history, POI, satellite, and mission-event layers for operator context.",
+      "description": "Grafana Geomap does not support true continuous auto-follow for a moving marker in this provisioned dashboard. The map uses Fit to data on the Current Position layer, last value only, so each data refresh refits to the latest Current Position without setting a fixed zoom. Operators can pause dashboard refresh for free-pan/zoom inspection and resume refresh to recenter on the aircraft.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -709,8 +709,7 @@
           "layer": "Current Position",
           "noRepeat": false,
           "padding": 25,
-          "shared": false,
-          "zoom": 6
+          "shared": false
         }
       },
       "pluginVersion": "12.2.1",

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -95,7 +95,7 @@ def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:
     assert HCX_COMM_LAYER_SOURCES.isdisjoint(layer_sources)
 
 
-def test_fullscreen_overview_refits_view_to_current_position_on_data_refresh() -> None:
+def test_fullscreen_overview_refits_view_without_forcing_zoom() -> None:
     panel = _current_position_panel()
     view = panel["options"]["view"]
 
@@ -103,8 +103,9 @@ def test_fullscreen_overview_refits_view_to_current_position_on_data_refresh() -
     assert view["allLayers"] is False
     assert view["layer"] == "Current Position"
     assert view["lastOnly"] is True
-    assert view["zoom"] == 6
     assert view["padding"] == 25
+    assert "zoom" not in view
+    assert "initialZoom" not in view
 
 
 def test_fullscreen_overview_documents_grafana_follow_limitation() -> None:
@@ -114,5 +115,8 @@ def test_fullscreen_overview_documents_grafana_follow_limitation() -> None:
 
     assert "Grafana Geomap does not support true continuous auto-follow" in description
     assert "refits to the latest Current Position" in description
+    assert "without setting a fixed zoom" in description
+    assert "pause dashboard refresh" in dashboard_docs
+    assert "resume refresh" in dashboard_docs
     assert "true continuous auto-follow" in dashboard_docs
     assert "Fit to data" in dashboard_docs

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -26,7 +26,7 @@ def _fullscreen_overview_dashboard() -> dict:
     return json.loads(DASHBOARD_PATH.read_text())
 
 
-def _current_position_layers() -> list[dict]:
+def _current_position_panel() -> dict:
     dashboard = _fullscreen_overview_dashboard()
     geomap_panels = [
         panel
@@ -35,7 +35,11 @@ def _current_position_layers() -> list[dict]:
         and panel.get("title") == "Current Position"
     ]
     assert len(geomap_panels) == 1
-    return geomap_panels[0]["options"]["layers"]
+    return geomap_panels[0]
+
+
+def _current_position_layers() -> list[dict]:
+    return _current_position_panel()["options"]["layers"]
 
 
 def _layers_by_name() -> dict[str, dict]:
@@ -89,3 +93,26 @@ def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:
         if layer.get("type") == "geojson"
     }
     assert HCX_COMM_LAYER_SOURCES.isdisjoint(layer_sources)
+
+
+def test_fullscreen_overview_refits_view_to_current_position_on_data_refresh() -> None:
+    panel = _current_position_panel()
+    view = panel["options"]["view"]
+
+    assert view["id"] == "fit"
+    assert view["allLayers"] is False
+    assert view["layer"] == "Current Position"
+    assert view["lastOnly"] is True
+    assert view["zoom"] == 6
+    assert view["padding"] == 25
+
+
+def test_fullscreen_overview_documents_grafana_follow_limitation() -> None:
+    panel = _current_position_panel()
+    description = panel["description"]
+    dashboard_docs = (REPO_ROOT / "docs" / "grafana-dashboards.md").read_text()
+
+    assert "Grafana Geomap does not support true continuous auto-follow" in description
+    assert "refits to the latest Current Position" in description
+    assert "true continuous auto-follow" in dashboard_docs
+    assert "Fit to data" in dashboard_docs


### PR DESCRIPTION
## Summary
- Configure fullscreen overview Geomap to use native Fit to data on the `Current Position` layer, last value only, so refreshes recenter around the latest aircraft position.
- Remove the forced follow zoom from the Geomap view config so the dashboard no longer pins the operator to zoom 6.
- Preserve existing planned route, position history, POI, satellite, mission-event, and current-position layers.
- Document the Grafana limitation: true continuous auto-follow/track-camera with preserved manual zoom is not supported natively; the least-awful operator workflow is pause dashboard refresh for free-pan/zoom, then resume refresh to recenter.

## Verification
- `pytest tools/tests/test_fullscreen_overview_dashboard.py -q`
- `python -m json.tool monitoring/grafana/provisioning/dashboards/fullscreen-overview.json >/tmp/fullscreen-overview.json.validated`
- `git diff --check`
- `pytest tools/tests/test_docs.py -q` currently fails on pre-existing broken documentation links to missing `CLAUDE.md` / other docs, unrelated to this PR.
- No backend Python files changed, so the repository Docker rebuild sequence was not required. Live Grafana browser verification remains manual.

Closes #45
