### PR TITLE
feat: add DNS public IP watcher

### DIFF
--- a/backend/starlink-location/app/services/ground_entry_point.py
+++ b/backend/starlink-location/app/services/ground_entry_point.py
@@ -7,8 +7,9 @@ import math
 import os
 import time
 from dataclasses import dataclass
-from functools import lru_cache
+from typing import Callable
 
+import dns.resolver
 import httpx
 
 from app.core.metrics.prometheus_metrics import (
@@ -20,7 +21,8 @@ from app.core.metrics.prometheus_metrics import (
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_REFRESH_INTERVAL_SECONDS = 300.0
+_DEFAULT_REFRESH_INTERVAL_SECONDS = 1.0
+_OPENDNS_RESOLVERS = ["208.67.222.222", "208.67.220.220"]
 _last_ground_entry_point_location_labels: tuple[str, str, str, str, str] | None = None
 _last_ground_entry_point_info_labels: tuple[str, str, str] | None = None
 _last_ground_entry_point_refresh_monotonic: float | None = None
@@ -43,42 +45,114 @@ class GroundEntryPoint:
         return ", ".join(parts) if parts else "Unknown"
 
 
-@lru_cache(maxsize=1)
-def get_cached_ground_entry_point() -> GroundEntryPoint | None:
-    """Resolve and cache the current public egress location.
+class GroundEntryPointResolver:
+    """Resolve public IP frequently, geolocating only when the IP changes."""
 
-    The lookup intentionally fails closed: if public-IP or geolocation services
-    are unavailable, metrics and exports continue with empty ground-entry values
-    rather than delaying telemetry collection. Apparently even satellites must
-    occasionally wait for a website to answer.
-    """
-    return discover_ground_entry_point()
+    def __init__(
+        self,
+        ip_resolver: Callable[[], str | None] | None = None,
+        geolocator: Callable[[str], GroundEntryPoint | None] | None = None,
+        poll_interval_seconds: float = _DEFAULT_REFRESH_INTERVAL_SECONDS,
+        time_source: Callable[[], float] | None = None,
+    ) -> None:
+        self._ip_resolver = ip_resolver or resolve_public_ip_via_dns
+        self._geolocator = geolocator or geolocate_public_ip
+        self._poll_interval_seconds = poll_interval_seconds
+        self._time_source = time_source or time.monotonic
+        self._last_lookup_at: float | None = None
+        self._current_ip: str | None = None
+        self._current_entry: GroundEntryPoint | None = None
+        self._entry_cache: dict[str, GroundEntryPoint] = {}
+
+    def current(self) -> GroundEntryPoint | None:
+        """Return the most recently resolved ground entry point."""
+        configured = _entry_point_from_environment()
+        if configured is not None:
+            self._current_ip = configured.ip or self._current_ip
+            self._current_entry = configured
+            return configured
+        return self._current_entry
+
+    def invalidate(self, clear_geolocation_cache: bool = False) -> None:
+        """Clear current resolver state, optionally dropping per-IP geolocation cache."""
+        self._last_lookup_at = None
+        self._current_ip = None
+        self._current_entry = None
+        if clear_geolocation_cache:
+            self._entry_cache.clear()
+
+    def refresh(self, force: bool = False) -> GroundEntryPoint | None:
+        """Refresh public IP state and geolocate only when the IP changes."""
+        configured = _entry_point_from_environment()
+        if configured is not None:
+            self._current_ip = configured.ip or self._current_ip
+            self._current_entry = configured
+            return configured
+
+        now = self._time_source()
+        if (
+            not force
+            and self._last_lookup_at is not None
+            and now - self._last_lookup_at < self._poll_interval_seconds
+        ):
+            return self._current_entry
+
+        self._last_lookup_at = now
+
+        try:
+            ip = self._ip_resolver()
+        except Exception as exc:  # pragma: no cover - defensive network guard
+            logger.warning("Failed to resolve public IP: %s", exc)
+            return self._current_entry
+
+        if not ip:
+            return self._current_entry
+
+        if ip == self._current_ip and self._current_entry is not None:
+            return self._current_entry
+
+        cached_entry = self._entry_cache.get(ip)
+        if cached_entry is not None:
+            self._current_ip = ip
+            self._current_entry = cached_entry
+            return cached_entry
+
+        try:
+            entry = self._geolocator(ip)
+        except Exception as exc:  # pragma: no cover - defensive network guard
+            logger.warning("Failed to geolocate public IP %s: %s", ip, exc)
+            return self._current_entry
+
+        if entry is None:
+            return self._current_entry
+
+        self._entry_cache[ip] = entry
+        self._current_ip = ip
+        self._current_entry = entry
+        return entry
 
 
-def invalidate_cached_ground_entry_point() -> None:
-    """Invalidate the cached ground entry point so the next lookup re-discovers it."""
-    get_cached_ground_entry_point.cache_clear()
+def resolve_public_ip_via_dns(timeout_seconds: float = 2.0) -> str | None:
+    """Resolve the current public IP using OpenDNS rather than HTTP."""
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.nameservers = _OPENDNS_RESOLVERS
+    resolver.timeout = timeout_seconds
+    resolver.lifetime = timeout_seconds
+    answers = list(resolver.resolve("myip.opendns.com", "A", search=False))
+    if not answers:
+        return None
+    return str(answers[0]).strip()
 
 
-def discover_ground_entry_point(
+def geolocate_public_ip(
+    ip: str,
     timeout_seconds: float = 5.0,
 ) -> GroundEntryPoint | None:
-    """Discover the public egress IP and geolocate it with ipinfo.io."""
-    configured = _entry_point_from_environment()
-    if configured is not None:
-        return configured
-
-    try:
-        with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
-            ip = client.get("https://ifconfig.me/ip").text.strip()
-            if not ip:
-                return None
-            response = client.get(f"https://ipinfo.io/{ip}/json")
-            response.raise_for_status()
-            payload = response.json()
-    except Exception as exc:  # pragma: no cover - defensive network guard
-        logger.warning("Failed to discover ground entry point: %s", exc)
-        return None
+    """Geolocate a public IP using ipinfo.io."""
+    with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
+        response = client.get(f"https://ipinfo.io/{ip}/json")
+        response.raise_for_status()
+        payload = response.json()
 
     loc = str(payload.get("loc") or "")
     try:
@@ -96,6 +170,34 @@ def discover_ground_entry_point(
         latitude=latitude,
         longitude=longitude,
     )
+
+
+_resolver = GroundEntryPointResolver()
+
+
+def invalidate_cached_ground_entry_point() -> None:
+    """Invalidate current ground-entry state so the next lookup re-discovers it."""
+    _resolver.invalidate(clear_geolocation_cache=True)
+
+
+def discover_ground_entry_point(
+    timeout_seconds: float = 5.0,
+) -> GroundEntryPoint | None:
+    """Discover the public egress IP and geolocate it with DNS-based IP lookup."""
+    configured = _entry_point_from_environment()
+    if configured is not None:
+        return configured
+
+    resolver = GroundEntryPointResolver(
+        ip_resolver=lambda: resolve_public_ip_via_dns(timeout_seconds=min(timeout_seconds, 2.0)),
+        geolocator=lambda ip: geolocate_public_ip(ip, timeout_seconds=timeout_seconds),
+    )
+    return resolver.refresh(force=True)
+
+
+def get_cached_ground_entry_point() -> GroundEntryPoint | None:
+    """Return the last-known ground entry point without forcing a network lookup."""
+    return _resolver.current()
 
 
 def clear_ground_entry_point_metrics() -> None:
@@ -162,12 +264,12 @@ def publish_ground_entry_point_metrics(entry_point: GroundEntryPoint | None) -> 
 
 def refresh_ground_entry_point_metrics(
     now_monotonic: float | None = None,
+    force: bool = False,
 ) -> GroundEntryPoint | None:
-    """Invalidate cached discovery, re-resolve the entry point, and publish metrics."""
+    """Refresh DNS-watched ground-entry state and publish current metrics."""
     global _last_ground_entry_point_refresh_monotonic
 
-    invalidate_cached_ground_entry_point()
-    entry_point = get_cached_ground_entry_point()
+    entry_point = _resolver.refresh(force=force)
     publish_ground_entry_point_metrics(entry_point)
     _last_ground_entry_point_refresh_monotonic = (
         time.monotonic() if now_monotonic is None else now_monotonic
@@ -179,7 +281,7 @@ def maybe_refresh_ground_entry_point_metrics(
     refresh_interval_seconds: float | None = None,
     now_monotonic: float | None = None,
 ) -> GroundEntryPoint | None:
-    """Refresh entry-point metrics only when the periodic refresh interval has elapsed."""
+    """Refresh entry-point metrics only when the DNS watcher interval has elapsed."""
     interval_seconds = (
         _DEFAULT_REFRESH_INTERVAL_SECONDS
         if refresh_interval_seconds is None

--- a/backend/starlink-location/main.py
+++ b/backend/starlink-location/main.py
@@ -328,10 +328,10 @@ async def _background_update_loop(poi_manager=None):
     error_count = 0
     try:
         ground_entry_refresh_interval_seconds = float(
-            os.getenv("STARLINK_GROUND_ENTRY_REFRESH_SECONDS", "300")
+            os.getenv("STARLINK_GROUND_ENTRY_REFRESH_SECONDS", "1")
         )
     except ValueError:
-        ground_entry_refresh_interval_seconds = 300.0
+        ground_entry_refresh_interval_seconds = 1.0
         logger.warning_json(
             "Invalid STARLINK_GROUND_ENTRY_REFRESH_SECONDS; using default",
             extra_fields={"value": os.getenv("STARLINK_GROUND_ENTRY_REFRESH_SECONDS")},

--- a/backend/starlink-location/requirements.txt
+++ b/backend/starlink-location/requirements.txt
@@ -8,6 +8,7 @@ pytest>=7.4.0
 pytest-asyncio>=0.21.0
 pytest-cov>=4.1.0
 httpx>=0.25.0
+dnspython>=2.7.0
 numpy>=1.24.0
 fastkml>=1.3.0
 watchdog>=4.0.0

--- a/backend/starlink-location/tests/unit/test_ground_entry_point.py
+++ b/backend/starlink-location/tests/unit/test_ground_entry_point.py
@@ -8,6 +8,7 @@ from app.core.metrics import REGISTRY
 from app.services import ground_entry_point as gep
 from app.services.ground_entry_point import (
     GroundEntryPoint,
+    GroundEntryPointResolver,
     maybe_refresh_ground_entry_point_metrics,
     publish_ground_entry_point_metrics,
     refresh_ground_entry_point_metrics,
@@ -42,10 +43,8 @@ def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -
     assert "starlink_ground_entry_point_longitude_degrees -95.9345" in output
 
 
-def test_refresh_ground_entry_point_metrics_invalidates_cache_and_replaces_labels(
-    monkeypatch,
-) -> None:
-    discoveries = iter(
+def test_refresh_ground_entry_point_metrics_replaces_labels(monkeypatch) -> None:
+    entries = iter(
         [
             GroundEntryPoint(
                 ip="203.0.113.10",
@@ -64,11 +63,7 @@ def test_refresh_ground_entry_point_metrics_invalidates_cache_and_replaces_label
         ]
     )
 
-    monkeypatch.setattr(
-        gep,
-        "discover_ground_entry_point",
-        lambda timeout_seconds=5.0: next(discoveries),
-    )
+    monkeypatch.setattr(gep._resolver, "refresh", lambda force=False: next(entries))
 
     first = refresh_ground_entry_point_metrics(now_monotonic=10.0)
     second = refresh_ground_entry_point_metrics(now_monotonic=20.0)
@@ -93,7 +88,10 @@ def test_maybe_refresh_ground_entry_point_metrics_honors_refresh_interval(
 ) -> None:
     refresh_times: list[float] = []
 
-    def fake_refresh(now_monotonic: float | None = None) -> GroundEntryPoint:
+    def fake_refresh(
+        now_monotonic: float | None = None,
+        force: bool = False,
+    ) -> GroundEntryPoint:
         refresh_times.append(-1.0 if now_monotonic is None else now_monotonic)
         gep._last_ground_entry_point_refresh_monotonic = now_monotonic
         return GroundEntryPoint(
@@ -118,19 +116,19 @@ def test_maybe_refresh_ground_entry_point_metrics_honors_refresh_interval(
     )
 
     maybe_refresh_ground_entry_point_metrics(
-        refresh_interval_seconds=300.0,
+        refresh_interval_seconds=1.0,
         now_monotonic=100.0,
     )
     maybe_refresh_ground_entry_point_metrics(
-        refresh_interval_seconds=300.0,
-        now_monotonic=200.0,
+        refresh_interval_seconds=1.0,
+        now_monotonic=100.5,
     )
     maybe_refresh_ground_entry_point_metrics(
-        refresh_interval_seconds=300.0,
-        now_monotonic=401.0,
+        refresh_interval_seconds=1.0,
+        now_monotonic=101.0,
     )
 
-    assert refresh_times == [100.0, 401.0]
+    assert refresh_times == [100.0, 101.0]
 
 
 def test_maybe_refresh_ground_entry_point_metrics_falls_back_from_nan_interval(
@@ -138,7 +136,10 @@ def test_maybe_refresh_ground_entry_point_metrics_falls_back_from_nan_interval(
 ) -> None:
     refresh_times: list[float] = []
 
-    def fake_refresh(now_monotonic: float | None = None) -> GroundEntryPoint:
+    def fake_refresh(
+        now_monotonic: float | None = None,
+        force: bool = False,
+    ) -> GroundEntryPoint:
         refresh_times.append(-1.0 if now_monotonic is None else now_monotonic)
         gep._last_ground_entry_point_refresh_monotonic = now_monotonic
         return GroundEntryPoint(
@@ -168,7 +169,125 @@ def test_maybe_refresh_ground_entry_point_metrics_falls_back_from_nan_interval(
     )
     maybe_refresh_ground_entry_point_metrics(
         refresh_interval_seconds=float("nan"),
-        now_monotonic=401.0,
+        now_monotonic=100.5,
+    )
+    maybe_refresh_ground_entry_point_metrics(
+        refresh_interval_seconds=float("nan"),
+        now_monotonic=101.0,
     )
 
-    assert refresh_times == [100.0, 401.0]
+    assert refresh_times == [100.0, 101.0]
+
+
+def test_resolver_suppresses_dns_polling_until_interval_elapses() -> None:
+    now = 10.0
+    resolve_calls: list[float] = []
+
+    def resolve_ip() -> str:
+        resolve_calls.append(now)
+        return "203.0.113.10"
+
+    def geolocate_ip(ip: str) -> GroundEntryPoint:
+        return GroundEntryPoint(
+            ip=ip,
+            city="Omaha",
+            country="US",
+            latitude=41.2565,
+            longitude=-95.9345,
+        )
+
+    resolver = GroundEntryPointResolver(
+        ip_resolver=resolve_ip,
+        geolocator=geolocate_ip,
+        poll_interval_seconds=1.0,
+        time_source=lambda: now,
+    )
+
+    first = resolver.refresh()
+    now = 10.5
+    second = resolver.refresh()
+    now = 11.0
+    third = resolver.refresh()
+
+    assert first is not None
+    assert second is first
+    assert third is first
+    assert resolve_calls == [10.0, 11.0]
+
+
+def test_resolver_geolocates_only_when_public_ip_changes() -> None:
+    resolved_ips = iter(["203.0.113.10", "203.0.113.10", "198.51.100.24"])
+    geolocate_calls: list[str] = []
+
+    def resolve_ip() -> str:
+        return next(resolved_ips)
+
+    def geolocate_ip(ip: str) -> GroundEntryPoint:
+        geolocate_calls.append(ip)
+        if ip == "203.0.113.10":
+            return GroundEntryPoint(
+                ip=ip,
+                city="Omaha",
+                country="US",
+                latitude=41.2565,
+                longitude=-95.9345,
+            )
+        return GroundEntryPoint(
+            ip=ip,
+            city="Dallas",
+            country="US",
+            latitude=32.7767,
+            longitude=-96.797,
+        )
+
+    resolver = GroundEntryPointResolver(
+        ip_resolver=resolve_ip,
+        geolocator=geolocate_ip,
+        poll_interval_seconds=0.0,
+    )
+
+    first = resolver.refresh()
+    second = resolver.refresh()
+    third = resolver.refresh()
+
+    assert first is not None
+    assert second is first
+    assert third is not None
+    assert third.ip == "198.51.100.24"
+    assert geolocate_calls == ["203.0.113.10", "198.51.100.24"]
+
+
+def test_resolver_reuses_cached_geolocation_when_prior_ip_returns() -> None:
+    resolved_ips = iter(["203.0.113.10", "198.51.100.24", "203.0.113.10"])
+    geolocate_calls: list[str] = []
+
+    def resolve_ip() -> str:
+        return next(resolved_ips)
+
+    def geolocate_ip(ip: str) -> GroundEntryPoint:
+        geolocate_calls.append(ip)
+        city = "Omaha" if ip == "203.0.113.10" else "Dallas"
+        latitude = 41.2565 if ip == "203.0.113.10" else 32.7767
+        longitude = -95.9345 if ip == "203.0.113.10" else -96.797
+        return GroundEntryPoint(
+            ip=ip,
+            city=city,
+            country="US",
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+    resolver = GroundEntryPointResolver(
+        ip_resolver=resolve_ip,
+        geolocator=geolocate_ip,
+        poll_interval_seconds=0.0,
+    )
+
+    first = resolver.refresh()
+    second = resolver.refresh()
+    third = resolver.refresh()
+
+    assert first is not None
+    assert second is not None
+    assert third is first
+    assert geolocate_calls == ["203.0.113.10", "198.51.100.24"]


### PR DESCRIPTION
## Summary
- Replace the ifconfig.me public-IP discovery path with an in-process DNS watcher using OpenDNS `myip.opendns.com` resolution.
- Refresh public-IP detection on a 1-second default cadence and geolocate only when the detected IP changes.
- Cache geolocation results per IP and keep the dashboard/export caveat intact: public IP is still only a ground-entry/PoP heuristic, not proof of true PoP identity.

## Test Plan
- `python -m pytest backend/starlink-location/tests/unit/test_ground_entry_point.py -q`
- `python -m pytest backend/starlink-location/tests/unit -q`
- `python -m ruff check backend/starlink-location/app/services/ground_entry_point.py backend/starlink-location/main.py backend/starlink-location/tests/unit/test_ground_entry_point.py`
- `docker compose down && docker compose build --no-cache`
- `docker compose up -d`; `docker compose ps`; `curl -fsS http://localhost:8000/health`

## Release implications
- Backend dependency change: adds `dnspython` for in-process DNS resolution.
- Runtime default change: `STARLINK_GROUND_ENTRY_REFRESH_SECONDS` now defaults to `1` instead of `300`; geolocation remains change-triggered and cached.

Addresses #73.
