### PR TITLE
Fix IDL wraparound in live track path

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_latitude_degrees",
+          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -794,7 +794,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_longitude_degrees",
+          "expr": "starlink_dish_longitude_degrees < 0",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_latitude_degrees",
+          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -885,7 +885,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_longitude_degrees",
+          "expr": "starlink_dish_longitude_degrees >= 0",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,

--- a/monitoring/grafana/provisioning/dashboards/overview.json
+++ b/monitoring/grafana/provisioning/dashboards/overview.json
@@ -172,7 +172,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {},
         "textMode": "auto"
@@ -358,7 +360,7 @@
         "layers": [
           {
             "type": "route",
-            "name": "Historical Route",
+            "name": "Historical Route - Western Hemisphere",
             "config": {
               "style": {
                 "color": {
@@ -374,7 +376,37 @@
               "latitude": "lat_history",
               "longitude": "lon_history"
             },
-            "tooltip": false
+            "tooltip": false,
+            "filterByRefId": "E",
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-E-F"
+            }
+          },
+          {
+            "type": "route",
+            "name": "Historical Route - Eastern Hemisphere",
+            "config": {
+              "style": {
+                "color": {
+                  "fixed": "green"
+                },
+                "opacity": 0.6,
+                "lineWidth": 3
+              },
+              "showLegend": true
+            },
+            "location": {
+              "mode": "coords",
+              "latitude": "lat_history",
+              "longitude": "lon_history"
+            },
+            "tooltip": false,
+            "filterByRefId": "E_EAST",
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-E_EAST-F_EAST"
+            }
           },
           {
             "type": "markers",
@@ -422,7 +454,12 @@
               "latitude": "latitude",
               "longitude": "longitude"
             },
-            "tooltip": true
+            "tooltip": true,
+            "filterByRefId": "A",
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-A-B-C-D"
+            }
           }
         ],
         "view": {
@@ -486,7 +523,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_latitude_degrees",
+          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -494,7 +531,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_longitude_degrees",
+          "expr": "starlink_dish_longitude_degrees < 0",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -516,15 +553,57 @@
           "legendFormat": "heading_history",
           "refId": "H",
           "interval": "1s"
+        },
+        {
+          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "lat_history",
+          "refId": "E_EAST",
+          "interval": "1s"
+        },
+        {
+          "expr": "starlink_dish_longitude_degrees >= 0",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "lon_history",
+          "refId": "F_EAST",
+          "interval": "1s"
         }
       ],
       "title": "Live Position Map",
       "transformations": [
         {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:A|B|C|D)$/"
+          },
           "id": "joinByField",
           "options": {
             "byField": "Time",
-            "mode": "outer"
+            "mode": "inner"
+          }
+        },
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:E|F)$/"
+          },
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "inner"
+          }
+        },
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:E_EAST|F_EAST)$/"
+          },
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "inner"
           }
         }
       ],
@@ -643,7 +722,9 @@
         "footer": {
           "countRows": "all",
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -729,7 +810,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
@@ -793,7 +876,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
@@ -905,7 +990,11 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["last", "max", "min"],
+          "calcs": [
+            "last",
+            "max",
+            "min"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -980,7 +1069,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {},
         "textMode": "auto"
@@ -1044,7 +1135,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {},
         "textMode": "auto"
@@ -1108,7 +1201,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {},
         "textMode": "auto"
@@ -1187,7 +1282,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {},
         "textMode": "auto"
@@ -1378,7 +1475,11 @@
   "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["starlink", "monitoring", "overview"],
+  "tags": [
+    "starlink",
+    "monitoring",
+    "overview"
+  ],
   "templating": {
     "list": []
   },

--- a/monitoring/grafana/provisioning/dashboards/position-movement.json
+++ b/monitoring/grafana/provisioning/dashboards/position-movement.json
@@ -105,7 +105,9 @@
         "reduceOptions": {
           "values": false,
           "fields": "",
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {},
         "textMode": "auto"
@@ -291,7 +293,7 @@
         "layers": [
           {
             "type": "route",
-            "name": "Historical Route",
+            "name": "Historical Route - Western Hemisphere",
             "config": {
               "style": {
                 "color": {
@@ -307,7 +309,37 @@
               "latitude": "lat_history",
               "longitude": "lon_history"
             },
-            "tooltip": false
+            "tooltip": false,
+            "filterByRefId": "E",
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-E-F"
+            }
+          },
+          {
+            "type": "route",
+            "name": "Historical Route - Eastern Hemisphere",
+            "config": {
+              "style": {
+                "color": {
+                  "fixed": "green"
+                },
+                "opacity": 0.6,
+                "lineWidth": 3
+              },
+              "showLegend": true
+            },
+            "location": {
+              "mode": "coords",
+              "latitude": "lat_history",
+              "longitude": "lon_history"
+            },
+            "tooltip": false,
+            "filterByRefId": "E_EAST",
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-E_EAST-F_EAST"
+            }
           },
           {
             "type": "markers",
@@ -355,7 +387,12 @@
               "latitude": "latitude",
               "longitude": "longitude"
             },
-            "tooltip": true
+            "tooltip": true,
+            "filterByRefId": "A",
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-A-B-C-D"
+            }
           }
         ],
         "view": {
@@ -419,7 +456,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_latitude_degrees",
+          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -427,7 +464,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_longitude_degrees",
+          "expr": "starlink_dish_longitude_degrees < 0",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -449,15 +486,57 @@
           "legendFormat": "heading_history",
           "refId": "H",
           "interval": "1s"
+        },
+        {
+          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "lat_history",
+          "refId": "E_EAST",
+          "interval": "1s"
+        },
+        {
+          "expr": "starlink_dish_longitude_degrees >= 0",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "lon_history",
+          "refId": "F_EAST",
+          "interval": "1s"
         }
       ],
       "title": "Live Position Map (Large)",
       "transformations": [
         {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:A|B|C|D)$/"
+          },
           "id": "joinByField",
           "options": {
             "byField": "Time",
-            "mode": "outer"
+            "mode": "inner"
+          }
+        },
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:E|F)$/"
+          },
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "inner"
+          }
+        },
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:E_EAST|F_EAST)$/"
+          },
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "inner"
           }
         }
       ],
@@ -526,7 +605,12 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["last", "max", "min", "mean"],
+          "calcs": [
+            "last",
+            "max",
+            "min",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -614,7 +698,12 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["last", "max", "min", "mean"],
+          "calcs": [
+            "last",
+            "max",
+            "min",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -641,7 +730,11 @@
   "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["starlink", "monitoring", "position"],
+  "tags": [
+    "starlink",
+    "monitoring",
+    "position"
+  ],
   "templating": {
     "list": [
       {

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -68,6 +68,14 @@ def _panel_by_title(title: str) -> dict:
     return panels[0]
 
 
+def _target_by_ref_id(panel: dict, ref_id: str) -> dict:
+    targets = [
+        target for target in panel["targets"] if target.get("refId") == ref_id
+    ]
+    assert len(targets) == 1
+    return targets[0]
+
+
 def _field_override_by_name(panel: dict, field_name: str) -> dict:
     matches = [
         override
@@ -161,6 +169,40 @@ def test_fullscreen_overview_poi_table_hides_active_route_fields() -> None:
 
     assert organize_options["excludeByName"]["active"] is True
     assert organize_options["excludeByName"]["is_on_active_route"] is True
+
+
+def test_fullscreen_overview_live_history_is_split_by_hemisphere_for_idl() -> None:
+    map_panel = _panel_by_title("Current Position")
+    layers = _layers_by_name()
+
+    west_history = layers["Position History - Western Hemisphere"]
+    east_history = layers["Position History - Eastern Hemisphere"]
+
+    assert west_history["type"] == "route"
+    assert west_history["filterData"]["options"] == "joinByField-E-F"
+    assert west_history["location"] == {
+        "latitude": "latitude_history",
+        "longitude": "longitude_history",
+        "mode": "coords",
+    }
+    assert east_history["type"] == "route"
+    assert east_history["filterData"]["options"] == "joinByField-E_EAST-F_EAST"
+    assert east_history["location"] == west_history["location"]
+
+    assert _target_by_ref_id(map_panel, "E")["expr"] == (
+        "starlink_dish_latitude_degrees and "
+        "starlink_dish_longitude_degrees < 0"
+    )
+    assert _target_by_ref_id(map_panel, "F")["expr"] == (
+        "starlink_dish_longitude_degrees < 0"
+    )
+    assert _target_by_ref_id(map_panel, "E_EAST")["expr"] == (
+        "starlink_dish_latitude_degrees and "
+        "starlink_dish_longitude_degrees >= 0"
+    )
+    assert _target_by_ref_id(map_panel, "F_EAST")["expr"] == (
+        "starlink_dish_longitude_degrees >= 0"
+    )
 
 
 def test_fullscreen_overview_poi_table_anchors_eta_left_and_flexes_poi_name() -> None:

--- a/tools/tests/test_grafana_live_track_idl.py
+++ b/tools/tests/test_grafana_live_track_idl.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_DIR = (
+    REPO_ROOT / "monitoring" / "grafana" / "provisioning" / "dashboards"
+)
+
+HEMISPHERE_HISTORY_TARGETS = {
+    "E": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
+    "F": "starlink_dish_longitude_degrees < 0",
+    "E_EAST": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
+    "F_EAST": "starlink_dish_longitude_degrees >= 0",
+}
+
+DASHBOARD_LIVE_MAPS = [
+    (
+        "fullscreen-overview.json",
+        "Current Position",
+        "Position History - Western Hemisphere",
+        "Position History - Eastern Hemisphere",
+        "latitude_history",
+        "longitude_history",
+    ),
+    (
+        "overview.json",
+        "Live Position Map",
+        "Historical Route - Western Hemisphere",
+        "Historical Route - Eastern Hemisphere",
+        "lat_history",
+        "lon_history",
+    ),
+    (
+        "position-movement.json",
+        "Live Position Map (Large)",
+        "Historical Route - Western Hemisphere",
+        "Historical Route - Eastern Hemisphere",
+        "lat_history",
+        "lon_history",
+    ),
+]
+
+
+def _dashboard(filename: str) -> dict:
+    return json.loads((DASHBOARD_DIR / filename).read_text())
+
+
+def _panel_by_title(dashboard: dict, title: str) -> dict:
+    panels = [panel for panel in dashboard["panels"] if panel.get("title") == title]
+    assert len(panels) == 1
+    return panels[0]
+
+
+def _target_exprs(panel: dict) -> dict[str, str]:
+    return {
+        target["refId"]: target["expr"]
+        for target in panel["targets"]
+        if target.get("refId") in HEMISPHERE_HISTORY_TARGETS
+    }
+
+
+def _route_layers_by_name(panel: dict) -> dict[str, dict]:
+    return {
+        layer["name"]: layer
+        for layer in panel["options"]["layers"]
+        if layer.get("type") == "route"
+    }
+
+
+def _join_filters(panel: dict) -> set[str]:
+    return {
+        transformation.get("filter", {}).get("options")
+        for transformation in panel.get("transformations", [])
+        if transformation.get("id") == "joinByField"
+    }
+
+
+def test_live_history_track_queries_are_split_by_hemisphere_for_idl() -> None:
+    for filename, panel_title, *_ in DASHBOARD_LIVE_MAPS:
+        panel = _panel_by_title(_dashboard(filename), panel_title)
+
+        assert _target_exprs(panel) == HEMISPHERE_HISTORY_TARGETS
+
+
+def test_live_history_track_layers_are_split_by_hemisphere_for_idl() -> None:
+    for (
+        filename,
+        panel_title,
+        west_layer_name,
+        east_layer_name,
+        latitude_field,
+        longitude_field,
+    ) in DASHBOARD_LIVE_MAPS:
+        panel = _panel_by_title(_dashboard(filename), panel_title)
+        route_layers = _route_layers_by_name(panel)
+
+        west_history = route_layers[west_layer_name]
+        east_history = route_layers[east_layer_name]
+
+        assert west_history["filterByRefId"] == "E"
+        assert west_history["filterData"] == {
+            "id": "byRefId",
+            "options": "joinByField-E-F",
+        }
+        assert west_history["location"] == {
+            "mode": "coords",
+            "latitude": latitude_field,
+            "longitude": longitude_field,
+        }
+
+        assert east_history["filterByRefId"] == "E_EAST"
+        assert east_history["filterData"] == {
+            "id": "byRefId",
+            "options": "joinByField-E_EAST-F_EAST",
+        }
+        assert east_history["location"] == west_history["location"]
+
+
+def test_live_history_transformations_join_each_hemisphere_independently() -> None:
+    for filename, panel_title, *_ in DASHBOARD_LIVE_MAPS:
+        panel = _panel_by_title(_dashboard(filename), panel_title)
+
+        assert {
+            "/^(?:E|F)$/",
+            "/^(?:E_EAST|F_EAST)$/",
+        } <= _join_filters(panel)


### PR DESCRIPTION
## Summary
- Splits live history latitude/longitude PromQL into western/eastern hemisphere series to prevent Grafana route interpolation across the IDL.
- Adds separate route layers and join transformations for the western/eastern history frames on fullscreen, overview, and position/movement maps.
- Adds focused dashboard JSON tests covering the split targets, layer filters, and independent join transformations.

## Test plan
- `python -m pytest tools/tests/test_grafana_live_track_idl.py tools/tests/test_fullscreen_overview_dashboard.py -q` (13 passed)
- `git diff --check origin/main...HEAD`
- `python -m json.tool` on the three changed dashboard JSON files
- `python -m pytest tools/tests -q` (392 passed, 14 failed: pre-existing/unrelated docs internal-link failures to missing `CLAUDE.md`, `docs/missions/data/models.md`, and `.specify/memory/constitution.md`)

## Runtime verification
- Local services were already running and healthy: `starlink-location` on :8000 and Grafana on :3000.
- `docker compose up -d` from this checkout could not recreate the stack because the existing dev stack owns the fixed container names.
- Grafana's running container is mounted from `/home/brian/.hermes/kanban/worktrees/starlink-dashboard-dev/monitoring/grafana/provisioning`, so I imported a temporary dashboard copy through the Grafana API from this branch's `fullscreen-overview.json`, verified the served dashboard JSON contained the split E/F and E_EAST/F_EAST targets/layers, opened it in Grafana, and then deleted the temporary dashboard.

Closes #59
