### PR TITLE
fix: format GEP location labels

### DIFF
--- a/backend/starlink-location/app/core/metrics/prometheus_metrics.py
+++ b/backend/starlink-location/app/core/metrics/prometheus_metrics.py
@@ -146,14 +146,14 @@ starlink_ground_entry_point_longitude_degrees = Gauge(
 starlink_ground_entry_point_location = Gauge(
     "starlink_ground_entry_point_location",
     "Ground entry point location with labels for Grafana geomap display",
-    labelnames=["lat", "lon", "city", "country", "ip"],
+    labelnames=["lat", "lon", "city", "region", "country", "ip", "display"],
     registry=REGISTRY,
 )
 
 starlink_ground_entry_point_info = Gauge(
     "starlink_ground_entry_point_info",
     "Ground entry point identity information",
-    labelnames=["city", "country", "ip"],
+    labelnames=["city", "region", "country", "ip", "display"],
     registry=REGISTRY,
 )
 

--- a/backend/starlink-location/app/services/ground_entry_point.py
+++ b/backend/starlink-location/app/services/ground_entry_point.py
@@ -25,8 +25,10 @@ logger = logging.getLogger(__name__)
 _DEFAULT_REFRESH_INTERVAL_SECONDS = 1.0
 _CLOUDFLARE_TRACE_URL = "https://1.1.1.1/cdn-cgi/trace"
 _OPENDNS_RESOLVERS = ["208.67.222.222", "208.67.220.220"]
-_last_ground_entry_point_location_labels: tuple[str, str, str, str, str] | None = None
-_last_ground_entry_point_info_labels: tuple[str, str, str] | None = None
+_last_ground_entry_point_location_labels: (
+    tuple[str, str, str, str, str, str, str] | None
+) = None
+_last_ground_entry_point_info_labels: tuple[str, str, str, str, str] | None = None
 _last_ground_entry_point_refresh_monotonic: float | None = None
 
 
@@ -39,11 +41,16 @@ class GroundEntryPoint:
     country: str
     latitude: float
     longitude: float
+    region: str = ""
 
     @property
     def label(self) -> str:
-        """Return compact city/country display text for dashboards."""
-        parts = [part for part in (self.city, self.country) if part]
+        """Return compact, punctuation-safe display text for dashboards."""
+        parts = _display_location_parts(
+            city=self.city,
+            region=self.region,
+            country=self.country,
+        )
         return ", ".join(parts) if parts else "Unknown"
 
 
@@ -211,8 +218,9 @@ def geolocate_public_ip(
 
     return GroundEntryPoint(
         ip=str(payload.get("ip") or ip),
-        city=str(payload.get("city") or ""),
-        country=str(payload.get("country") or ""),
+        city=_clean_location_part(payload.get("city")),
+        region=_clean_location_part(payload.get("region")),
+        country=_clean_location_part(payload.get("country")),
         latitude=latitude,
         longitude=longitude,
     )
@@ -235,7 +243,9 @@ def discover_ground_entry_point(
         return configured
 
     resolver = GroundEntryPointResolver(
-        ip_resolver=lambda: resolve_public_ip(timeout_seconds=min(timeout_seconds, 2.0)),
+        ip_resolver=lambda: resolve_public_ip(
+            timeout_seconds=min(timeout_seconds, 2.0)
+        ),
         geolocator=lambda ip: geolocate_public_ip(ip, timeout_seconds=timeout_seconds),
     )
     return resolver.refresh(force=True)
@@ -264,7 +274,9 @@ def clear_ground_entry_point_metrics() -> None:
 
     if _last_ground_entry_point_info_labels is not None:
         try:
-            starlink_ground_entry_point_info.remove(*_last_ground_entry_point_info_labels)
+            starlink_ground_entry_point_info.remove(
+                *_last_ground_entry_point_info_labels
+            )
         except KeyError:
             pass
         _last_ground_entry_point_info_labels = None
@@ -284,10 +296,18 @@ def publish_ground_entry_point_metrics(entry_point: GroundEntryPoint | None) -> 
         lat_label,
         lon_label,
         entry_point.city,
+        entry_point.region,
         entry_point.country,
         entry_point.ip,
+        entry_point.label,
     )
-    info_labels = (entry_point.city, entry_point.country, entry_point.ip)
+    info_labels = (
+        entry_point.city,
+        entry_point.region,
+        entry_point.country,
+        entry_point.ip,
+        entry_point.label,
+    )
 
     starlink_ground_entry_point_latitude_degrees.set(entry_point.latitude)
     starlink_ground_entry_point_longitude_degrees.set(entry_point.longitude)
@@ -295,13 +315,17 @@ def publish_ground_entry_point_metrics(entry_point: GroundEntryPoint | None) -> 
         lat=location_labels[0],
         lon=location_labels[1],
         city=location_labels[2],
-        country=location_labels[3],
-        ip=location_labels[4],
+        region=location_labels[3],
+        country=location_labels[4],
+        ip=location_labels[5],
+        display=location_labels[6],
     ).set(1)
     starlink_ground_entry_point_info.labels(
         city=info_labels[0],
-        country=info_labels[1],
-        ip=info_labels[2],
+        region=info_labels[1],
+        country=info_labels[2],
+        ip=info_labels[3],
+        display=info_labels[4],
     ).set(1)
 
     _last_ground_entry_point_location_labels = location_labels
@@ -343,9 +367,11 @@ def maybe_refresh_ground_entry_point_metrics(
 
     current_monotonic = time.monotonic() if now_monotonic is None else now_monotonic
 
-    if _last_ground_entry_point_refresh_monotonic is None or (
-        current_monotonic - _last_ground_entry_point_refresh_monotonic
-    ) >= interval_seconds:
+    if (
+        _last_ground_entry_point_refresh_monotonic is None
+        or (current_monotonic - _last_ground_entry_point_refresh_monotonic)
+        >= interval_seconds
+    ):
         return refresh_ground_entry_point_metrics(now_monotonic=current_monotonic)
 
     return get_cached_ground_entry_point()
@@ -365,8 +391,33 @@ def _entry_point_from_environment() -> GroundEntryPoint | None:
         return None
     return GroundEntryPoint(
         ip=os.getenv("STARLINK_GROUND_ENTRY_IP", ""),
-        city=os.getenv("STARLINK_GROUND_ENTRY_CITY", ""),
-        country=os.getenv("STARLINK_GROUND_ENTRY_COUNTRY", ""),
+        city=_clean_location_part(os.getenv("STARLINK_GROUND_ENTRY_CITY")),
+        region=_clean_location_part(
+            os.getenv("STARLINK_GROUND_ENTRY_REGION")
+            or os.getenv("STARLINK_GROUND_ENTRY_STATE")
+        ),
+        country=_clean_location_part(os.getenv("STARLINK_GROUND_ENTRY_COUNTRY")),
         latitude=latitude,
         longitude=longitude,
     )
+
+
+def _display_location_parts(city: str, region: str, country: str) -> list[str]:
+    """Choose dashboard location parts without placeholder junk or punctuation gaps."""
+    clean_city = _clean_location_part(city)
+    clean_region = _clean_location_part(region)
+    clean_country = _clean_location_part(country)
+
+    if clean_country.upper() == "US" and clean_region:
+        return [part for part in (clean_city, clean_region) if part]
+    return [part for part in (clean_city, clean_country) if part]
+
+
+def _clean_location_part(value: object) -> str:
+    """Normalize empty/placeholder location fields to an empty string."""
+    if value is None:
+        return ""
+    text = str(value).strip().strip(",")
+    if text.lower() in {"", "none", "null", "unknown", "n/a", "na"}:
+        return ""
+    return text

--- a/backend/starlink-location/app/services/ground_entry_point.py
+++ b/backend/starlink-location/app/services/ground_entry_point.py
@@ -51,7 +51,7 @@ class GroundEntryPoint:
             region=self.region,
             country=self.country,
         )
-        return ", ".join(parts) if parts else "Unknown"
+        return ", ".join(parts) if parts else "Ground Entry Point"
 
 
 class GroundEntryPointResolver:

--- a/backend/starlink-location/tests/unit/test_ground_entry_point.py
+++ b/backend/starlink-location/tests/unit/test_ground_entry_point.py
@@ -161,6 +161,17 @@ def test_ground_entry_point_label_omits_empty_and_placeholder_parts() -> None:
         ).label
         == "JP"
     )
+    assert (
+        GroundEntryPoint(
+            ip="198.51.100.25",
+            city="null",
+            region="unknown",
+            country="n/a",
+            latitude=0.0,
+            longitude=0.0,
+        ).label
+        == "Ground Entry Point"
+    )
 
 
 def test_geolocate_public_ip_parses_ipinfo_region(monkeypatch) -> None:

--- a/backend/starlink-location/tests/unit/test_ground_entry_point.py
+++ b/backend/starlink-location/tests/unit/test_ground_entry_point.py
@@ -91,6 +91,7 @@ def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -
     entry_point = GroundEntryPoint(
         ip="203.0.113.10",
         city="Omaha",
+        region="Nebraska",
         country="US",
         latitude=41.2565,
         longitude=-95.9345,
@@ -101,12 +102,102 @@ def test_publish_ground_entry_point_metrics_exposes_location_and_info_labels() -
     output = generate_latest(REGISTRY).decode("utf-8")
     assert "starlink_ground_entry_point_location" in output
     assert 'city="Omaha"' in output
+    assert 'region="Nebraska"' in output
     assert 'country="US"' in output
+    assert 'display="Omaha, Nebraska"' in output
     assert 'ip="203.0.113.10"' in output
     assert 'lat="41.2565"' in output
     assert 'lon="-95.9345"' in output
     assert "starlink_ground_entry_point_latitude_degrees 41.2565" in output
     assert "starlink_ground_entry_point_longitude_degrees -95.9345" in output
+
+
+def test_ground_entry_point_label_formats_us_with_region() -> None:
+    entry_point = GroundEntryPoint(
+        ip="203.0.113.10",
+        city="Omaha",
+        region="Nebraska",
+        country="US",
+        latitude=41.2565,
+        longitude=-95.9345,
+    )
+
+    assert entry_point.label == "Omaha, Nebraska"
+
+
+def test_ground_entry_point_label_formats_non_us_with_country() -> None:
+    entry_point = GroundEntryPoint(
+        ip="198.51.100.24",
+        city="Tokyo",
+        region="Tokyo",
+        country="JP",
+        latitude=35.6764,
+        longitude=139.65,
+    )
+
+    assert entry_point.label == "Tokyo, JP"
+
+
+def test_ground_entry_point_label_omits_empty_and_placeholder_parts() -> None:
+    assert (
+        GroundEntryPoint(
+            ip="203.0.113.10",
+            city=" unknown ",
+            region="Nebraska",
+            country="US",
+            latitude=41.2565,
+            longitude=-95.9345,
+        ).label
+        == "Nebraska"
+    )
+    assert (
+        GroundEntryPoint(
+            ip="198.51.100.24",
+            city="",
+            region="None",
+            country="JP",
+            latitude=35.6764,
+            longitude=139.65,
+        ).label
+        == "JP"
+    )
+
+
+def test_geolocate_public_ip_parses_ipinfo_region(monkeypatch) -> None:
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {
+                "ip": "203.0.113.10",
+                "city": "Omaha",
+                "region": "Nebraska",
+                "country": "US",
+                "loc": "41.2565,-95.9345",
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def get(self, url: str) -> FakeResponse:
+            assert url == "https://ipinfo.io/203.0.113.10/json"
+            return FakeResponse()
+
+    monkeypatch.setattr(gep.httpx, "Client", FakeClient)
+
+    entry_point = gep.geolocate_public_ip("203.0.113.10")
+
+    assert entry_point is not None
+    assert entry_point.region == "Nebraska"
+    assert entry_point.label == "Omaha, Nebraska"
 
 
 def test_refresh_ground_entry_point_metrics_replaces_labels(monkeypatch) -> None:

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -1716,7 +1716,7 @@
           },
           "expr": "starlink_ground_entry_point_info",
           "instant": true,
-          "legendFormat": "{{city}}, {{country}}",
+          "legendFormat": "{{display}}",
           "refId": "A"
         }
       ],

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -141,7 +141,9 @@ def test_fullscreen_overview_has_optional_rainviewer_radar_below_operational_lay
     )
 
 
-def test_fullscreen_overview_rainviewer_cache_buster_does_not_use_refresh_variable() -> None:
+def test_fullscreen_overview_rainviewer_cache_buster_does_not_use_refresh_variable() -> (
+    None
+):
     dashboard = _fullscreen_overview_dashboard()
     radar_layer = _layers_by_name()[RADAR_LAYER_NAME]
     variable_names = {variable["name"] for variable in dashboard["templating"]["list"]}
@@ -223,6 +225,23 @@ def test_fullscreen_overview_places_obstruction_gauge_between_ground_entry_point
         layers_by_name["Ground Entry Point"]["config"]["coords"]["lon"]
         == "starlink_ground_entry_point_longitude_degrees"
     )
+
+
+def test_fullscreen_overview_ground_entry_point_uses_safe_display_label() -> None:
+    ground_entry_panel = _panel_by_title("Ground Entry Point")
+
+    assert ground_entry_panel["targets"] == [
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093",
+            },
+            "expr": "starlink_ground_entry_point_info",
+            "instant": True,
+            "legendFormat": "{{display}}",
+            "refId": "A",
+        }
+    ]
 
 
 def test_fullscreen_overview_obstruction_gauge_uses_absolute_thresholds() -> None:


### PR DESCRIPTION
## Summary
- Adds ipinfo `region` support to the GEP data model, environment override path, and Prometheus labels.
- Publishes a sanitized `display` label so Grafana renders safe location text instead of hard-coding `{{city}}, {{country}}`.
- Updates focused backend and dashboard tests for U.S., non-U.S., partial, and placeholder location cases.

## Data-path assumptions
- ipinfo returns U.S. state/region in the `region` field; no synthetic state data is invented when it is absent.
- The existing `country` label remains whatever upstream supplies (currently ipinfo country code, e.g. `US`/`JP`).
- Grafana reads the preformatted Prometheus `display` label so incomplete fields degrade without dangling punctuation.

## Cases verified
- U.S. complete location: `Omaha, Nebraska` from city + region when country is `US`.
- Non-U.S. complete location: `Tokyo, JP` from city + country, ignoring region for display.
- Partial/placeholder fields: joins only meaningful values; omits empty, `unknown`, `None`, `null`, `n/a`, and dangling commas.
- All-placeholder/no meaningful fields: display falls back to `Ground Entry Point` rather than emitting placeholder junk.

## Verification
- `python -m black backend/starlink-location/app/services/ground_entry_point.py backend/starlink-location/app/core/metrics/prometheus_metrics.py backend/starlink-location/tests/unit/test_ground_entry_point.py tools/tests/test_fullscreen_overview_dashboard.py`
- `python -m ruff check backend/starlink-location/app/services/ground_entry_point.py backend/starlink-location/app/core/metrics/prometheus_metrics.py backend/starlink-location/tests/unit/test_ground_entry_point.py tools/tests/test_fullscreen_overview_dashboard.py`
- `python -m pytest backend/starlink-location/tests/unit/test_ground_entry_point.py tools/tests/test_fullscreen_overview_dashboard.py -q` (29 passed, 3 existing warnings)
- `docker compose build --no-cache starlink-location` (passed)
- One-off runtime health check from rebuilt `starlink-location` image on port 18082 returned HTTP 200 JSON with `status: degraded`, `mode: simulation`; degraded is expected because Prometheus had not scraped the temporary container.

## Notes
- The full repository Docker restart sequence was not used because this isolated checkout conflicts with existing fixed container names (`starlink-location`, etc.). Instead, the backend image was rebuilt no-cache and started as an isolated one-off container for the health check.
- Documentation impact: none; dashboard/backend behavior only.

Closes #83
