### PR TITLE
fix: stop radar refresh map reinitialization

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -382,7 +382,7 @@
               "attribution": "Weather radar \u00a9 Rain Viewer / MeteoLab Inc.",
               "maxZoom": 7,
               "minZoom": 0,
-              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png?refresh=${radar_refresh}"
+              "url": "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png?refresh=${__to:date:YYYYMMDDHHmm}"
             },
             "name": "Weather Radar (RainViewer)",
             "noRepeat": false,
@@ -1948,34 +1948,6 @@
         ],
         "query": "Departure & Arrival : departure\\,arrival, All POIs :  , Departure Only : departure, Arrival Only : arrival, Waypoints Only : waypoint, Alternates Only : alternate",
         "type": "custom"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "0",
-          "value": "0"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "definition": "query_result(floor(vector(time() / 300)))",
-        "description": "Hidden five-minute token that forces Grafana Geomap XYZ layer reinitialization so weather radar tiles can advance without a manual page reload.",
-        "hide": 2,
-        "includeAll": false,
-        "label": "Radar refresh token",
-        "multi": false,
-        "name": "radar_refresh",
-        "options": [],
-        "query": {
-          "query": "query_result(floor(vector(time() / 300)))",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/.* ([0-9]+) .*/",
-        "skipUrlSync": true,
-        "sort": 0,
-        "type": "query"
       }
     ]
   },

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -18,10 +18,9 @@ CORE_MAP_LAYERS = {
     "Satellites",
 }
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
-RAINVIEWER_RADAR_REFRESH_VARIABLE = "radar_refresh"
 RAINVIEWER_RADAR_TILE_URL = (
     "http://localhost:8000/api/weather/radar/rainviewer/{z}/{x}/{y}.png"
-    f"?refresh=${{{RAINVIEWER_RADAR_REFRESH_VARIABLE}}}"
+    "?refresh=${__to:date:YYYYMMDDHHmm}"
 )
 HCX_COMM_LAYER_TOKENS = {"CommKaOverlay", "HCX"}
 HCX_COMM_LAYER_SOURCES = {"commka.geojson"}
@@ -142,27 +141,13 @@ def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_lay
     )
 
 
-def test_fullscreen_overview_rainviewer_cache_buster_uses_refresh_variable() -> None:
+def test_fullscreen_overview_rainviewer_cache_buster_does_not_use_refresh_variable() -> None:
     dashboard = _fullscreen_overview_dashboard()
     radar_layer = _layers_by_name()[RADAR_LAYER_NAME]
-    variables_by_name = {
-        variable["name"]: variable for variable in dashboard["templating"]["list"]
-    }
-    refresh_variable = variables_by_name[RAINVIEWER_RADAR_REFRESH_VARIABLE]
+    variable_names = {variable["name"] for variable in dashboard["templating"]["list"]}
 
-    assert radar_layer["config"]["url"].endswith(
-        f"?refresh=${{{RAINVIEWER_RADAR_REFRESH_VARIABLE}}}"
-    )
-    assert refresh_variable["hide"] == 2
-    assert refresh_variable["refresh"] == 2
-    assert refresh_variable["type"] == "query"
-    assert refresh_variable["datasource"] == {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093",
-    }
-    assert refresh_variable["skipUrlSync"] is True
-    assert refresh_variable["regex"] == "/.* ([0-9]+) .*/"
-    assert "floor(vector(time() / 300))" in refresh_variable["definition"]
+    assert radar_layer["config"]["url"].endswith("?refresh=${__to:date:YYYYMMDDHHmm}")
+    assert "radar_refresh" not in variable_names
 
 
 def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:


### PR DESCRIPTION
## Summary
- backs out the PR #78 hidden Prometheus `radar_refresh` variable that was tied to Grafana time-range refresh
- restores the stable RainViewer radar tile URL used before the flashing regression
- adds dashboard regression coverage so the fullscreen radar layer does not depend on a refresh variable that can reinitialize the Geomap layer

## Root cause
PR #78 introduced a hidden Grafana query variable with `refresh: 2` and referenced it from the Geomap XYZ tile URL. The fullscreen dashboard refreshes every second, which continuously updates the dashboard time range; Grafana re-evaluates time-range-refresh variables and treats the templated XYZ URL as changed/reinitialized. That forces the Geomap layer/source through the same rebuild path that solved stale tiles, but on the operator display it presents as full-map flashing roughly once per second. The variable-driven layer rebuild was the wrong lever.

## Test plan
- [x] `pytest tools/tests/test_fullscreen_overview_dashboard.py::test_fullscreen_overview_rainviewer_cache_buster_does_not_use_refresh_variable -q` (fails before dashboard fix; passes after)
- [x] `pytest tools/tests/test_fullscreen_overview_dashboard.py -q`
- [x] `cd backend/starlink-location && pytest tests/unit/test_weather_api.py tests/unit/test_weather_radar.py -q`
- [x] `python -m json.tool monitoring/grafana/provisioning/dashboards/fullscreen-overview.json`
- [x] `python -m ruff check tools/tests/test_fullscreen_overview_dashboard.py`

## Runtime verification notes
- No Python backend files changed, so the repo-required backend no-cache Docker rebuild sequence was not required.
- `docker compose ps` shows Grafana/Prometheus/backend running and backend healthy.
- Grafana API for `starlink-fullscreen` now reports the radar URL as `?refresh=${__to:date:YYYYMMDDHHmm}` and `has_radar_refresh_variable: False` while the dashboard remains on `refresh: 1s`.
- I could not perform pixel-level browser observation in this worker, but the live dashboard JSON no longer contains the variable-driven mechanism that reinitialized the Geomap layer.

Closes #79
