### PR TITLE
fix: read obstruction percentage from status payload

### DIFF
--- a/backend/starlink-location/app/live/client.py
+++ b/backend/starlink-location/app/live/client.py
@@ -348,10 +348,17 @@ class StarlinkClient:
                 packet_loss_percent=float(packet_loss),
             )
 
-            # Extract obstruction data
-            obstruction_fraction = obstruction.get("fraction_obstructed", 0.0)
+            # Extract obstruction data.
+            # starlink_grpc.status_data() returns fraction_obstructed on the
+            # general status dict, while the separate obstruction dict contains
+            # only wedge detail/validity metadata. Fall back to the obstruction
+            # dict for compatibility with older mocks.
+            obstruction_fraction = status.get(
+                "fraction_obstructed",
+                obstruction.get("fraction_obstructed", 0.0),
+            )
             obstruction_pct = ObstructionData(
-                obstruction_percent=float(obstruction_fraction * 100)
+                obstruction_percent=float((obstruction_fraction or 0.0) * 100)
             )
 
             # Extract environmental data

--- a/backend/starlink-location/tests/unit/test_starlink_client.py
+++ b/backend/starlink-location/tests/unit/test_starlink_client.py
@@ -356,8 +356,13 @@ class TestStarlinkClientTelemetry:
             "uplink_throughput_bps": 20e6,  # 20 Mbps
             "pop_ping_drop_rate": 0.01,  # 1%
             "temperature_c": 35.0,
+            "fraction_obstructed": 0.15,
         }
-        obstruction_dict = {"fraction_obstructed": 0.15}
+        obstruction_dict = {
+            "wedges_fraction_obstructed[]": [None] * 12,
+            "raw_wedges_fraction_obstructed[]": [None] * 12,
+            "valid_s": None,
+        }
         alert_dict = {}
         mock_status.return_value = (status_dict, obstruction_dict, alert_dict)
 


### PR DESCRIPTION
## Summary
- fix live telemetry obstruction parsing to read `fraction_obstructed` from the Starlink status payload
- keep a fallback to the obstruction-detail dict for older mocks/backward compatibility
- update the regression test to match the real `starlink_grpc.status_data()` shape so non-zero obstruction no longer collapses to 0

## Root cause
`starlink_grpc.status_data()` returns `fraction_obstructed` on the general status dict, while the separate obstruction dict only contains wedge/validity detail. The client was reading the wrong payload, so live obstruction percent defaulted to 0.

## Test Plan
- `pytest tests/unit/test_starlink_client.py::TestStarlinkClientTelemetry::test_get_telemetry_success tests/unit/test_live_coordinator.py tests/unit/test_metrics.py tests/unit/test_metrics_export.py tests/integration/test_status.py tests/integration/test_metrics_endpoint.py -q`
- `pytest tests/unit -q`
- `docker compose down && docker compose build --no-cache`
- `docker run --rm --name starlink-location-verification --env-file .env -p 18000:8000 starlink-dashboard-starlink-location:latest`
- `curl -fsS http://localhost:18000/health`

Closes #63.
