### PR TITLE
feat: add fullscreen weather radar overlay

### DIFF
--- a/backend/starlink-location/app/api/weather.py
+++ b/backend/starlink-location/app/api/weather.py
@@ -1,0 +1,26 @@
+"""Weather-related API routes."""
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import RedirectResponse
+
+from app.services.weather_radar import RainViewerRadarService
+
+router = APIRouter(prefix="/api/weather", tags=["weather"])
+rainviewer_radar_service = RainViewerRadarService()
+
+
+@router.get("/radar/rainviewer/{z}/{x}/{y}.png")
+def rainviewer_radar_tile(z: int, x: int, y: int) -> RedirectResponse:
+    """Redirect Grafana XYZ tile requests to the latest RainViewer radar frame."""
+    try:
+        tile_url = rainviewer_radar_service.tile_url(z=z, x=x, y=y)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return RedirectResponse(
+        url=tile_url,
+        status_code=307,
+        headers={"Cache-Control": "public, max-age=300"},
+    )

--- a/backend/starlink-location/app/services/weather_radar.py
+++ b/backend/starlink-location/app/services/weather_radar.py
@@ -1,0 +1,95 @@
+"""RainViewer weather radar tile URL resolution."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+RAINVIEWER_METADATA_URL = "https://api.rainviewer.com/public/weather-maps.json"
+RAINVIEWER_MAX_ZOOM = 7
+RAINVIEWER_TILE_SIZE = 512
+RAINVIEWER_COLOR_SCHEME = 2
+RAINVIEWER_OPTIONS = "1_1"
+
+MetadataFetcher = Callable[[], dict[str, Any]]
+
+
+def fetch_rainviewer_metadata() -> dict[str, Any]:
+    """Fetch RainViewer's weather map frame metadata."""
+    request = Request(
+        RAINVIEWER_METADATA_URL,
+        headers={"User-Agent": "starlink-dashboard/0.2 weather-radar"},
+    )
+    with urlopen(request, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+class RainViewerRadarService:
+    """Build RainViewer radar tile URLs from cached metadata."""
+
+    def __init__(
+        self,
+        metadata_fetcher: MetadataFetcher = fetch_rainviewer_metadata,
+        cache_ttl_seconds: int = 300,
+    ) -> None:
+        self._metadata_fetcher = metadata_fetcher
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._cached_metadata: dict[str, Any] | None = None
+        self._cached_at_monotonic = 0.0
+
+    def tile_url(self, z: int, x: int, y: int) -> str:
+        """Return a redirect target for the latest available radar tile."""
+        if z < 0 or z > RAINVIEWER_MAX_ZOOM:
+            raise ValueError(f"RainViewer radar zoom must be 0-{RAINVIEWER_MAX_ZOOM}")
+        if x < 0 or y < 0:
+            raise ValueError("RainViewer radar tile coordinates must be non-negative")
+
+        metadata = self._metadata()
+        host = metadata.get("host")
+        frame = self._latest_frame(metadata)
+        path = frame.get("path")
+        if not isinstance(host, str) or not isinstance(path, str):
+            raise RuntimeError("RainViewer metadata unavailable")
+
+        return (
+            f"{host}{path}/{RAINVIEWER_TILE_SIZE}/{z}/{x}/{y}/"
+            f"{RAINVIEWER_COLOR_SCHEME}/{RAINVIEWER_OPTIONS}.png"
+        )
+
+    def _metadata(self) -> dict[str, Any]:
+        now = time.monotonic()
+        if (
+            self._cached_metadata is not None
+            and now - self._cached_at_monotonic < self._cache_ttl_seconds
+        ):
+            return self._cached_metadata
+
+        try:
+            metadata = self._metadata_fetcher()
+        except (OSError, URLError, json.JSONDecodeError) as exc:
+            raise RuntimeError("RainViewer metadata unavailable") from exc
+
+        self._cached_metadata = metadata
+        self._cached_at_monotonic = now
+        return metadata
+
+    @staticmethod
+    def _latest_frame(metadata: dict[str, Any]) -> dict[str, Any]:
+        radar = metadata.get("radar")
+        if not isinstance(radar, dict):
+            raise RuntimeError("RainViewer metadata unavailable")
+
+        nowcast = radar.get("nowcast") or []
+        past = radar.get("past") or []
+        frames = nowcast if nowcast else past
+        if not frames:
+            raise RuntimeError("RainViewer metadata unavailable")
+
+        latest = max(frames, key=lambda frame: frame.get("time", 0))
+        if not isinstance(latest, dict):
+            raise RuntimeError("RainViewer metadata unavailable")
+        return latest

--- a/backend/starlink-location/main.py
+++ b/backend/starlink-location/main.py
@@ -23,6 +23,7 @@ from app.api import (
     routes,
     status,
     ui,
+    weather,
 )
 from app.mission import (
     routes as mission_routes,
@@ -496,6 +497,7 @@ app.include_router(mission_routes_v2.router, tags=["Missions V2"])
 app.include_router(satellite_routes.router, tags=["Satellites"])
 app.include_router(export.router, tags=["Export"])
 app.include_router(gps.router, tags=["GPS"])
+app.include_router(weather.router, tags=["Weather"])
 app.include_router(ui.router, tags=["UI"])
 
 

--- a/backend/starlink-location/tests/unit/test_weather_api.py
+++ b/backend/starlink-location/tests/unit/test_weather_api.py
@@ -1,0 +1,31 @@
+"""Tests for weather radar API routes."""
+
+from app.api import weather
+
+
+def test_rainviewer_radar_tile_endpoint_redirects_to_latest_tile(client, monkeypatch) -> None:
+    monkeypatch.setattr(
+        weather.rainviewer_radar_service,
+        "tile_url",
+        lambda z, x, y: f"https://tilecache.rainviewer.com/radar/{z}/{x}/{y}.png",
+    )
+
+    response = client.get("/api/weather/radar/rainviewer/3/4/5.png", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://tilecache.rainviewer.com/radar/3/4/5.png"
+    assert response.headers["cache-control"] == "public, max-age=300"
+
+
+def test_rainviewer_radar_tile_endpoint_returns_503_when_source_unavailable(
+    client, monkeypatch
+) -> None:
+    def unavailable_tile_url(z: int, x: int, y: int) -> str:
+        raise RuntimeError("RainViewer metadata unavailable")
+
+    monkeypatch.setattr(weather.rainviewer_radar_service, "tile_url", unavailable_tile_url)
+
+    response = client.get("/api/weather/radar/rainviewer/3/4/5.png")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "RainViewer metadata unavailable"}

--- a/backend/starlink-location/tests/unit/test_weather_radar.py
+++ b/backend/starlink-location/tests/unit/test_weather_radar.py
@@ -1,0 +1,70 @@
+"""Tests for RainViewer weather radar tile helpers."""
+
+from unittest.mock import Mock
+from urllib.error import URLError
+
+import pytest
+
+from app.services.weather_radar import RainViewerRadarService
+
+
+RAINVIEWER_METADATA = {
+    "host": "https://tilecache.rainviewer.com",
+    "radar": {
+        "past": [
+            {"time": 1000, "path": "/v2/radar/old"},
+            {"time": 1600, "path": "/v2/radar/latest"},
+        ],
+        "nowcast": [],
+    },
+}
+
+
+def test_rainviewer_service_builds_latest_radar_tile_url() -> None:
+    service = RainViewerRadarService(metadata_fetcher=lambda: RAINVIEWER_METADATA)
+
+    tile_url = service.tile_url(z=4, x=5, y=6)
+
+    assert (
+        tile_url
+        == "https://tilecache.rainviewer.com/v2/radar/latest/512/4/5/6/2/1_1.png"
+    )
+
+
+def test_rainviewer_service_prefers_nowcast_frame_when_available() -> None:
+    metadata = {
+        "host": "https://tilecache.rainviewer.com",
+        "radar": {
+            "past": [{"time": 1000, "path": "/v2/radar/past"}],
+            "nowcast": [{"time": 2000, "path": "/v2/radar/nowcast"}],
+        },
+    }
+    service = RainViewerRadarService(metadata_fetcher=lambda: metadata)
+
+    assert service.tile_url(z=0, x=0, y=0).startswith(
+        "https://tilecache.rainviewer.com/v2/radar/nowcast/"
+    )
+
+
+def test_rainviewer_service_caches_metadata_between_tile_requests() -> None:
+    metadata_fetcher = Mock(return_value=RAINVIEWER_METADATA)
+    service = RainViewerRadarService(metadata_fetcher=metadata_fetcher, cache_ttl_seconds=600)
+
+    service.tile_url(z=1, x=2, y=3)
+    service.tile_url(z=1, x=2, y=4)
+
+    assert metadata_fetcher.call_count == 1
+
+
+def test_rainviewer_service_rejects_zoom_levels_rainviewer_does_not_serve() -> None:
+    service = RainViewerRadarService(metadata_fetcher=lambda: RAINVIEWER_METADATA)
+
+    with pytest.raises(ValueError, match="zoom"):
+        service.tile_url(z=8, x=0, y=0)
+
+
+def test_rainviewer_service_reports_unavailable_metadata() -> None:
+    service = RainViewerRadarService(metadata_fetcher=lambda: (_ for _ in ()).throw(URLError("nope")))
+
+    with pytest.raises(RuntimeError, match="RainViewer metadata unavailable"):
+        service.tile_url(z=0, x=0, y=0)

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -379,6 +379,19 @@
         "layers": [
           {
             "config": {
+              "attribution": "Weather radar \u00a9 Rain Viewer / MeteoLab Inc.",
+              "maxZoom": 7,
+              "minZoom": 0,
+              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
+            },
+            "name": "Weather Radar (RainViewer)",
+            "noRepeat": false,
+            "opacity": 0.35,
+            "tooltip": false,
+            "type": "xyz"
+          },
+          {
+            "config": {
               "showLegend": true,
               "style": {
                 "color": {

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -386,7 +386,7 @@
             },
             "name": "Weather Radar (RainViewer)",
             "noRepeat": false,
-            "opacity": 0.35,
+            "opacity": 0.7,
             "tooltip": false,
             "type": "xyz"
           },

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -18,6 +18,8 @@ CORE_MAP_LAYERS = {
     "MissionEvents",
     "Satellites",
 }
+RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
+RAINVIEWER_RADAR_TILE_URL = "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
 HCX_COMM_LAYER_SOURCES = {"commka.geojson"}
 EXPECTED_CLOCK_DEFAULTS = {
@@ -99,6 +101,24 @@ def test_fullscreen_overview_keeps_core_map_layers_visible_by_default() -> None:
     assert CORE_MAP_LAYERS <= layers.keys()
     for layer_name in CORE_MAP_LAYERS:
         assert layers[layer_name].get("opacity", 1) > 0
+
+
+def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_layers() -> None:
+    layers = _current_position_layers()
+    layers_by_name = {layer["name"]: layer for layer in layers}
+    radar_layer = layers_by_name[RADAR_LAYER_NAME]
+
+    assert radar_layer["type"] == "xyz"
+    assert radar_layer["config"] == {
+        "attribution": "Weather radar © Rain Viewer / MeteoLab Inc.",
+        "maxZoom": 7,
+        "minZoom": 0,
+        "url": RAINVIEWER_RADAR_TILE_URL,
+    }
+    assert radar_layer["opacity"] == 0.35
+    assert layers.index(radar_layer) < min(
+        layers.index(layers_by_name[layer_name]) for layer_name in CORE_MAP_LAYERS
+    )
 
 
 def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -115,7 +115,7 @@ def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_lay
         "minZoom": 0,
         "url": RAINVIEWER_RADAR_TILE_URL,
     }
-    assert radar_layer["opacity"] == 0.35
+    assert radar_layer["opacity"] == 0.7
     assert layers.index(radar_layer) < min(
         layers.index(layers_by_name[layer_name]) for layer_name in CORE_MAP_LAYERS
     )


### PR DESCRIPTION
## Summary
- adds a RainViewer-backed optional XYZ weather radar layer to the fullscreen overview Geomap, rendered below operational route/marker/satellite layers at low opacity
- adds a Starlink Location backend weather API that resolves the latest RainViewer frame and redirects tile requests with short cache headers
- adds dashboard and backend unit coverage for radar layer configuration, tile URL resolution, and API responses

## Verification
- `pytest tools/tests/test_fullscreen_overview_dashboard.py -q`
- `cd backend/starlink-location && pytest tests/unit/test_weather_radar.py tests/unit/test_weather_api.py -q`
- `docker compose build --no-cache`
- `docker compose up -d` with `starlink-location` healthy
- `curl -fsS http://localhost:8000/health`
- `curl -fsSL -o /tmp/radar-live-after-build.png http://localhost:8000/api/weather/radar/rainviewer/2/1/1.png` -> valid 512x512 PNG
- Browser/Grafana visual check: fullscreen dashboard rendered with map panel and faint radar overlay; no browser console errors

## Notes
- Grafana Geomap supports the radar as an XYZ tile layer. A relative tile URL incorrectly routed requests through Grafana, so the dashboard uses `http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png` for the local stack.
- RainViewer public metadata and tile endpoints were verified during implementation; attribution is included on the layer.

Closes #47
