### PR TITLE
fix: prefer Cloudflare trace for public IP

### DIFF
--- a/backend/starlink-location/app/services/ground_entry_point.py
+++ b/backend/starlink-location/app/services/ground_entry_point.py
@@ -7,6 +7,7 @@ import math
 import os
 import time
 from dataclasses import dataclass
+from ipaddress import AddressValueError, IPv4Address
 from typing import Callable
 
 import dns.resolver
@@ -22,6 +23,7 @@ from app.core.metrics.prometheus_metrics import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_REFRESH_INTERVAL_SECONDS = 1.0
+_CLOUDFLARE_TRACE_URL = "https://1.1.1.1/cdn-cgi/trace"
 _OPENDNS_RESOLVERS = ["208.67.222.222", "208.67.220.220"]
 _last_ground_entry_point_location_labels: tuple[str, str, str, str, str] | None = None
 _last_ground_entry_point_info_labels: tuple[str, str, str] | None = None
@@ -55,7 +57,7 @@ class GroundEntryPointResolver:
         poll_interval_seconds: float = _DEFAULT_REFRESH_INTERVAL_SECONDS,
         time_source: Callable[[], float] | None = None,
     ) -> None:
-        self._ip_resolver = ip_resolver or resolve_public_ip_via_dns
+        self._ip_resolver = ip_resolver or resolve_public_ip
         self._geolocator = geolocator or geolocate_public_ip
         self._poll_interval_seconds = poll_interval_seconds
         self._time_source = time_source or time.monotonic
@@ -132,8 +134,35 @@ class GroundEntryPointResolver:
         return entry
 
 
+def resolve_public_ip(timeout_seconds: float = 2.0) -> str | None:
+    """Resolve the current public IPv4, preferring Cloudflare trace."""
+    try:
+        ip = resolve_public_ip_via_cloudflare_trace(timeout_seconds=timeout_seconds)
+    except Exception as exc:  # pragma: no cover - defensive network guard
+        logger.warning("Cloudflare trace public-IP lookup failed: %s", exc)
+        ip = None
+    if ip:
+        return ip
+
+    try:
+        return resolve_public_ip_via_dns(timeout_seconds=timeout_seconds)
+    except Exception as exc:  # pragma: no cover - defensive network guard
+        logger.warning("OpenDNS public-IP lookup failed: %s", exc)
+        return None
+
+
+def resolve_public_ip_via_cloudflare_trace(
+    timeout_seconds: float = 2.0,
+) -> str | None:
+    """Resolve the current public IPv4 using Cloudflare's trace endpoint."""
+    with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
+        response = client.get(_CLOUDFLARE_TRACE_URL)
+        response.raise_for_status()
+        return _extract_cloudflare_trace_ipv4(response.text)
+
+
 def resolve_public_ip_via_dns(timeout_seconds: float = 2.0) -> str | None:
-    """Resolve the current public IP using OpenDNS rather than HTTP."""
+    """Resolve the current public IPv4 using OpenDNS as a fallback."""
     resolver = dns.resolver.Resolver(configure=False)
     resolver.nameservers = _OPENDNS_RESOLVERS
     resolver.timeout = timeout_seconds
@@ -141,7 +170,24 @@ def resolve_public_ip_via_dns(timeout_seconds: float = 2.0) -> str | None:
     answers = list(resolver.resolve("myip.opendns.com", "A", search=False))
     if not answers:
         return None
-    return str(answers[0]).strip()
+    return _normalize_ipv4_address(str(answers[0]).strip())
+
+
+def _extract_cloudflare_trace_ipv4(trace_body: str) -> str | None:
+    """Extract and validate the ``ip=`` IPv4 value from Cloudflare trace text."""
+    for line in trace_body.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key == "ip":
+            return _normalize_ipv4_address(value.strip())
+    return None
+
+
+def _normalize_ipv4_address(value: str) -> str | None:
+    """Return a canonical IPv4 string, or None when the value is not IPv4."""
+    try:
+        return str(IPv4Address(value))
+    except AddressValueError:
+        return None
 
 
 def geolocate_public_ip(
@@ -183,13 +229,13 @@ def invalidate_cached_ground_entry_point() -> None:
 def discover_ground_entry_point(
     timeout_seconds: float = 5.0,
 ) -> GroundEntryPoint | None:
-    """Discover the public egress IP and geolocate it with DNS-based IP lookup."""
+    """Discover the public egress IP and geolocate it."""
     configured = _entry_point_from_environment()
     if configured is not None:
         return configured
 
     resolver = GroundEntryPointResolver(
-        ip_resolver=lambda: resolve_public_ip_via_dns(timeout_seconds=min(timeout_seconds, 2.0)),
+        ip_resolver=lambda: resolve_public_ip(timeout_seconds=min(timeout_seconds, 2.0)),
         geolocator=lambda ip: geolocate_public_ip(ip, timeout_seconds=timeout_seconds),
     )
     return resolver.refresh(force=True)

--- a/backend/starlink-location/tests/unit/test_ground_entry_point.py
+++ b/backend/starlink-location/tests/unit/test_ground_entry_point.py
@@ -21,6 +21,72 @@ def setup_function() -> None:
     gep._last_ground_entry_point_refresh_monotonic = None
 
 
+def test_extract_cloudflare_trace_ipv4_reads_valid_ip_line() -> None:
+    trace_body = """fl=123f45
+h=1.1.1.1
+ip=203.0.113.10
+ts=1781950000.123
+"""
+
+    assert gep._extract_cloudflare_trace_ipv4(trace_body) == "203.0.113.10"
+
+
+def test_extract_cloudflare_trace_ipv4_rejects_missing_or_non_ipv4_values() -> None:
+    assert gep._extract_cloudflare_trace_ipv4("h=1.1.1.1\nloc=US\n") is None
+    assert gep._extract_cloudflare_trace_ipv4("ip=2001:db8::1\n") is None
+    assert gep._extract_cloudflare_trace_ipv4("ip=999.0.0.1\n") is None
+
+
+def test_resolve_public_ip_prefers_cloudflare_trace(monkeypatch) -> None:
+    lookup_timeouts: list[float] = []
+
+    def trace_lookup(timeout_seconds: float) -> str:
+        lookup_timeouts.append(timeout_seconds)
+        return "203.0.113.10"
+
+    def dns_lookup(timeout_seconds: float) -> str:  # pragma: no cover - must not run
+        raise AssertionError("OpenDNS fallback should not run after trace succeeds")
+
+    monkeypatch.setattr(gep, "resolve_public_ip_via_cloudflare_trace", trace_lookup)
+    monkeypatch.setattr(gep, "resolve_public_ip_via_dns", dns_lookup)
+
+    assert gep.resolve_public_ip(timeout_seconds=1.5) == "203.0.113.10"
+    assert lookup_timeouts == [1.5]
+
+
+def test_resolve_public_ip_falls_back_to_dns_when_trace_has_no_ipv4(
+    monkeypatch,
+) -> None:
+    lookup_order: list[str] = []
+
+    def trace_lookup(timeout_seconds: float) -> None:
+        lookup_order.append(f"trace:{timeout_seconds}")
+        return None
+
+    def dns_lookup(timeout_seconds: float) -> str:
+        lookup_order.append(f"dns:{timeout_seconds}")
+        return "198.51.100.24"
+
+    monkeypatch.setattr(gep, "resolve_public_ip_via_cloudflare_trace", trace_lookup)
+    monkeypatch.setattr(gep, "resolve_public_ip_via_dns", dns_lookup)
+
+    assert gep.resolve_public_ip(timeout_seconds=1.25) == "198.51.100.24"
+    assert lookup_order == ["trace:1.25", "dns:1.25"]
+
+
+def test_resolve_public_ip_returns_none_when_all_sources_fail(monkeypatch) -> None:
+    def trace_lookup(timeout_seconds: float) -> None:
+        raise RuntimeError("trace unavailable")
+
+    def dns_lookup(timeout_seconds: float) -> None:
+        raise RuntimeError("dns unavailable")
+
+    monkeypatch.setattr(gep, "resolve_public_ip_via_cloudflare_trace", trace_lookup)
+    monkeypatch.setattr(gep, "resolve_public_ip_via_dns", dns_lookup)
+
+    assert gep.resolve_public_ip() is None
+
+
 def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -> None:
     entry_point = GroundEntryPoint(
         ip="203.0.113.10",


### PR DESCRIPTION
## Summary
- Prefer Cloudflare trace for public IPv4 detection, matching the user-verified source after the CGNAT-to-public-IP service change.
- Keep OpenDNS as a validated fallback instead of the primary resolver.
- Preserve the existing 1 Hz polling, geolocate-on-change behavior, and per-IP cache.
- Add focused regression coverage for Cloudflare trace parsing plus fallback/failure behavior.

## Verification
- `python -m pytest tests/unit/test_ground_entry_point.py -q` — 12 passed
- `python -m ruff check app/services/ground_entry_point.py tests/unit/test_ground_entry_point.py` — passed
- `python -m pytest -q` — 889 passed, 22 skipped
- Runtime resolver check in this worker environment: Cloudflare trace, OpenDNS, and selected resolver all returned `70.171.184.194`.
- Required Docker lifecycle rebuild and health sequence was attempted but blocked by the terminal approval gate at the container-stop step; Docker is installed (`Docker 29.1.3`, Compose `2.40.3`).

Closes #81
