### PR TITLE
Add ground entry point metrics and exports

### DIFF
--- a/backend/starlink-location/app/core/metrics/__init__.py
+++ b/backend/starlink-location/app/core/metrics/__init__.py
@@ -17,6 +17,10 @@ from app.core.metrics.prometheus_metrics import (
     starlink_network_throughput_down_mbps_current,
     starlink_network_throughput_up_mbps_current,
     starlink_network_packet_loss_percent,
+    starlink_ground_entry_point_latitude_degrees,
+    starlink_ground_entry_point_longitude_degrees,
+    starlink_ground_entry_point_location,
+    starlink_ground_entry_point_info,
     # Network metrics - Histograms
     starlink_network_latency_ms,
     starlink_network_throughput_down_mbps,
@@ -103,6 +107,10 @@ __all__ = [
     "starlink_network_throughput_down_mbps_current",
     "starlink_network_throughput_up_mbps_current",
     "starlink_network_packet_loss_percent",
+    "starlink_ground_entry_point_latitude_degrees",
+    "starlink_ground_entry_point_longitude_degrees",
+    "starlink_ground_entry_point_location",
+    "starlink_ground_entry_point_info",
     # Network metrics - Histograms
     "starlink_network_latency_ms",
     "starlink_network_throughput_down_mbps",

--- a/backend/starlink-location/app/core/metrics/prometheus_metrics.py
+++ b/backend/starlink-location/app/core/metrics/prometheus_metrics.py
@@ -131,6 +131,32 @@ starlink_network_packet_loss_percent = Gauge(
     registry=REGISTRY,
 )
 
+starlink_ground_entry_point_latitude_degrees = Gauge(
+    "starlink_ground_entry_point_latitude_degrees",
+    "Ground entry point latitude in decimal degrees",
+    registry=REGISTRY,
+)
+
+starlink_ground_entry_point_longitude_degrees = Gauge(
+    "starlink_ground_entry_point_longitude_degrees",
+    "Ground entry point longitude in decimal degrees",
+    registry=REGISTRY,
+)
+
+starlink_ground_entry_point_location = Gauge(
+    "starlink_ground_entry_point_location",
+    "Ground entry point location with labels for Grafana geomap display",
+    labelnames=["lat", "lon", "city", "country", "ip"],
+    registry=REGISTRY,
+)
+
+starlink_ground_entry_point_info = Gauge(
+    "starlink_ground_entry_point_info",
+    "Ground entry point identity information",
+    labelnames=["city", "country", "ip"],
+    registry=REGISTRY,
+)
+
 # ============================================================================
 # Network metrics - Histograms for percentile analysis
 # ============================================================================

--- a/backend/starlink-location/app/mission/exporter/__init__.py
+++ b/backend/starlink-location/app/mission/exporter/__init__.py
@@ -23,6 +23,8 @@ from app.mission.exporter.__main__ import (
     generate_timeline_export,
     _generate_route_map,
     _segment_rows,
+    GroundEntryPoint,
+    get_cached_ground_entry_point,
 )
 from app.mission.exporter.transport_utils import (
     TRANSPORT_DISPLAY,
@@ -60,6 +62,8 @@ __all__ = [
     "generate_timeline_export",
     "_generate_route_map",
     "_segment_rows",
+    "GroundEntryPoint",
+    "get_cached_ground_entry_point",
     "TRANSPORT_DISPLAY",
     "STATE_COLUMNS",
     "Transport",

--- a/backend/starlink-location/app/mission/exporter/__main__.py
+++ b/backend/starlink-location/app/mission/exporter/__main__.py
@@ -68,6 +68,10 @@ from app.mission.exporter.pptx_styling import (
 )
 from app.services.poi_manager import POIManager
 from app.services.route_manager import RouteManager
+from app.services.ground_entry_point import (
+    GroundEntryPoint,
+    get_cached_ground_entry_point,
+)
 from app.mission.timeline_builder.calculator import route_with_adjusted_departure
 
 logger = logging.getLogger(__name__)
@@ -1340,6 +1344,8 @@ def _segment_rows(
     export_timeline = timeline.model_copy(deep=True)
     normalize_call_availability_timeline(export_timeline)
     mission_start = mission_start_timestamp(export_timeline)
+    ground_entry_point = get_cached_ground_entry_point()
+    ground_entry_values = _ground_entry_export_values(ground_entry_point)
     rows: list[tuple[datetime, int, dict]] = []
 
     for idx, segment in enumerate(export_timeline.segments, start=1):
@@ -1391,6 +1397,7 @@ def _segment_rows(
             "Systems Affected": ", ".join(systems_affected),
             "Reasons": _compact_reason_label(segment),
             "Notes / Source Events": notes_and_sources,
+            **ground_entry_values,
             "Metadata": (
                 json.dumps(segment.metadata, sort_keys=True) if segment.metadata else ""
             ),
@@ -1417,6 +1424,11 @@ def _segment_rows(
         "Systems Affected",
         "Reasons",
         "Notes / Source Events",
+        "Ground Entry City",
+        "Ground Entry Country",
+        "Ground Entry IP",
+        "Ground Entry Latitude",
+        "Ground Entry Longitude",
         "Metadata",
     ]
 
@@ -1424,6 +1436,27 @@ def _segment_rows(
         row for _, _, row in sorted(rows, key=lambda item: (item[0], item[1]))
     ]
     return pd.DataFrame.from_records(ordered_records, columns=columns)
+
+
+def _ground_entry_export_values(
+    entry_point: GroundEntryPoint | None,
+) -> dict[str, str | float]:
+    """Return CSV column values for the current ground entry point."""
+    if entry_point is None:
+        return {
+            "Ground Entry City": "",
+            "Ground Entry Country": "",
+            "Ground Entry IP": "",
+            "Ground Entry Latitude": "",
+            "Ground Entry Longitude": "",
+        }
+    return {
+        "Ground Entry City": entry_point.city,
+        "Ground Entry Country": entry_point.country,
+        "Ground Entry IP": entry_point.ip,
+        "Ground Entry Latitude": entry_point.latitude,
+        "Ground Entry Longitude": entry_point.longitude,
+    }
 
 
 def _advisory_rows(

--- a/backend/starlink-location/app/services/ground_entry_point.py
+++ b/backend/starlink-location/app/services/ground_entry_point.py
@@ -1,0 +1,137 @@
+"""Ground entry point discovery and Prometheus publication."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+import httpx
+
+from app.core.metrics.prometheus_metrics import (
+    starlink_ground_entry_point_info,
+    starlink_ground_entry_point_latitude_degrees,
+    starlink_ground_entry_point_location,
+    starlink_ground_entry_point_longitude_degrees,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class GroundEntryPoint:
+    """Public internet egress location used as a ground entry point proxy."""
+
+    ip: str
+    city: str
+    country: str
+    latitude: float
+    longitude: float
+
+    @property
+    def label(self) -> str:
+        """Return compact city/country display text for dashboards."""
+        parts = [part for part in (self.city, self.country) if part]
+        return ", ".join(parts) if parts else "Unknown"
+
+
+@lru_cache(maxsize=1)
+def get_cached_ground_entry_point() -> GroundEntryPoint | None:
+    """Resolve and cache the current public egress location.
+
+    The lookup intentionally fails closed: if public-IP or geolocation services
+    are unavailable, metrics and exports continue with empty ground-entry values
+    rather than delaying telemetry collection. Apparently even satellites must
+    occasionally wait for a website to answer.
+    """
+    return discover_ground_entry_point()
+
+
+def discover_ground_entry_point(
+    timeout_seconds: float = 5.0,
+) -> GroundEntryPoint | None:
+    """Discover the public egress IP and geolocate it with ipinfo.io."""
+    configured = _entry_point_from_environment()
+    if configured is not None:
+        return configured
+
+    try:
+        with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
+            ip = client.get("https://ifconfig.me/ip").text.strip()
+            if not ip:
+                return None
+            response = client.get(f"https://ipinfo.io/{ip}/json")
+            response.raise_for_status()
+            payload = response.json()
+    except Exception as exc:  # pragma: no cover - defensive network guard
+        logger.warning("Failed to discover ground entry point: %s", exc)
+        return None
+
+    loc = str(payload.get("loc") or "")
+    try:
+        latitude_raw, longitude_raw = loc.split(",", maxsplit=1)
+        latitude = float(latitude_raw)
+        longitude = float(longitude_raw)
+    except (TypeError, ValueError):
+        logger.warning("Ground entry point geolocation missing loc field")
+        return None
+
+    return GroundEntryPoint(
+        ip=str(payload.get("ip") or ip),
+        city=str(payload.get("city") or ""),
+        country=str(payload.get("country") or ""),
+        latitude=latitude,
+        longitude=longitude,
+    )
+
+
+def publish_ground_entry_point_metrics(entry_point: GroundEntryPoint | None) -> None:
+    """Publish ground entry point metrics for Grafana and Prometheus exports."""
+    if entry_point is None:
+        return
+
+    lat_label = f"{entry_point.latitude:.6g}"
+    lon_label = f"{entry_point.longitude:.6g}"
+    starlink_ground_entry_point_latitude_degrees.set(entry_point.latitude)
+    starlink_ground_entry_point_longitude_degrees.set(entry_point.longitude)
+    starlink_ground_entry_point_location.labels(
+        lat=lat_label,
+        lon=lon_label,
+        city=entry_point.city,
+        country=entry_point.country,
+        ip=entry_point.ip,
+    ).set(1)
+    starlink_ground_entry_point_info.labels(
+        city=entry_point.city,
+        country=entry_point.country,
+        ip=entry_point.ip,
+    ).set(1)
+
+
+def refresh_ground_entry_point_metrics() -> GroundEntryPoint | None:
+    """Resolve the cached ground entry point and publish its metrics."""
+    entry_point = get_cached_ground_entry_point()
+    publish_ground_entry_point_metrics(entry_point)
+    return entry_point
+
+
+def _entry_point_from_environment() -> GroundEntryPoint | None:
+    """Build a ground entry point from explicit environment overrides."""
+    lat_raw = os.getenv("STARLINK_GROUND_ENTRY_LATITUDE")
+    lon_raw = os.getenv("STARLINK_GROUND_ENTRY_LONGITUDE")
+    if not (lat_raw and lon_raw):
+        return None
+    try:
+        latitude = float(lat_raw)
+        longitude = float(lon_raw)
+    except ValueError:
+        logger.warning("Invalid STARLINK_GROUND_ENTRY latitude/longitude override")
+        return None
+    return GroundEntryPoint(
+        ip=os.getenv("STARLINK_GROUND_ENTRY_IP", ""),
+        city=os.getenv("STARLINK_GROUND_ENTRY_CITY", ""),
+        country=os.getenv("STARLINK_GROUND_ENTRY_COUNTRY", ""),
+        latitude=latitude,
+        longitude=longitude,
+    )

--- a/backend/starlink-location/main.py
+++ b/backend/starlink-location/main.py
@@ -38,6 +38,7 @@ from app.live.coordinator import LiveCoordinator
 from app.simulation.coordinator import SimulationCoordinator
 from app.services.poi_manager import POIManager
 from app.services.route_manager import RouteManager
+from app.services.ground_entry_point import refresh_ground_entry_point_metrics
 from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
 from app.core.limiter import limiter
@@ -84,6 +85,23 @@ async def startup_event():
 
         # Initialize coordinator based on configured mode
         active_mode = _simulation_config.mode
+
+        try:
+            entry_point = refresh_ground_entry_point_metrics()
+            if entry_point is not None:
+                logger.info_json(
+                    "Ground entry point discovered",
+                    extra_fields={
+                        "city": entry_point.city,
+                        "country": entry_point.country,
+                    },
+                )
+        except Exception as e:  # pragma: no cover - defensive startup guard
+            logger.warning_json(
+                "Failed to publish ground entry point metrics",
+                extra_fields={"error": str(e)},
+                exc_info=True,
+            )
 
         if _simulation_config.mode == "live":
             # Initialize LiveCoordinator for real terminal data

--- a/backend/starlink-location/tests/unit/test_ground_entry_point.py
+++ b/backend/starlink-location/tests/unit/test_ground_entry_point.py
@@ -1,0 +1,33 @@
+"""Tests for ground entry point discovery and metric formatting."""
+
+from __future__ import annotations
+
+from prometheus_client import generate_latest
+
+from app.core.metrics import REGISTRY
+from app.services.ground_entry_point import (
+    GroundEntryPoint,
+    publish_ground_entry_point_metrics,
+)
+
+
+def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -> None:
+    entry_point = GroundEntryPoint(
+        ip="203.0.113.10",
+        city="Omaha",
+        country="US",
+        latitude=41.2565,
+        longitude=-95.9345,
+    )
+
+    publish_ground_entry_point_metrics(entry_point)
+
+    output = generate_latest(REGISTRY).decode("utf-8")
+    assert "starlink_ground_entry_point_location" in output
+    assert 'city="Omaha"' in output
+    assert 'country="US"' in output
+    assert 'ip="203.0.113.10"' in output
+    assert 'lat="41.2565"' in output
+    assert 'lon="-95.9345"' in output
+    assert "starlink_ground_entry_point_latitude_degrees 41.2565" in output
+    assert "starlink_ground_entry_point_longitude_degrees -95.9345" in output

--- a/backend/starlink-location/tests/unit/test_mission_exporter.py
+++ b/backend/starlink-location/tests/unit/test_mission_exporter.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 import app.mission.exporter as mission_exporter
+import app.mission.exporter.__main__ as mission_exporter_main
 from app.mission.exporter import (
     ExportGenerationError,
     TimelineExportFormat,
@@ -122,6 +123,37 @@ class TestMissionTimelineExporters:
         assert "X-Band" in output
         assert "CommKa" in output
         assert "StarShield" in output
+
+    def test_generate_csv_includes_ground_entry_point_columns(
+        self, monkeypatch, mission, timeline
+    ):
+        monkeypatch.setattr(
+            mission_exporter_main,
+            "get_cached_ground_entry_point",
+            lambda: mission_exporter.GroundEntryPoint(
+                ip="203.0.113.10",
+                city="Omaha",
+                country="US",
+                latitude=41.2565,
+                longitude=-95.9345,
+            ),
+        )
+
+        df = mission_exporter._segment_rows(timeline, mission)
+
+        assert set(
+            [
+                "Ground Entry City",
+                "Ground Entry Country",
+                "Ground Entry IP",
+                "Ground Entry Latitude",
+                "Ground Entry Longitude",
+            ]
+        ) <= set(df.columns)
+        assert set(df["Ground Entry City"]) == {"Omaha"}
+        assert set(df["Ground Entry Country"]) == {"US"}
+        assert set(df["Ground Entry Latitude"]) == {41.2565}
+        assert set(df["Ground Entry Longitude"]) == {-95.9345}
 
     def test_generate_pptx_starts_with_zip_header(self, mission, timeline):
         output = generate_timeline_export(

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -658,6 +658,61 @@
           },
           {
             "config": {
+              "coords": {
+                "lat": "starlink_ground_entry_point_latitude_degrees",
+                "lon": "starlink_ground_entry_point_longitude_degrees"
+              },
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "fixed": "blue"
+                },
+                "opacity": 1,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "fixed": 12,
+                  "max": 20,
+                  "min": 5,
+                  "mode": "fixed"
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "text": {
+                  "fixed": "GEP",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 18,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "filterData": {
+              "id": "byRefId",
+              "options": "joinByField-GP_LAT-GP_LON"
+            },
+            "layer-tooltip": true,
+            "location": {
+              "latitude": "ground_entry_latitude",
+              "longitude": "ground_entry_longitude",
+              "mode": "coords"
+            },
+            "name": "Ground Entry Point",
+            "tooltip": true,
+            "type": "markers"
+          },
+          {
+            "config": {
               "showLegend": false,
               "style": {
                 "color": {
@@ -956,6 +1011,30 @@
             "method": "GET",
             "params": []
           }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "starlink_ground_entry_point_latitude_degrees",
+          "instant": true,
+          "interval": "1s",
+          "intervalFactor": 1,
+          "legendFormat": "ground_entry_latitude",
+          "refId": "GP_LAT"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "starlink_ground_entry_point_longitude_degrees",
+          "instant": true,
+          "interval": "1s",
+          "intervalFactor": 1,
+          "legendFormat": "ground_entry_longitude",
+          "refId": "GP_LON"
         }
       ],
       "title": "Current Position",
@@ -986,6 +1065,17 @@
           "filter": {
             "id": "byRefId",
             "options": "/^(?:E_EAST|F_EAST)$/"
+          },
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "inner"
+          }
+        },
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "/^(?:GP_LAT|GP_LON)$/"
           },
           "id": "joinByField",
           "options": {
@@ -1386,7 +1476,12 @@
       "id": 2,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "min", "max", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1529,7 +1624,12 @@
       "id": 3,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max", "min", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1559,6 +1659,69 @@
       ],
       "title": "Download/Upload Throughput",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 0,
+        "y": 26
+      },
+      "id": 205,
+      "options": {
+        "colorMode": "value",
+        "graphOrientation": "auto",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "starlink_ground_entry_point_info",
+          "instant": true,
+          "legendFormat": "{{city}}, {{country}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ground Entry Point",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -1630,14 +1793,18 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 18,
-        "x": 0,
+        "w": 9,
+        "x": 9,
         "y": 26
       },
       "id": 4,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull", "max", "mean"],
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1665,7 +1832,11 @@
   "preload": false,
   "refresh": "1s",
   "schemaVersion": 42,
-  "tags": ["starlink", "fullscreen", "overview"],
+  "tags": [
+    "starlink",
+    "fullscreen",
+    "overview"
+  ],
   "templating": {
     "list": [
       {
@@ -1719,7 +1890,14 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["1s", "5s", "10s", "30s", "1m", "5m"]
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
   },
   "timezone": "utc",
   "title": "Fullscreen Overview",

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DASHBOARD_PATH = (
     REPO_ROOT
@@ -19,7 +18,9 @@ CORE_MAP_LAYERS = {
     "Satellites",
 }
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
-RAINVIEWER_RADAR_TILE_URL = "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
+RAINVIEWER_RADAR_TILE_URL = (
+    "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
+)
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
 HCX_COMM_LAYER_SOURCES = {"commka.geojson"}
 EXPECTED_CLOCK_DEFAULTS = {
@@ -39,8 +40,7 @@ def _current_position_layers() -> list[dict]:
     geomap_panels = [
         panel
         for panel in dashboard["panels"]
-        if panel.get("type") == "geomap"
-        and panel.get("title") == "Current Position"
+        if panel.get("type") == "geomap" and panel.get("title") == "Current Position"
     ]
     assert len(geomap_panels) == 1
     return geomap_panels[0]["options"]["layers"]
@@ -61,9 +61,7 @@ def _clock_panels_by_title() -> dict[str, dict]:
 
 def _panel_by_title(title: str) -> dict:
     dashboard = _fullscreen_overview_dashboard()
-    panels = [
-        panel for panel in dashboard["panels"] if panel.get("title") == title
-    ]
+    panels = [panel for panel in dashboard["panels"] if panel.get("title") == title]
     assert len(panels) == 1
     return panels[0]
 
@@ -122,7 +120,9 @@ def test_fullscreen_overview_keeps_core_map_layers_visible_by_default() -> None:
         assert layers[layer_name].get("opacity", 1) > 0
 
 
-def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_layers() -> None:
+def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_layers() -> (
+    None
+):
     layers = _current_position_layers()
     layers_by_name = {layer["name"]: layer for layer in layers}
     radar_layer = layers_by_name[RADAR_LAYER_NAME]
@@ -190,4 +190,22 @@ def test_fullscreen_overview_gives_map_more_vertical_space() -> None:
     packet_loss_panel = _panel_by_title("Packet Loss")
 
     assert map_panel["gridPos"] == {"h": 23, "w": 18, "x": 0, "y": 3}
-    assert packet_loss_panel["gridPos"] == {"h": 4, "w": 18, "x": 0, "y": 26}
+    assert packet_loss_panel["gridPos"] == {"h": 4, "w": 9, "x": 9, "y": 26}
+
+
+def test_fullscreen_overview_splits_ground_entry_point_and_packet_loss_row() -> None:
+    ground_entry_panel = _panel_by_title("Ground Entry Point")
+    packet_loss_panel = _panel_by_title("Packet Loss")
+    layers_by_name = _layers_by_name()
+
+    assert ground_entry_panel["gridPos"] == {"h": 4, "w": 9, "x": 0, "y": 26}
+    assert packet_loss_panel["gridPos"] == {"h": 4, "w": 9, "x": 9, "y": 26}
+    assert "Ground Entry Point" in layers_by_name
+    assert (
+        layers_by_name["Ground Entry Point"]["config"]["coords"]["lat"]
+        == "starlink_ground_entry_point_latitude_degrees"
+    )
+    assert (
+        layers_by_name["Ground Entry Point"]["config"]["coords"]["lon"]
+        == "starlink_ground_entry_point_longitude_degrees"
+    )


### PR DESCRIPTION
## Summary
- add ground entry point discovery with Prometheus metrics for city/country/IP and coordinates
- show ground entry point data on the fullscreen overview dashboard alongside packet loss
- include ground entry point fields in mission CSV exports

## Verification
- pytest backend/starlink-location/tests/unit/test_ground_entry_point.py tools/tests/test_fullscreen_overview_dashboard.py backend/starlink-location/tests/unit/test_mission_exporter.py::TestMissionTimelineExporters::test_generate_csv_includes_ground_entry_point_columns -q
- pytest backend/starlink-location/tests/unit/test_metrics.py backend/starlink-location/tests/unit/test_mission_exporter.py backend/starlink-location/tests/unit/test_ground_entry_point.py tools/tests/test_fullscreen_overview_dashboard.py -q
- pytest backend/starlink-location/tests/unit -q
- docker compose build --no-cache
- curl -fsS http://localhost:8000/health

Closes #64