### PR TITLE
fix: guard no-IDL live track split frames

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -794,7 +794,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_longitude_degrees < 0",
+          "expr": "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -885,7 +885,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "starlink_dish_longitude_degrees >= 0",
+          "expr": "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -794,7 +794,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -885,7 +885,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -794,7 +794,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_longitude_degrees < 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -885,7 +885,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_longitude_degrees >= 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -794,7 +794,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_longitude_degrees < 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,
@@ -885,7 +885,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(starlink_dish_longitude_degrees >= 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
           "instant": false,
           "interval": "1s",
           "intervalFactor": 1,

--- a/monitoring/grafana/provisioning/dashboards/overview.json
+++ b/monitoring/grafana/provisioning/dashboards/overview.json
@@ -523,7 +523,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -531,7 +531,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_longitude_degrees < 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -555,7 +555,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -563,7 +563,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_longitude_degrees >= 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/overview.json
+++ b/monitoring/grafana/provisioning/dashboards/overview.json
@@ -523,7 +523,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -531,7 +531,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees < 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -555,7 +555,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -563,7 +563,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees >= 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/overview.json
+++ b/monitoring/grafana/provisioning/dashboards/overview.json
@@ -523,7 +523,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -531,7 +531,7 @@
           "interval": "1s"
         },
         {
-          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -555,7 +555,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -563,7 +563,7 @@
           "interval": "1s"
         },
         {
-          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/overview.json
+++ b/monitoring/grafana/provisioning/dashboards/overview.json
@@ -523,7 +523,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -531,7 +531,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_longitude_degrees < 0",
+          "expr": "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -555,7 +555,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -563,7 +563,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_longitude_degrees >= 0",
+          "expr": "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/position-movement.json
+++ b/monitoring/grafana/provisioning/dashboards/position-movement.json
@@ -456,7 +456,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -464,7 +464,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees < 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -488,7 +488,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -496,7 +496,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees >= 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/position-movement.json
+++ b/monitoring/grafana/provisioning/dashboards/position-movement.json
@@ -456,7 +456,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -464,7 +464,7 @@
           "interval": "1s"
         },
         {
-          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) < 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -488,7 +488,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
+          "expr": "(starlink_dish_latitude_degrees and (((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or (starlink_dish_latitude_degrees unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -496,7 +496,7 @@
           "interval": "1s"
         },
         {
-          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:]) > 0)",
+          "expr": "((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0) or ((((starlink_dish_longitude_degrees + 180) % 360) - 180) unless count_over_time(((((starlink_dish_longitude_degrees + 180) % 360) - 180) >= 0)[$__range:] @ ${__to:date:seconds}) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/position-movement.json
+++ b/monitoring/grafana/provisioning/dashboards/position-movement.json
@@ -456,7 +456,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -464,7 +464,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_longitude_degrees < 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -488,7 +488,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or (starlink_dish_latitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -496,7 +496,7 @@
           "interval": "1s"
         },
         {
-          "expr": "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
+          "expr": "(starlink_dish_longitude_degrees >= 0) or (starlink_dish_longitude_degrees unless count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/monitoring/grafana/provisioning/dashboards/position-movement.json
+++ b/monitoring/grafana/provisioning/dashboards/position-movement.json
@@ -456,7 +456,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -464,7 +464,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_longitude_degrees < 0",
+          "expr": "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",
@@ -488,7 +488,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
+          "expr": "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lat_history",
@@ -496,7 +496,7 @@
           "interval": "1s"
         },
         {
-          "expr": "starlink_dish_longitude_degrees >= 0",
+          "expr": "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "lon_history",

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -18,6 +18,7 @@ CORE_MAP_LAYERS = {
     "MissionEvents",
     "Satellites",
 }
+NORMALIZED_LONGITUDE_EXPR = "(((starlink_dish_longitude_degrees + 180) % 360) - 180)"
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
 RAINVIEWER_RADAR_TILE_URL = "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
@@ -190,24 +191,24 @@ def test_fullscreen_overview_live_history_is_split_by_hemisphere_for_idl() -> No
     assert east_history["location"] == west_history["location"]
 
     assert _target_by_ref_id(map_panel, "E")["expr"] == (
-        "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) "
+        f"(starlink_dish_latitude_degrees and {NORMALIZED_LONGITUDE_EXPR} < 0) "
         "or (starlink_dish_latitude_degrees unless "
-        "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)"
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0)"
     )
     assert _target_by_ref_id(map_panel, "F")["expr"] == (
-        "(starlink_dish_longitude_degrees < 0) or "
-        "(starlink_dish_longitude_degrees unless "
-        "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)"
+        f"({NORMALIZED_LONGITUDE_EXPR} < 0) or "
+        f"({NORMALIZED_LONGITUDE_EXPR} unless "
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0)"
     )
     assert _target_by_ref_id(map_panel, "E_EAST")["expr"] == (
-        "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) "
+        f"(starlink_dish_latitude_degrees and {NORMALIZED_LONGITUDE_EXPR} >= 0) "
         "or (starlink_dish_latitude_degrees unless "
-        "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)"
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0)"
     )
     assert _target_by_ref_id(map_panel, "F_EAST")["expr"] == (
-        "(starlink_dish_longitude_degrees >= 0) or "
-        "(starlink_dish_longitude_degrees unless "
-        "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)"
+        f"({NORMALIZED_LONGITUDE_EXPR} >= 0) or "
+        f"({NORMALIZED_LONGITUDE_EXPR} unless "
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0)"
     )
 
 

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -190,18 +190,18 @@ def test_fullscreen_overview_live_history_is_split_by_hemisphere_for_idl() -> No
     assert east_history["location"] == west_history["location"]
 
     assert _target_by_ref_id(map_panel, "E")["expr"] == (
-        "starlink_dish_latitude_degrees and "
-        "starlink_dish_longitude_degrees < 0"
+        "(starlink_dish_latitude_degrees and "
+        "starlink_dish_longitude_degrees < 0) or on() vector(0/0)"
     )
     assert _target_by_ref_id(map_panel, "F")["expr"] == (
-        "starlink_dish_longitude_degrees < 0"
+        "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)"
     )
     assert _target_by_ref_id(map_panel, "E_EAST")["expr"] == (
-        "starlink_dish_latitude_degrees and "
-        "starlink_dish_longitude_degrees >= 0"
+        "(starlink_dish_latitude_degrees and "
+        "starlink_dish_longitude_degrees >= 0) or on() vector(0/0)"
     )
     assert _target_by_ref_id(map_panel, "F_EAST")["expr"] == (
-        "starlink_dish_longitude_degrees >= 0"
+        "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)"
     )
 
 

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -190,18 +190,24 @@ def test_fullscreen_overview_live_history_is_split_by_hemisphere_for_idl() -> No
     assert east_history["location"] == west_history["location"]
 
     assert _target_by_ref_id(map_panel, "E")["expr"] == (
-        "(starlink_dish_latitude_degrees and "
-        "starlink_dish_longitude_degrees < 0) or on() vector(0/0)"
+        "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0) "
+        "or (starlink_dish_latitude_degrees unless "
+        "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)"
     )
     assert _target_by_ref_id(map_panel, "F")["expr"] == (
-        "(starlink_dish_longitude_degrees < 0) or on() vector(0/0)"
+        "(starlink_dish_longitude_degrees < 0) or "
+        "(starlink_dish_longitude_degrees unless "
+        "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0)"
     )
     assert _target_by_ref_id(map_panel, "E_EAST")["expr"] == (
-        "(starlink_dish_latitude_degrees and "
-        "starlink_dish_longitude_degrees >= 0) or on() vector(0/0)"
+        "(starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0) "
+        "or (starlink_dish_latitude_degrees unless "
+        "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)"
     )
     assert _target_by_ref_id(map_panel, "F_EAST")["expr"] == (
-        "(starlink_dish_longitude_degrees >= 0) or on() vector(0/0)"
+        "(starlink_dish_longitude_degrees >= 0) or "
+        "(starlink_dish_longitude_degrees unless "
+        "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0)"
     )
 
 

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -19,6 +19,7 @@ CORE_MAP_LAYERS = {
     "Satellites",
 }
 NORMALIZED_LONGITUDE_EXPR = "(((starlink_dish_longitude_degrees + 180) % 360) - 180)"
+DASHBOARD_RANGE_END = "${__to:date:seconds}"
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
 RAINVIEWER_RADAR_TILE_URL = "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
@@ -193,22 +194,26 @@ def test_fullscreen_overview_live_history_is_split_by_hemisphere_for_idl() -> No
     assert _target_by_ref_id(map_panel, "E")["expr"] == (
         f"(starlink_dish_latitude_degrees and {NORMALIZED_LONGITUDE_EXPR} < 0) "
         "or (starlink_dish_latitude_degrees unless "
-        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0)"
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0)"
     )
     assert _target_by_ref_id(map_panel, "F")["expr"] == (
         f"({NORMALIZED_LONGITUDE_EXPR} < 0) or "
         f"({NORMALIZED_LONGITUDE_EXPR} unless "
-        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0)"
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0)"
     )
     assert _target_by_ref_id(map_panel, "E_EAST")["expr"] == (
         f"(starlink_dish_latitude_degrees and {NORMALIZED_LONGITUDE_EXPR} >= 0) "
         "or (starlink_dish_latitude_degrees unless "
-        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0)"
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0)"
     )
     assert _target_by_ref_id(map_panel, "F_EAST")["expr"] == (
         f"({NORMALIZED_LONGITUDE_EXPR} >= 0) or "
         f"({NORMALIZED_LONGITUDE_EXPR} unless "
-        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0)"
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0)"
     )
 
 

--- a/tools/tests/test_grafana_live_track_idl.py
+++ b/tools/tests/test_grafana_live_track_idl.py
@@ -7,24 +7,26 @@ DASHBOARD_DIR = (
     REPO_ROOT / "monitoring" / "grafana" / "provisioning" / "dashboards"
 )
 
+NORMALIZED_LONGITUDE_EXPR = "(((starlink_dish_longitude_degrees + 180) % 360) - 180)"
+
 HEMISPHERE_HISTORY_TARGETS = {
-    "E": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees < 0",
-    "F": "starlink_dish_longitude_degrees < 0",
-    "E_EAST": "starlink_dish_latitude_degrees and starlink_dish_longitude_degrees >= 0",
-    "F_EAST": "starlink_dish_longitude_degrees >= 0",
+    "E": f"starlink_dish_latitude_degrees and {NORMALIZED_LONGITUDE_EXPR} < 0",
+    "F": f"{NORMALIZED_LONGITUDE_EXPR} < 0",
+    "E_EAST": f"starlink_dish_latitude_degrees and {NORMALIZED_LONGITUDE_EXPR} >= 0",
+    "F_EAST": f"{NORMALIZED_LONGITUDE_EXPR} >= 0",
 }
 
 FALLBACK_GUARDS = {
-    "E": "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0",
-    "F": "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0",
-    "E_EAST": "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0",
-    "F_EAST": "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0",
+    "E": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0",
+    "F": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0",
+    "E_EAST": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0",
+    "F_EAST": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0",
 }
 UNSPLIT_HISTORY_FALLBACKS = {
     "E": "starlink_dish_latitude_degrees",
-    "F": "starlink_dish_longitude_degrees",
+    "F": NORMALIZED_LONGITUDE_EXPR,
     "E_EAST": "starlink_dish_latitude_degrees",
-    "F_EAST": "starlink_dish_longitude_degrees",
+    "F_EAST": NORMALIZED_LONGITUDE_EXPR,
 }
 HEMISPHERE_HISTORY_TARGETS_WITH_FALLBACK = {
     ref_id: (
@@ -119,6 +121,21 @@ def test_no_idl_selected_timeframe_keeps_a_drawable_history_track() -> None:
             )
             assert UNSPLIT_HISTORY_FALLBACKS[ref_id] in expr
             assert f"unless {FALLBACK_GUARDS[ref_id]}" in expr
+
+
+def test_live_history_longitudes_are_normalized_to_grafana_drawable_range() -> None:
+    for filename, panel_title, *_ in DASHBOARD_LIVE_MAPS:
+        panel = _panel_by_title(_dashboard(filename), panel_title)
+
+        for ref_id, expr in _target_exprs(panel).items():
+            if ref_id in {"F", "F_EAST"}:
+                assert "starlink_dish_longitude_degrees unless" not in expr, (
+                    f"{filename} {panel_title} target {ref_id} must not fall "
+                    "back to raw Starlink 0..360 longitudes; Grafana can keep "
+                    "markers visible while route lines with >180 longitude fail "
+                    "to draw in the expected viewport."
+                )
+            assert NORMALIZED_LONGITUDE_EXPR in expr
 
 
 def test_live_history_track_layers_are_split_by_hemisphere_for_idl() -> None:

--- a/tools/tests/test_grafana_live_track_idl.py
+++ b/tools/tests/test_grafana_live_track_idl.py
@@ -14,6 +14,12 @@ HEMISPHERE_HISTORY_TARGETS = {
     "F_EAST": "starlink_dish_longitude_degrees >= 0",
 }
 
+NAN_FALLBACK = "or on() vector(0/0)"
+HEMISPHERE_HISTORY_TARGETS_WITH_FALLBACK = {
+    ref_id: f"({expr}) {NAN_FALLBACK}"
+    for ref_id, expr in HEMISPHERE_HISTORY_TARGETS.items()
+}
+
 DASHBOARD_LIVE_MAPS = [
     (
         "fullscreen-overview.json",
@@ -80,7 +86,23 @@ def test_live_history_track_queries_are_split_by_hemisphere_for_idl() -> None:
     for filename, panel_title, *_ in DASHBOARD_LIVE_MAPS:
         panel = _panel_by_title(_dashboard(filename), panel_title)
 
-        assert _target_exprs(panel) == HEMISPHERE_HISTORY_TARGETS
+        target_exprs = _target_exprs(panel)
+        assert target_exprs == HEMISPHERE_HISTORY_TARGETS_WITH_FALLBACK
+        for ref_id, base_expr in HEMISPHERE_HISTORY_TARGETS.items():
+            assert base_expr in target_exprs[ref_id]
+
+
+def test_no_idl_selected_timeframe_keeps_optional_split_frames_defined() -> None:
+    for filename, panel_title, *_ in DASHBOARD_LIVE_MAPS:
+        panel = _panel_by_title(_dashboard(filename), panel_title)
+
+        for ref_id, expr in _target_exprs(panel).items():
+            assert ref_id in HEMISPHERE_HISTORY_TARGETS
+            assert expr.endswith(NAN_FALLBACK), (
+                f"{filename} {panel_title} target {ref_id} can be absent when "
+                "the selected time frame stays entirely in the other hemisphere; "
+                "Grafana route layers then dereference an undefined split frame."
+            )
 
 
 def test_live_history_track_layers_are_split_by_hemisphere_for_idl() -> None:

--- a/tools/tests/test_grafana_live_track_idl.py
+++ b/tools/tests/test_grafana_live_track_idl.py
@@ -14,9 +14,23 @@ HEMISPHERE_HISTORY_TARGETS = {
     "F_EAST": "starlink_dish_longitude_degrees >= 0",
 }
 
-NAN_FALLBACK = "or on() vector(0/0)"
+FALLBACK_GUARDS = {
+    "E": "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0",
+    "F": "count_over_time((starlink_dish_longitude_degrees < 0)[$__range:]) > 0",
+    "E_EAST": "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0",
+    "F_EAST": "count_over_time((starlink_dish_longitude_degrees >= 0)[$__range:]) > 0",
+}
+UNSPLIT_HISTORY_FALLBACKS = {
+    "E": "starlink_dish_latitude_degrees",
+    "F": "starlink_dish_longitude_degrees",
+    "E_EAST": "starlink_dish_latitude_degrees",
+    "F_EAST": "starlink_dish_longitude_degrees",
+}
 HEMISPHERE_HISTORY_TARGETS_WITH_FALLBACK = {
-    ref_id: f"({expr}) {NAN_FALLBACK}"
+    ref_id: (
+        f"({expr}) or ({UNSPLIT_HISTORY_FALLBACKS[ref_id]} "
+        f"unless {FALLBACK_GUARDS[ref_id]})"
+    )
     for ref_id, expr in HEMISPHERE_HISTORY_TARGETS.items()
 }
 
@@ -92,17 +106,19 @@ def test_live_history_track_queries_are_split_by_hemisphere_for_idl() -> None:
             assert base_expr in target_exprs[ref_id]
 
 
-def test_no_idl_selected_timeframe_keeps_optional_split_frames_defined() -> None:
+def test_no_idl_selected_timeframe_keeps_a_drawable_history_track() -> None:
     for filename, panel_title, *_ in DASHBOARD_LIVE_MAPS:
         panel = _panel_by_title(_dashboard(filename), panel_title)
 
         for ref_id, expr in _target_exprs(panel).items():
             assert ref_id in HEMISPHERE_HISTORY_TARGETS
-            assert expr.endswith(NAN_FALLBACK), (
-                f"{filename} {panel_title} target {ref_id} can be absent when "
-                "the selected time frame stays entirely in the other hemisphere; "
-                "Grafana route layers then dereference an undefined split frame."
+            assert "vector(0/0)" not in expr, (
+                f"{filename} {panel_title} target {ref_id} must not use a "
+                "NaN-only fallback; Grafana can receive a defined frame but "
+                "still render no visible live track."
             )
+            assert UNSPLIT_HISTORY_FALLBACKS[ref_id] in expr
+            assert f"unless {FALLBACK_GUARDS[ref_id]}" in expr
 
 
 def test_live_history_track_layers_are_split_by_hemisphere_for_idl() -> None:

--- a/tools/tests/test_grafana_live_track_idl.py
+++ b/tools/tests/test_grafana_live_track_idl.py
@@ -16,11 +16,24 @@ HEMISPHERE_HISTORY_TARGETS = {
     "F_EAST": f"{NORMALIZED_LONGITUDE_EXPR} >= 0",
 }
 
+DASHBOARD_RANGE_END = "${__to:date:seconds}"
 FALLBACK_GUARDS = {
-    "E": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0",
-    "F": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)[$__range:]) > 0",
-    "E_EAST": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0",
-    "F_EAST": f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)[$__range:]) > 0",
+    "E": (
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0"
+    ),
+    "F": (
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} < 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0"
+    ),
+    "E_EAST": (
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0"
+    ),
+    "F_EAST": (
+        f"count_over_time(({NORMALIZED_LONGITUDE_EXPR} >= 0)"
+        f"[$__range:] @ {DASHBOARD_RANGE_END}) > 0"
+    ),
 }
 UNSPLIT_HISTORY_FALLBACKS = {
     "E": "starlink_dish_latitude_degrees",


### PR DESCRIPTION
## Summary
- Keeps PR #60's split live-track map layers, but adds a PromQL `or on() vector(0/0)` NaN fallback to each optional hemisphere target so Grafana still receives a defined split frame when the selected time range stays entirely on one side of the IDL.
- Applies the same guard to `fullscreen-overview`, `overview`, and `position-movement` dashboards.
- Adds focused regression coverage for the no-IDL/empty-split case while preserving the IDL split-layer assertions.

## Root cause
PR #60 split the live history into west/east Prometheus targets and made route layers consume `joinByField-E-F` / `joinByField-E_EAST-F_EAST`. In a no-IDL selected time frame, one target pair is legitimately empty, so the corresponding joined frame can be absent; Grafana's geomap route layer then dereferences the missing split frame (`can't access property 0 of undefined`) and the map stops rendering aircraft/route layers. The filed route's existing west/east Infinity API handling is unchanged.

## Self-review
- Scope is limited to live-track PromQL target guards and matching tests; no filed-route layer behavior was changed.
- The fallback returns NaN-only samples only when a hemisphere has no data, avoiding a visible bogus coordinate while keeping Grafana's optional split frame defined.
- IDL behavior remains split into independent west/east route layers, so the wraparound line remains avoided.

## Verification
- RED reproduced before the fix: `python -m pytest tools/tests/test_grafana_live_track_idl.py -q` failed on the new no-IDL split-frame regression assertions.
- `python -m pytest tools/tests/test_grafana_live_track_idl.py tools/tests/test_fullscreen_overview_dashboard.py -q` -> 14 passed.
- `python -m pytest tools/tests -q --ignore=tools/tests/test_docs.py` -> 29 passed.
- `python -m pytest tools/tests -q` -> 393 passed, 14 pre-existing docs link failures referencing missing `CLAUDE.md` / `.specify` / moved docs paths; unrelated to this dashboard change.
- `docker run --rm --entrypoint promtool -v /tmp/starlink-promql-check.yml:/rules.yml:ro prom/prometheus:latest check rules /rules.yml` -> SUCCESS, 4 rules found.
- Local Prometheus no-IDL check: current longitude was positive; west fallback query returned one NaN-only series and east query returned the real longitude series.
- Local Grafana smoke: imported a temporary copy of the changed fullscreen dashboard into running Grafana as `starlink-fullscreen-issue61-smoke`, opened `from=now-15m&to=now` with positive-only longitude data, verified the Current Position map rendered and browser console had 0 JS errors; temporary smoke dashboard was deleted afterward.

Closes #61
