### PR TITLE
fix: refresh RainViewer weather radar tiles

### DIFF
--- a/backend/starlink-location/app/api/weather.py
+++ b/backend/starlink-location/app/api/weather.py
@@ -22,5 +22,5 @@ def rainviewer_radar_tile(z: int, x: int, y: int) -> RedirectResponse:
     return RedirectResponse(
         url=tile_url,
         status_code=307,
-        headers={"Cache-Control": "public, max-age=300"},
+        headers={"Cache-Control": "no-store"},
     )

--- a/backend/starlink-location/tests/unit/test_weather_api.py
+++ b/backend/starlink-location/tests/unit/test_weather_api.py
@@ -21,7 +21,29 @@ def test_rainviewer_radar_tile_endpoint_redirects_to_latest_tile(
         response.headers["location"]
         == "https://tilecache.rainviewer.com/radar/3/4/5.png"
     )
-    assert response.headers["cache-control"] == "public, max-age=300"
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_rainviewer_radar_tile_endpoint_allows_dashboard_refresh_token(
+    client, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        weather.rainviewer_radar_service,
+        "tile_url",
+        lambda z, x, y: f"https://tilecache.rainviewer.com/radar/{z}/{x}/{y}.png",
+    )
+
+    response = client.get(
+        "/api/weather/radar/rainviewer/3/4/5.png?refresh=202606171200",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 307
+    assert (
+        response.headers["location"]
+        == "https://tilecache.rainviewer.com/radar/3/4/5.png"
+    )
+    assert response.headers["cache-control"] == "no-store"
 
 
 def test_rainviewer_radar_tile_endpoint_returns_503_when_source_unavailable(

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -382,7 +382,7 @@
               "attribution": "Weather radar \u00a9 Rain Viewer / MeteoLab Inc.",
               "maxZoom": 7,
               "minZoom": 0,
-              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
+              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png?refresh=${__to:date:YYYYMMDDHHmm}"
             },
             "name": "Weather Radar (RainViewer)",
             "noRepeat": false,

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -20,6 +20,7 @@ CORE_MAP_LAYERS = {
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
 RAINVIEWER_RADAR_TILE_URL = (
     "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
+    "?refresh=${__to:date:YYYYMMDDHHmm}"
 )
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
 HCX_COMM_LAYER_SOURCES = {"commka.geojson"}
@@ -140,6 +141,12 @@ def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_lay
     )
 
 
+def test_fullscreen_overview_rainviewer_cache_buster_is_bounded_to_minute() -> None:
+    radar_layer = _layers_by_name()[RADAR_LAYER_NAME]
+
+    assert radar_layer["config"]["url"].endswith("?refresh=${__to:date:YYYYMMDDHHmm}")
+
+
 def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:
     layers = _current_position_layers()
 
@@ -193,7 +200,9 @@ def test_fullscreen_overview_gives_map_more_vertical_space() -> None:
     assert packet_loss_panel["gridPos"] == {"h": 4, "w": 7, "x": 11, "y": 26}
 
 
-def test_fullscreen_overview_places_obstruction_gauge_between_ground_entry_point_and_packet_loss() -> None:
+def test_fullscreen_overview_places_obstruction_gauge_between_ground_entry_point_and_packet_loss() -> (
+    None
+):
     ground_entry_panel = _panel_by_title("Ground Entry Point")
     obstruction_panel = _panel_by_title("Obstruction %")
     packet_loss_panel = _panel_by_title("Packet Loss")


### PR DESCRIPTION
## Summary
- Adds a bounded minute-granularity Grafana refresh token to the RainViewer XYZ radar layer URL so the map tile source invalidates while the dashboard stays open.
- Changes the backend RainViewer redirect response to `Cache-Control: no-store` so browser/proxy caches do not keep stale redirect targets after the dashboard refresh token advances.
- Preserves upstream discipline by keeping RainViewer metadata caching in `RainViewerRadarService`; the refresh token only invalidates the dashboard/backend tile URL, not the upstream metadata fetch cadence.

## Verification
- RED: `python -m pytest backend/starlink-location/tests/unit/test_weather_api.py tools/tests/test_fullscreen_overview_dashboard.py -q` failed on old redirect cache header and old stable dashboard tile URL.
- `python -m pytest backend/starlink-location/tests/unit/test_weather_api.py backend/starlink-location/tests/unit/test_weather_radar.py tools/tests/test_fullscreen_overview_dashboard.py -q` — 20 passed.
- `python -m ruff check backend/starlink-location/app/api/weather.py backend/starlink-location/tests/unit/test_weather_api.py tools/tests/test_fullscreen_overview_dashboard.py` — passed.
- `python -m pytest backend/starlink-location/tests/unit -q` — 729 passed.
- `docker compose down && docker compose build --no-cache` — passed.
- `docker compose up -d && docker compose ps` — stack started; backend healthy.
- `curl -fsS http://localhost:8000/health` — backend responded in simulation mode.
- `GET /api/weather/radar/rainviewer/3/4/5.png?refresh=202606171200` — returned 307 with `cache-control: no-store` and a current RainViewer redirect target.
- Grafana API for `starlink-fullscreen` shows the provisioned radar URL includes `?refresh=${__to:date:YYYYMMDDHHmm}`.

## Docs / config impact
- Dashboard JSON changed for the fullscreen overview weather radar layer only.
- Weather API redirect cache semantics changed from browser-cacheable redirect to `no-store`; upstream RainViewer metadata cache behavior remains unchanged.

Closes #75
