### PR TITLE
fix: include GEP fields in telemetry CSV export

### DIFF
--- a/backend/starlink-location/app/api/export/csv_export.py
+++ b/backend/starlink-location/app/api/export/csv_export.py
@@ -13,6 +13,7 @@ from app.core.logging import get_logger
 from .prometheus import (
     EXPORT_METRICS,
     calculate_step,
+    export_columns,
     query_all_metrics,
 )
 
@@ -21,10 +22,10 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 # CSV column headers
-CSV_COLUMNS = ["timestamp"] + [col for _, col in EXPORT_METRICS]
+CSV_COLUMNS = ["timestamp", *export_columns()]
 
 
-def generate_csv(data_by_timestamp: dict[float, dict[str, float]]) -> str:
+def generate_csv(data_by_timestamp: dict[float, dict[str, float | str]]) -> str:
     """Generate CSV content from metric data.
 
     Args:
@@ -42,9 +43,13 @@ def generate_csv(data_by_timestamp: dict[float, dict[str, float]]) -> str:
     # Write data rows sorted by timestamp
     for ts in sorted(data_by_timestamp.keys()):
         row_data = data_by_timestamp[ts]
-        row = [datetime.utcfromtimestamp(ts).isoformat() + "Z"]
-        for _, col in EXPORT_METRICS:
-            row.append(row_data.get(col, ""))
+        row: list[object] = [datetime.utcfromtimestamp(ts).isoformat() + "Z"]
+        for metric in EXPORT_METRICS:
+            if metric.column:
+                row.append(row_data.get(metric.column, ""))
+            if metric.label_columns:
+                for column_name in metric.label_columns.values():
+                    row.append(row_data.get(column_name, ""))
         writer.writerow(row)
 
     return output.getvalue()

--- a/backend/starlink-location/app/api/export/prometheus.py
+++ b/backend/starlink-location/app/api/export/prometheus.py
@@ -1,8 +1,9 @@
 """Prometheus HTTP API client for querying historical metrics."""
 
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 
@@ -13,20 +14,61 @@ logger = get_logger(__name__)
 # Prometheus URL - internal docker network
 PROMETHEUS_URL = os.getenv("PROMETHEUS_URL", "http://prometheus:9090")
 
+
+@dataclass(frozen=True)
+class ExportMetric:
+    """Prometheus metric to include in historical CSV exports."""
+
+    metric: str
+    column: str | None = None
+    label_columns: dict[str, str] | None = None
+
+
 # Metrics to export
 EXPORT_METRICS = [
-    ("starlink_dish_latitude_degrees", "latitude"),
-    ("starlink_dish_longitude_degrees", "longitude"),
-    ("starlink_dish_altitude_feet", "altitude_feet"),
-    ("starlink_dish_speed_knots", "speed_knots"),
-    ("starlink_dish_heading_degrees", "heading_degrees"),
-    ("starlink_network_latency_ms_current", "latency_ms"),
-    ("starlink_network_throughput_down_mbps_current", "throughput_down_mbps"),
-    ("starlink_network_throughput_up_mbps_current", "throughput_up_mbps"),
-    ("starlink_network_packet_loss_percent", "packet_loss_percent"),
-    ("starlink_dish_obstruction_percent", "obstruction_percent"),
-    ("starlink_signal_quality_percent", "signal_quality_percent"),
+    ExportMetric("starlink_dish_latitude_degrees", "latitude"),
+    ExportMetric("starlink_dish_longitude_degrees", "longitude"),
+    ExportMetric("starlink_dish_altitude_feet", "altitude_feet"),
+    ExportMetric("starlink_dish_speed_knots", "speed_knots"),
+    ExportMetric("starlink_dish_heading_degrees", "heading_degrees"),
+    ExportMetric("starlink_network_latency_ms_current", "latency_ms"),
+    ExportMetric(
+        "starlink_network_throughput_down_mbps_current", "throughput_down_mbps"
+    ),
+    ExportMetric(
+        "starlink_network_throughput_up_mbps_current", "throughput_up_mbps"
+    ),
+    ExportMetric("starlink_network_packet_loss_percent", "packet_loss_percent"),
+    ExportMetric("starlink_dish_obstruction_percent", "obstruction_percent"),
+    ExportMetric("starlink_signal_quality_percent", "signal_quality_percent"),
+    ExportMetric(
+        "starlink_ground_entry_point_latitude_degrees",
+        "ground_entry_latitude",
+    ),
+    ExportMetric(
+        "starlink_ground_entry_point_longitude_degrees",
+        "ground_entry_longitude",
+    ),
+    ExportMetric(
+        "starlink_ground_entry_point_location",
+        label_columns={
+            "city": "ground_entry_city",
+            "country": "ground_entry_country",
+            "ip": "ground_entry_ip",
+        },
+    ),
 ]
+
+
+def export_columns() -> list[str]:
+    """Return ordered CSV columns for all configured export metrics."""
+    columns: list[str] = []
+    for metric in EXPORT_METRICS:
+        if metric.column:
+            columns.append(metric.column)
+        if metric.label_columns:
+            columns.extend(metric.label_columns.values())
+    return columns
 
 
 def calculate_step(start: datetime, end: datetime, step: Optional[int] = None) -> int:
@@ -62,7 +104,7 @@ async def query_metric_range(
     start: datetime,
     end: datetime,
     step: int,
-) -> list[tuple[float, float]]:
+) -> list[dict[str, Any]]:
     """Query Prometheus for a metric over a time range.
 
     Args:
@@ -72,7 +114,7 @@ async def query_metric_range(
         step: Step interval in seconds
 
     Returns:
-        List of (timestamp, value) tuples
+        Raw Prometheus result series for the requested metric
     """
     # Format timestamps for Prometheus (RFC3339 or Unix timestamp)
     # Convert to UTC and use Unix timestamps to avoid timezone issues
@@ -108,20 +150,14 @@ async def query_metric_range(
         )
         return []
 
-    results = data.get("data", {}).get("result", [])
-    if not results:
-        return []
-
-    # Extract values from first result (should only be one for gauge metrics)
-    values = results[0].get("values", [])
-    return [(float(ts), float(val)) for ts, val in values]
+    return data.get("data", {}).get("result", [])
 
 
 async def query_all_metrics(
     start: datetime,
     end: datetime,
     step: int,
-) -> dict[float, dict[str, float]]:
+) -> dict[float, dict[str, float | str]]:
     """Query all export metrics and join by timestamp.
 
     Args:
@@ -132,17 +168,28 @@ async def query_all_metrics(
     Returns:
         Dict mapping timestamp -> {column_name: value}
     """
-    # Collect all data points by timestamp
-    data_by_timestamp: dict[float, dict[str, float]] = {}
+    data_by_timestamp: dict[float, dict[str, float | str]] = {}
 
-    for prom_metric, column_name in EXPORT_METRICS:
+    for export_metric in EXPORT_METRICS:
         try:
-            values = await query_metric_range(prom_metric, start, end, step)
-            for ts, val in values:
-                if ts not in data_by_timestamp:
-                    data_by_timestamp[ts] = {}
-                data_by_timestamp[ts][column_name] = val
+            results = await query_metric_range(export_metric.metric, start, end, step)
+            for result in results:
+                labels = result.get("metric", {})
+                values = result.get("values", [])
+                for ts, val in values:
+                    timestamp = float(ts)
+                    if timestamp not in data_by_timestamp:
+                        data_by_timestamp[timestamp] = {}
+                    if export_metric.column:
+                        data_by_timestamp[timestamp][export_metric.column] = float(val)
+                    if export_metric.label_columns:
+                        for label_name, column_name in export_metric.label_columns.items():
+                            data_by_timestamp[timestamp][column_name] = labels.get(
+                                label_name, ""
+                            )
         except Exception as e:
-            logger.warning("Failed to query metric %s: %s", prom_metric, str(e))
+            logger.warning(
+                "Failed to query metric %s: %s", export_metric.metric, str(e)
+            )
 
     return data_by_timestamp

--- a/backend/starlink-location/tests/unit/test_csv_export.py
+++ b/backend/starlink-location/tests/unit/test_csv_export.py
@@ -1,0 +1,144 @@
+"""Unit tests for Starlink telemetry CSV export."""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.api.export import csv_export, prometheus
+
+
+GROUND_ENTRY_COLUMNS = [
+    "ground_entry_latitude",
+    "ground_entry_longitude",
+    "ground_entry_city",
+    "ground_entry_country",
+    "ground_entry_ip",
+]
+
+
+def _sample_export_row() -> dict[str, float | str]:
+    return {
+        "latitude": 40.0,
+        "longitude": -73.0,
+        "altitude_feet": 10000.0,
+        "speed_knots": 250.0,
+        "heading_degrees": 180.0,
+        "latency_ms": 45.0,
+        "throughput_down_mbps": 120.0,
+        "throughput_up_mbps": 25.0,
+        "packet_loss_percent": 0.5,
+        "obstruction_percent": 5.0,
+        "signal_quality_percent": 98.0,
+        "ground_entry_latitude": 41.2565,
+        "ground_entry_longitude": -95.9345,
+        "ground_entry_city": "Omaha",
+        "ground_entry_country": "US",
+        "ground_entry_ip": "203.0.113.10",
+    }
+
+
+def test_csv_columns_include_ground_entry_fields() -> None:
+    assert csv_export.CSV_COLUMNS[0] == "timestamp"
+    for column in GROUND_ENTRY_COLUMNS:
+        assert column in csv_export.CSV_COLUMNS
+
+    metric_names = {metric.metric for metric in prometheus.EXPORT_METRICS}
+    assert "starlink_ground_entry_point_latitude_degrees" in metric_names
+    assert "starlink_ground_entry_point_longitude_degrees" in metric_names
+    assert "starlink_ground_entry_point_location" in metric_names
+
+
+@pytest.mark.anyio("asyncio")
+async def test_query_all_metrics_includes_ground_entry_numeric_and_label_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=5)
+    timestamp = 1710000000.0
+
+    async def fake_query_metric_range(
+        metric: str,
+        start: datetime,
+        end: datetime,
+        step: int,
+    ) -> list[dict[str, object]]:
+        if metric == "starlink_dish_latitude_degrees":
+            return [{"metric": {}, "values": [[timestamp, "40.0"]]}]
+        if metric == "starlink_ground_entry_point_latitude_degrees":
+            return [{"metric": {}, "values": [[timestamp, "41.2565"]]}]
+        if metric == "starlink_ground_entry_point_longitude_degrees":
+            return [{"metric": {}, "values": [[timestamp, "-95.9345"]]}]
+        if metric == "starlink_ground_entry_point_location":
+            return [
+                {
+                    "metric": {
+                        "city": "Omaha",
+                        "country": "US",
+                        "ip": "203.0.113.10",
+                    },
+                    "values": [[timestamp, "1"]],
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(prometheus, "query_metric_range", fake_query_metric_range)
+
+    data = await prometheus.query_all_metrics(start, end, step=10)
+
+    assert data[timestamp]["latitude"] == 40.0
+    assert data[timestamp]["ground_entry_latitude"] == 41.2565
+    assert data[timestamp]["ground_entry_longitude"] == -95.9345
+    assert data[timestamp]["ground_entry_city"] == "Omaha"
+    assert data[timestamp]["ground_entry_country"] == "US"
+    assert data[timestamp]["ground_entry_ip"] == "203.0.113.10"
+
+
+def test_generate_csv_includes_ground_entry_columns_and_values() -> None:
+    content = csv_export.generate_csv({1710000000.0: _sample_export_row()})
+    rows = list(csv.reader(io.StringIO(content)))
+
+    assert rows[0] == csv_export.CSV_COLUMNS
+
+    header = rows[0]
+    values = rows[1]
+    assert values[header.index("ground_entry_latitude")] == "41.2565"
+    assert values[header.index("ground_entry_longitude")] == "-95.9345"
+    assert values[header.index("ground_entry_city")] == "Omaha"
+    assert values[header.index("ground_entry_country")] == "US"
+    assert values[header.index("ground_entry_ip")] == "203.0.113.10"
+
+
+def test_export_starlink_csv_response_includes_ground_entry_columns(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=5)
+
+    async def fake_query_all_metrics(
+        start: datetime,
+        end: datetime,
+        step: int,
+    ) -> dict[float, dict[str, float | str]]:
+        return {1710000000.0: _sample_export_row()}
+
+    monkeypatch.setattr(csv_export, "query_all_metrics", fake_query_all_metrics)
+
+    response = client.get(
+        "/api/export/starlink-csv",
+        params={
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "step": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    rows = list(csv.reader(io.StringIO(response.text)))
+    assert rows[0] == csv_export.CSV_COLUMNS
+    assert "ground_entry_latitude" in rows[0]
+    assert "ground_entry_longitude" in rows[0]
+    assert "ground_entry_city" in rows[0]

--- a/frontend/mission-planner/src/pages/DataExportPage.tsx
+++ b/frontend/mission-planner/src/pages/DataExportPage.tsx
@@ -124,7 +124,8 @@ export function DataExportPage() {
       <div className="mb-6">
         <h1 className="text-3xl font-bold">Data Export</h1>
         <p className="text-gray-600 mt-2">
-          Export historical Starlink telemetry data to CSV
+          Export historical Starlink telemetry and Ground Entry Point data to
+          CSV
         </p>
       </div>
 
@@ -216,6 +217,9 @@ export function DataExportPage() {
             <li>Position: latitude, longitude, altitude, speed, heading</li>
             <li>Network: latency, throughput (up/down), packet loss</li>
             <li>Signal: obstruction percent, signal quality</li>
+            <li>
+              Ground Entry Point: latitude, longitude, city, country, and IP
+            </li>
           </ul>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add Ground Entry Point latitude/longitude metrics to the historical `/api/export/starlink-csv` export
- include Ground Entry Point city/country/IP from Prometheus label-bearing series in exported rows
- update Mission Planner Data Export copy and add regression coverage for the time-series export path

## Test Plan
- `pytest backend/starlink-location/tests/unit/test_csv_export.py -q`
- `pytest backend/starlink-location/tests/unit/test_csv_export.py backend/starlink-location/tests/unit/test_ground_entry_point.py -q`
- `npm run lint`
- `npm run build`
- `docker compose down && docker compose build --no-cache`
- `python - <<'PY'\nfrom app.api.export.csv_export import CSV_COLUMNS\nprint('\\n'.join(CSV_COLUMNS))\nPY`

## Runtime verification notes
- `docker compose up -d` from this worktree is currently blocked by an existing host container named `starlink-location`, so I could not start an isolated stack from this checkout.
- `curl http://localhost:8000/health` returns healthy JSON on the host, but that response is from the pre-existing service and should not be treated as verification of this branch.

Closes #69
