### PR TITLE
fix: refresh weather radar geomap layer

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -382,7 +382,7 @@
               "attribution": "Weather radar \u00a9 Rain Viewer / MeteoLab Inc.",
               "maxZoom": 7,
               "minZoom": 0,
-              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png?refresh=${__to:date:YYYYMMDDHHmm}"
+              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png?refresh=${radar_refresh}"
             },
             "name": "Weather Radar (RainViewer)",
             "noRepeat": false,
@@ -1948,6 +1948,34 @@
         ],
         "query": "Departure & Arrival : departure\\,arrival, All POIs :  , Departure Only : departure, Arrival Only : arrival, Waypoints Only : waypoint, Alternates Only : alternate",
         "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "query_result(floor(vector(time() / 300)))",
+        "description": "Hidden five-minute token that forces Grafana Geomap XYZ layer reinitialization so weather radar tiles can advance without a manual page reload.",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Radar refresh token",
+        "multi": false,
+        "name": "radar_refresh",
+        "options": [],
+        "query": {
+          "query": "query_result(floor(vector(time() / 300)))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.* ([0-9]+) .*/",
+        "skipUrlSync": true,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -18,9 +18,10 @@ CORE_MAP_LAYERS = {
     "Satellites",
 }
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
+RAINVIEWER_RADAR_REFRESH_VARIABLE = "radar_refresh"
 RAINVIEWER_RADAR_TILE_URL = (
     "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
-    "?refresh=${__to:date:YYYYMMDDHHmm}"
+    f"?refresh=${{{RAINVIEWER_RADAR_REFRESH_VARIABLE}}}"
 )
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
 HCX_COMM_LAYER_SOURCES = {"commka.geojson"}
@@ -141,10 +142,27 @@ def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_lay
     )
 
 
-def test_fullscreen_overview_rainviewer_cache_buster_is_bounded_to_minute() -> None:
+def test_fullscreen_overview_rainviewer_cache_buster_uses_refresh_variable() -> None:
+    dashboard = _fullscreen_overview_dashboard()
     radar_layer = _layers_by_name()[RADAR_LAYER_NAME]
+    variables_by_name = {
+        variable["name"]: variable for variable in dashboard["templating"]["list"]
+    }
+    refresh_variable = variables_by_name[RAINVIEWER_RADAR_REFRESH_VARIABLE]
 
-    assert radar_layer["config"]["url"].endswith("?refresh=${__to:date:YYYYMMDDHHmm}")
+    assert radar_layer["config"]["url"].endswith(
+        f"?refresh=${{{RAINVIEWER_RADAR_REFRESH_VARIABLE}}}"
+    )
+    assert refresh_variable["hide"] == 2
+    assert refresh_variable["refresh"] == 2
+    assert refresh_variable["type"] == "query"
+    assert refresh_variable["datasource"] == {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093",
+    }
+    assert refresh_variable["skipUrlSync"] is True
+    assert refresh_variable["regex"] == "/.* ([0-9]+) .*/"
+    assert "floor(vector(time() / 300))" in refresh_variable["definition"]
 
 
 def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:


### PR DESCRIPTION
## Summary
- fixes the weather radar stale-update boundary in Grafana Geomap by replacing the static `${__to}` macro cache-buster with a hidden `radar_refresh` dashboard variable
- the variable is refreshed from Prometheus on time range changes and changes only every 5 minutes, forcing Grafana's XYZ layer to reinitialize at a bounded cadence instead of relying on the tile source to reinterpret a URL after initialization
- keeps existing backend RainViewer request discipline intact: backend metadata is still cached for 5 minutes and tile requests still flow through the existing endpoint

## Root cause
Grafana's built-in XYZ layer calls `getTemplateSrv().replace(cfg.url)` only when the OpenLayers XYZ source is initialized. Dashboard refreshes update panel data, but the static XYZ layer does not rebuild its source on each refresh. That means the previous `${__to:date:YYYYMMDDHHmm}` token did not advance for an already-open fullscreen dashboard; it only changed after a map/layer reinitialization such as a manual page reload.

## Test plan
- `pytest tools/tests/test_fullscreen_overview_dashboard.py -q`
- `cd backend/starlink-location && pytest tests/unit/test_weather_api.py tests/unit/test_weather_radar.py -q`
- verified Prometheus accepts the refresh-token expression: `floor(vector(time() / 300))`
- verified live Grafana API exposes `radar_refresh` and the weather radar URL uses `?refresh=${radar_refresh}`

## Runtime verification notes
- No Python backend files changed, so the repo-mandated backend no-cache Docker rebuild path was not required for this change.
- The already-running Grafana instance picked up the provisioned dashboard JSON; API verification shows the hidden variable and updated radar URL live.
- I could not perform a pixel-level browser observation in this worker because no browser automation runtime is installed, but the inspected Grafana source shows variable changes trigger Geomap reinitialization while ordinary data refreshes do not.

Closes #77
