### PR TITLE
fix: refresh ground entry point metrics after startup

### DIFF
--- a/backend/starlink-location/app/services/ground_entry_point.py
+++ b/backend/starlink-location/app/services/ground_entry_point.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
+import time
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -17,6 +19,11 @@ from app.core.metrics.prometheus_metrics import (
 )
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_REFRESH_INTERVAL_SECONDS = 300.0
+_last_ground_entry_point_location_labels: tuple[str, str, str, str, str] | None = None
+_last_ground_entry_point_info_labels: tuple[str, str, str] | None = None
+_last_ground_entry_point_refresh_monotonic: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +53,11 @@ def get_cached_ground_entry_point() -> GroundEntryPoint | None:
     occasionally wait for a website to answer.
     """
     return discover_ground_entry_point()
+
+
+def invalidate_cached_ground_entry_point() -> None:
+    """Invalidate the cached ground entry point so the next lookup re-discovers it."""
+    get_cached_ground_entry_point.cache_clear()
 
 
 def discover_ground_entry_point(
@@ -86,34 +98,109 @@ def discover_ground_entry_point(
     )
 
 
+def clear_ground_entry_point_metrics() -> None:
+    """Clear plain gauges and remove any previously published labelled series."""
+    global _last_ground_entry_point_location_labels, _last_ground_entry_point_info_labels
+
+    starlink_ground_entry_point_latitude_degrees.set(math.nan)
+    starlink_ground_entry_point_longitude_degrees.set(math.nan)
+
+    if _last_ground_entry_point_location_labels is not None:
+        try:
+            starlink_ground_entry_point_location.remove(
+                *_last_ground_entry_point_location_labels
+            )
+        except KeyError:
+            pass
+        _last_ground_entry_point_location_labels = None
+
+    if _last_ground_entry_point_info_labels is not None:
+        try:
+            starlink_ground_entry_point_info.remove(*_last_ground_entry_point_info_labels)
+        except KeyError:
+            pass
+        _last_ground_entry_point_info_labels = None
+
+
 def publish_ground_entry_point_metrics(entry_point: GroundEntryPoint | None) -> None:
     """Publish ground entry point metrics for Grafana and Prometheus exports."""
+    global _last_ground_entry_point_location_labels, _last_ground_entry_point_info_labels
+
+    clear_ground_entry_point_metrics()
     if entry_point is None:
         return
 
     lat_label = f"{entry_point.latitude:.6g}"
     lon_label = f"{entry_point.longitude:.6g}"
+    location_labels = (
+        lat_label,
+        lon_label,
+        entry_point.city,
+        entry_point.country,
+        entry_point.ip,
+    )
+    info_labels = (entry_point.city, entry_point.country, entry_point.ip)
+
     starlink_ground_entry_point_latitude_degrees.set(entry_point.latitude)
     starlink_ground_entry_point_longitude_degrees.set(entry_point.longitude)
     starlink_ground_entry_point_location.labels(
-        lat=lat_label,
-        lon=lon_label,
-        city=entry_point.city,
-        country=entry_point.country,
-        ip=entry_point.ip,
+        lat=location_labels[0],
+        lon=location_labels[1],
+        city=location_labels[2],
+        country=location_labels[3],
+        ip=location_labels[4],
     ).set(1)
     starlink_ground_entry_point_info.labels(
-        city=entry_point.city,
-        country=entry_point.country,
-        ip=entry_point.ip,
+        city=info_labels[0],
+        country=info_labels[1],
+        ip=info_labels[2],
     ).set(1)
 
+    _last_ground_entry_point_location_labels = location_labels
+    _last_ground_entry_point_info_labels = info_labels
 
-def refresh_ground_entry_point_metrics() -> GroundEntryPoint | None:
-    """Resolve the cached ground entry point and publish its metrics."""
+
+def refresh_ground_entry_point_metrics(
+    now_monotonic: float | None = None,
+) -> GroundEntryPoint | None:
+    """Invalidate cached discovery, re-resolve the entry point, and publish metrics."""
+    global _last_ground_entry_point_refresh_monotonic
+
+    invalidate_cached_ground_entry_point()
     entry_point = get_cached_ground_entry_point()
     publish_ground_entry_point_metrics(entry_point)
+    _last_ground_entry_point_refresh_monotonic = (
+        time.monotonic() if now_monotonic is None else now_monotonic
+    )
     return entry_point
+
+
+def maybe_refresh_ground_entry_point_metrics(
+    refresh_interval_seconds: float | None = None,
+    now_monotonic: float | None = None,
+) -> GroundEntryPoint | None:
+    """Refresh entry-point metrics only when the periodic refresh interval has elapsed."""
+    interval_seconds = (
+        _DEFAULT_REFRESH_INTERVAL_SECONDS
+        if refresh_interval_seconds is None
+        else refresh_interval_seconds
+    )
+    if not math.isfinite(interval_seconds) or interval_seconds <= 0:
+        logger.warning(
+            "Invalid ground entry refresh interval %r; using default %.1f seconds",
+            interval_seconds,
+            _DEFAULT_REFRESH_INTERVAL_SECONDS,
+        )
+        interval_seconds = _DEFAULT_REFRESH_INTERVAL_SECONDS
+
+    current_monotonic = time.monotonic() if now_monotonic is None else now_monotonic
+
+    if _last_ground_entry_point_refresh_monotonic is None or (
+        current_monotonic - _last_ground_entry_point_refresh_monotonic
+    ) >= interval_seconds:
+        return refresh_ground_entry_point_metrics(now_monotonic=current_monotonic)
+
+    return get_cached_ground_entry_point()
 
 
 def _entry_point_from_environment() -> GroundEntryPoint | None:

--- a/backend/starlink-location/main.py
+++ b/backend/starlink-location/main.py
@@ -38,7 +38,10 @@ from app.live.coordinator import LiveCoordinator
 from app.simulation.coordinator import SimulationCoordinator
 from app.services.poi_manager import POIManager
 from app.services.route_manager import RouteManager
-from app.services.ground_entry_point import refresh_ground_entry_point_metrics
+from app.services.ground_entry_point import (
+    maybe_refresh_ground_entry_point_metrics,
+    refresh_ground_entry_point_metrics,
+)
 from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
 from app.core.limiter import limiter
@@ -323,12 +326,27 @@ async def _background_update_loop(poi_manager=None):
 
     update_count = 0
     error_count = 0
+    try:
+        ground_entry_refresh_interval_seconds = float(
+            os.getenv("STARLINK_GROUND_ENTRY_REFRESH_SECONDS", "300")
+        )
+    except ValueError:
+        ground_entry_refresh_interval_seconds = 300.0
+        logger.warning_json(
+            "Invalid STARLINK_GROUND_ENTRY_REFRESH_SECONDS; using default",
+            extra_fields={"value": os.getenv("STARLINK_GROUND_ENTRY_REFRESH_SECONDS")},
+        )
+
 
     try:
         logger.info_json("Background update loop started")
 
         while True:
             try:
+                maybe_refresh_ground_entry_point_metrics(
+                    refresh_interval_seconds=ground_entry_refresh_interval_seconds
+                )
+
                 if _coordinator:
                     telemetry = _coordinator.update()
                     update_count += 1

--- a/backend/starlink-location/tests/unit/test_ground_entry_point.py
+++ b/backend/starlink-location/tests/unit/test_ground_entry_point.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 from prometheus_client import generate_latest
 
 from app.core.metrics import REGISTRY
+from app.services import ground_entry_point as gep
 from app.services.ground_entry_point import (
     GroundEntryPoint,
+    maybe_refresh_ground_entry_point_metrics,
     publish_ground_entry_point_metrics,
+    refresh_ground_entry_point_metrics,
 )
+
+
+def setup_function() -> None:
+    gep.invalidate_cached_ground_entry_point()
+    gep.clear_ground_entry_point_metrics()
+    gep._last_ground_entry_point_refresh_monotonic = None
 
 
 def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -> None:
@@ -31,3 +40,135 @@ def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -
     assert 'lon="-95.9345"' in output
     assert "starlink_ground_entry_point_latitude_degrees 41.2565" in output
     assert "starlink_ground_entry_point_longitude_degrees -95.9345" in output
+
+
+def test_refresh_ground_entry_point_metrics_invalidates_cache_and_replaces_labels(
+    monkeypatch,
+) -> None:
+    discoveries = iter(
+        [
+            GroundEntryPoint(
+                ip="203.0.113.10",
+                city="Omaha",
+                country="US",
+                latitude=41.2565,
+                longitude=-95.9345,
+            ),
+            GroundEntryPoint(
+                ip="198.51.100.20",
+                city="Tokyo",
+                country="JP",
+                latitude=35.6764,
+                longitude=139.65,
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(
+        gep,
+        "discover_ground_entry_point",
+        lambda timeout_seconds=5.0: next(discoveries),
+    )
+
+    first = refresh_ground_entry_point_metrics(now_monotonic=10.0)
+    second = refresh_ground_entry_point_metrics(now_monotonic=20.0)
+
+    assert first is not None
+    assert second is not None
+    assert first.city == "Omaha"
+    assert second.city == "Tokyo"
+
+    output = generate_latest(REGISTRY).decode("utf-8")
+    assert 'city="Tokyo"' in output
+    assert 'country="JP"' in output
+    assert 'ip="198.51.100.20"' in output
+    assert "starlink_ground_entry_point_latitude_degrees 35.6764" in output
+    assert "starlink_ground_entry_point_longitude_degrees 139.65" in output
+    assert 'city="Omaha"' not in output
+    assert 'ip="203.0.113.10"' not in output
+
+
+def test_maybe_refresh_ground_entry_point_metrics_honors_refresh_interval(
+    monkeypatch,
+) -> None:
+    refresh_times: list[float] = []
+
+    def fake_refresh(now_monotonic: float | None = None) -> GroundEntryPoint:
+        refresh_times.append(-1.0 if now_monotonic is None else now_monotonic)
+        gep._last_ground_entry_point_refresh_monotonic = now_monotonic
+        return GroundEntryPoint(
+            ip="203.0.113.10",
+            city="Omaha",
+            country="US",
+            latitude=41.2565,
+            longitude=-95.9345,
+        )
+
+    monkeypatch.setattr(gep, "refresh_ground_entry_point_metrics", fake_refresh)
+    monkeypatch.setattr(
+        gep,
+        "get_cached_ground_entry_point",
+        lambda: GroundEntryPoint(
+            ip="203.0.113.10",
+            city="Omaha",
+            country="US",
+            latitude=41.2565,
+            longitude=-95.9345,
+        ),
+    )
+
+    maybe_refresh_ground_entry_point_metrics(
+        refresh_interval_seconds=300.0,
+        now_monotonic=100.0,
+    )
+    maybe_refresh_ground_entry_point_metrics(
+        refresh_interval_seconds=300.0,
+        now_monotonic=200.0,
+    )
+    maybe_refresh_ground_entry_point_metrics(
+        refresh_interval_seconds=300.0,
+        now_monotonic=401.0,
+    )
+
+    assert refresh_times == [100.0, 401.0]
+
+
+def test_maybe_refresh_ground_entry_point_metrics_falls_back_from_nan_interval(
+    monkeypatch,
+) -> None:
+    refresh_times: list[float] = []
+
+    def fake_refresh(now_monotonic: float | None = None) -> GroundEntryPoint:
+        refresh_times.append(-1.0 if now_monotonic is None else now_monotonic)
+        gep._last_ground_entry_point_refresh_monotonic = now_monotonic
+        return GroundEntryPoint(
+            ip="203.0.113.10",
+            city="Omaha",
+            country="US",
+            latitude=41.2565,
+            longitude=-95.9345,
+        )
+
+    monkeypatch.setattr(gep, "refresh_ground_entry_point_metrics", fake_refresh)
+    monkeypatch.setattr(
+        gep,
+        "get_cached_ground_entry_point",
+        lambda: GroundEntryPoint(
+            ip="203.0.113.10",
+            city="Omaha",
+            country="US",
+            latitude=41.2565,
+            longitude=-95.9345,
+        ),
+    )
+
+    maybe_refresh_ground_entry_point_metrics(
+        refresh_interval_seconds=float("nan"),
+        now_monotonic=100.0,
+    )
+    maybe_refresh_ground_entry_point_metrics(
+        refresh_interval_seconds=float("nan"),
+        now_monotonic=401.0,
+    )
+
+    assert refresh_times == [100.0, 401.0]


### PR DESCRIPTION
## Summary
- add a periodic ground-entry-point refresh path in the backend update loop
- invalidate cached discovery before each refresh and remove stale labelled metric series before republishing
- guard invalid refresh interval values such as `nan`/`inf` by falling back to the default interval and cover the behavior with focused tests

## Test Plan
- [x] python -m pytest tools/tests/test_fullscreen_overview_dashboard.py backend/starlink-location/tests/unit/test_ground_entry_point.py
- [x] python -m pytest backend/starlink-location/tests/unit/test_ground_entry_point.py -q
- [x] docker compose down && docker compose build --no-cache
- [x] docker run -d --name starlink-location-issue71-smoke --env-file .env -p 18000:8000 starlink-dashboard-starlink-location:latest
- [x] curl -fsS http://localhost:18000/health
- [x] curl -fsS http://localhost:18000/metrics | grep 'starlink_ground_entry_point_'

Closes #71
