### PR TITLE
feat: add active X-band link overlay

### DIFF
--- a/backend/starlink-location/app/api/active_x_link.py
+++ b/backend/starlink-location/app/api/active_x_link.py
@@ -1,0 +1,40 @@
+"""Active X-band satellite link overlay endpoint."""
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from app.mission.dependencies import get_poi_manager, get_route_manager
+from app.services.active_x_link import build_active_x_link
+from app.services.poi_manager import POIManager
+from app.services.route_manager import RouteManager
+
+router = APIRouter(prefix="/api", tags=["active-x-link"])
+
+
+def get_coordinator(request: Request) -> Any:
+    """Get telemetry coordinator from app state."""
+    return getattr(request.app.state, "coordinator", None)
+
+
+@router.get(
+    "/active-x-link",
+    response_model=dict,
+    summary="Get active X-band aircraft-to-satellite link coordinates",
+)
+async def get_active_x_link(
+    state: Literal["normal", "warning"] | None = Query(
+        None,
+        description="Optional state filter for split Grafana route layers",
+    ),
+    coordinator: Any = Depends(get_coordinator),
+    route_manager: RouteManager = Depends(get_route_manager),
+    poi_manager: POIManager = Depends(get_poi_manager),
+) -> dict[str, Any]:
+    """Return two route points for the current aircraft-to-active-X satellite link."""
+    return build_active_x_link(
+        coordinator=coordinator,
+        route_manager=route_manager,
+        poi_manager=poi_manager,
+        state_filter=state,
+    )

--- a/backend/starlink-location/app/services/active_x_link.py
+++ b/backend/starlink-location/app/services/active_x_link.py
@@ -1,0 +1,204 @@
+"""Active X-band satellite link overlay data builder."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from app.mission import storage
+from app.mission.models import MissionLeg, XTransition
+from app.models.poi import POI
+from app.models.route import ParsedRoute
+from app.models.telemetry import TelemetryData
+from app.satellites.geometry import is_in_azimuth_range
+from app.satellites.rules import RuleEngine
+from app.services.route_eta_calculator import RouteETACalculator
+
+logger = logging.getLogger(__name__)
+
+LinkState = Literal["normal", "warning"]
+
+
+def empty_active_x_link(state: str | None = None) -> dict[str, Any]:
+    """Return an empty, Grafana-friendly active-X link response."""
+    return {
+        "coordinates": [],
+        "total": 0,
+        "satellite_id": None,
+        "state": state,
+        "color": None,
+        "relative_azimuth_degrees": None,
+        "in_forbidden_window": None,
+    }
+
+
+def build_active_x_link(
+    coordinator: Any,
+    route_manager: Any,
+    poi_manager: Any,
+    state_filter: LinkState | None = None,
+) -> dict[str, Any]:
+    """Build a two-point route from aircraft to active X-band satellite.
+
+    The active satellite is resolved from the active mission leg. X transitions
+    are ordered by their projected progress along the active route, matching the
+    mission timeline's route-projection semantics for live route-following use.
+    The visual state is derived from the existing normal X-band forbidden
+    relative-azimuth rule window (135°–225°).
+    """
+    try:
+        telemetry = coordinator.get_current_telemetry() if coordinator else None
+    except Exception as exc:  # pragma: no cover - defensive live-mode guard
+        logger.debug("Active X link unavailable: telemetry missing: %s", exc)
+        return empty_active_x_link(state_filter)
+
+    if telemetry is None:
+        return empty_active_x_link(state_filter)
+
+    route = route_manager.get_active_route() if route_manager else None
+    active_leg = _find_active_mission_leg()
+    if active_leg is None:
+        return empty_active_x_link(state_filter)
+
+    satellite_id = _resolve_active_satellite_id(active_leg, route, telemetry)
+    if not satellite_id:
+        return empty_active_x_link(state_filter)
+
+    satellite = _find_satellite_poi(poi_manager, satellite_id)
+    if satellite is None:
+        return empty_active_x_link(state_filter)
+
+    link_state, color, relative_azimuth, in_forbidden = _evaluate_link_state(
+        telemetry, satellite
+    )
+    if state_filter is not None and link_state != state_filter:
+        return {
+            **empty_active_x_link(state_filter),
+            "satellite_id": satellite_id,
+            "state": link_state,
+            "color": color,
+            "relative_azimuth_degrees": relative_azimuth,
+            "in_forbidden_window": in_forbidden,
+        }
+
+    aircraft = telemetry.position
+    common = {
+        "satellite_id": satellite_id,
+        "state": link_state,
+        "color": color,
+        "relative_azimuth_degrees": relative_azimuth,
+        "in_forbidden_window": in_forbidden,
+    }
+    coordinates = [
+        {
+            **common,
+            "point": "aircraft",
+            "sequence": 0,
+            "latitude": aircraft.latitude,
+            "longitude": aircraft.longitude,
+        },
+        {
+            **common,
+            "point": "satellite",
+            "sequence": 1,
+            "latitude": satellite.latitude,
+            "longitude": satellite.longitude,
+        },
+    ]
+    return {**common, "coordinates": coordinates, "total": len(coordinates)}
+
+
+def _find_active_mission_leg() -> MissionLeg | None:
+    missions_dir = storage.MISSIONS_DIR
+    if not missions_dir.exists():
+        return None
+
+    for mission_dir in sorted(missions_dir.iterdir()):
+        if not mission_dir.is_dir():
+            continue
+        mission = storage.load_mission_v2(mission_dir.name)
+        if mission is None:
+            continue
+        for leg in mission.legs:
+            if leg.is_active:
+                return leg
+    return None
+
+
+def _resolve_active_satellite_id(
+    leg: MissionLeg,
+    route: ParsedRoute | None,
+    telemetry: TelemetryData,
+) -> str | None:
+    current_satellite = leg.transports.initial_x_satellite_id
+    if not current_satellite:
+        return None
+    if route is None or not leg.transports.x_transitions:
+        return current_satellite
+
+    current_progress = _project_progress(
+        route,
+        telemetry.position.latitude,
+        telemetry.position.longitude,
+    )
+    if current_progress is None:
+        return current_satellite
+
+    transitions: list[tuple[float, XTransition]] = []
+    for transition in leg.transports.x_transitions:
+        progress = _project_progress(route, transition.latitude, transition.longitude)
+        if progress is not None:
+            transitions.append((progress, transition))
+
+    for progress, transition in sorted(transitions, key=lambda item: item[0]):
+        if current_progress >= progress and transition.target_satellite_id:
+            current_satellite = transition.target_satellite_id
+    return current_satellite
+
+
+def _project_progress(
+    route: ParsedRoute,
+    latitude: float,
+    longitude: float,
+) -> float | None:
+    try:
+        projection = RouteETACalculator(route).project_poi_to_route(latitude, longitude)
+    except Exception as exc:  # pragma: no cover - defensive geometry guard
+        logger.debug("Failed to project active X link point onto route: %s", exc)
+        return None
+    progress = projection.get("projected_route_progress")
+    return float(progress) if progress is not None else None
+
+
+def _find_satellite_poi(poi_manager: Any, satellite_id: str) -> POI | None:
+    if poi_manager is None:
+        return None
+    for poi in poi_manager.list_pois():
+        if poi.category == "satellite" and poi.name == satellite_id:
+            return poi
+    return None
+
+
+def _evaluate_link_state(
+    telemetry: TelemetryData, satellite: POI
+) -> tuple[str, str, float, bool]:
+    rule_engine = RuleEngine()
+    aircraft = telemetry.position
+    altitude_m = aircraft.altitude * 0.3048
+    _is_violation, relative_azimuth, _debug = rule_engine.evaluate_x_azimuth_window(
+        aircraft_lat=aircraft.latitude,
+        aircraft_lon=aircraft.longitude,
+        aircraft_alt=altitude_m,
+        satellite_lon=satellite.longitude,
+        timestamp=telemetry.timestamp,
+        heading_deg=aircraft.heading,
+        is_aar_mode=False,
+    )
+    in_forbidden = is_in_azimuth_range(
+        relative_azimuth,
+        rule_engine.config.normal_azimuth_min,
+        rule_engine.config.normal_azimuth_max,
+    )
+    if in_forbidden:
+        return "warning", "yellow", round(relative_azimuth, 1), True
+    return "normal", "green", round(relative_azimuth, 1), False

--- a/backend/starlink-location/app/services/active_x_link.py
+++ b/backend/starlink-location/app/services/active_x_link.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Literal
 
 from app.mission import storage
@@ -56,7 +57,7 @@ def build_active_x_link(
         return empty_active_x_link(state_filter)
 
     route = route_manager.get_active_route() if route_manager else None
-    active_leg = _find_active_mission_leg()
+    active_leg = _find_active_mission_leg(route)
     if active_leg is None:
         return empty_active_x_link(state_filter)
 
@@ -108,11 +109,13 @@ def build_active_x_link(
     return {**common, "coordinates": coordinates, "total": len(coordinates)}
 
 
-def _find_active_mission_leg() -> MissionLeg | None:
+def _find_active_mission_leg(route: ParsedRoute | None = None) -> MissionLeg | None:
     missions_dir = storage.MISSIONS_DIR
     if not missions_dir.exists():
         return None
 
+    active_route_id = _route_id(route) if route is not None else None
+    first_active_leg: MissionLeg | None = None
     for mission_dir in sorted(missions_dir.iterdir()):
         if not mission_dir.is_dir():
             continue
@@ -120,9 +123,20 @@ def _find_active_mission_leg() -> MissionLeg | None:
         if mission is None:
             continue
         for leg in mission.legs:
-            if leg.is_active:
+            if not leg.is_active:
+                continue
+            if first_active_leg is None:
+                first_active_leg = leg
+            if active_route_id is not None and leg.route_id == active_route_id:
                 return leg
-    return None
+    return first_active_leg
+
+
+def _route_id(route: ParsedRoute) -> str | None:
+    file_path = route.metadata.file_path
+    if not file_path:
+        return None
+    return Path(file_path).stem
 
 
 def _resolve_active_satellite_id(

--- a/backend/starlink-location/main.py
+++ b/backend/starlink-location/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.api import (
+    active_x_link,
     config,
     export,
     flight_status,
@@ -133,6 +134,7 @@ async def startup_event():
         )
 
         # Register coordinator with API modules
+        app.state.coordinator = _coordinator
         health.set_coordinator(_coordinator)
         status.set_coordinator(_coordinator)
         config.set_coordinator(_coordinator)
@@ -337,7 +339,6 @@ async def _background_update_loop(poi_manager=None):
             extra_fields={"value": os.getenv("STARLINK_GROUND_ENTRY_REFRESH_SECONDS")},
         )
 
-
     try:
         logger.info_json("Background update loop started")
 
@@ -522,6 +523,7 @@ async def generic_exception_handler(request: Request, exc: Exception):
 # Register API routers
 app.include_router(health.router, tags=["Health"])
 app.include_router(metrics.router, tags=["Metrics"])
+app.include_router(active_x_link.router, tags=["Active X Link"])
 app.include_router(status.router, tags=["Status"])
 app.include_router(config.router, tags=["Configuration"])
 app.include_router(flight_status.router, tags=["Flight Status"])

--- a/backend/starlink-location/tests/unit/test_active_x_link.py
+++ b/backend/starlink-location/tests/unit/test_active_x_link.py
@@ -1,0 +1,214 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.mission.models import Mission, MissionLeg, TransportConfig, XTransition
+from app.mission.storage import save_mission_v2
+from app.models.poi import POI
+from app.models.route import ParsedRoute, RouteMetadata, RoutePoint
+from app.models.telemetry import (
+    EnvironmentalData,
+    NetworkData,
+    ObstructionData,
+    PositionData,
+    TelemetryData,
+)
+from app.services.active_x_link import build_active_x_link
+from main import app
+
+
+class StaticCoordinator:
+    def __init__(self, telemetry: TelemetryData):
+        self.telemetry = telemetry
+
+    def get_current_telemetry(self) -> TelemetryData:
+        return self.telemetry
+
+
+class StaticRouteManager:
+    def __init__(self, route: ParsedRoute | None):
+        self.route = route
+
+    def get_active_route(self) -> ParsedRoute | None:
+        return self.route
+
+
+class StaticPOIManager:
+    def __init__(self, pois: list[POI]):
+        self.pois = pois
+
+    def list_pois(self):
+        return self.pois
+
+
+def _telemetry(latitude: float, longitude: float, heading: float) -> TelemetryData:
+    return TelemetryData(
+        timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        position=PositionData(
+            latitude=latitude,
+            longitude=longitude,
+            altitude=35000.0,
+            speed=450.0,
+            heading=heading,
+        ),
+        network=NetworkData(
+            latency_ms=40.0,
+            throughput_down_mbps=120.0,
+            throughput_up_mbps=20.0,
+            packet_loss_percent=0.0,
+        ),
+        obstruction=ObstructionData(obstruction_percent=0.0),
+        environmental=EnvironmentalData(),
+    )
+
+
+def _route() -> ParsedRoute:
+    return ParsedRoute(
+        metadata=RouteMetadata(
+            name="Test route",
+            file_path="/tmp/test-route.kml",
+            point_count=3,
+        ),
+        points=[
+            RoutePoint(latitude=0.0, longitude=0.0, sequence=0),
+            RoutePoint(latitude=0.0, longitude=10.0, sequence=1),
+            RoutePoint(latitude=0.0, longitude=20.0, sequence=2),
+        ],
+    )
+
+
+def _satellite(name: str, longitude: float) -> POI:
+    return POI(
+        id=name.lower(),
+        name=name,
+        latitude=0.0,
+        longitude=longitude,
+        icon="X",
+        category="satellite",
+    )
+
+
+def test_active_x_link_endpoint_is_registered() -> None:
+    assert any(
+        getattr(route, "path", None) == "/api/active-x-link" for route in app.routes
+    )
+
+
+def _save_active_mission(tmp_path: Path) -> None:
+    mission = Mission(
+        id="mission-85",
+        name="Mission 85",
+        legs=[
+            MissionLeg(
+                id="leg-1",
+                name="Leg 1",
+                route_id="test-route",
+                is_active=True,
+                transports=TransportConfig(
+                    initial_x_satellite_id="X-1",
+                    x_transitions=[
+                        XTransition(
+                            id="x-swap",
+                            latitude=0.0,
+                            longitude=10.0,
+                            target_satellite_id="X-2",
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
+    save_mission_v2(mission)
+
+
+def test_active_x_link_uses_transitioned_satellite_after_projected_transition(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    _save_active_mission(tmp_path)
+
+    result = build_active_x_link(
+        coordinator=StaticCoordinator(
+            _telemetry(latitude=0.0, longitude=15.0, heading=90.0)
+        ),
+        route_manager=StaticRouteManager(_route()),
+        poi_manager=StaticPOIManager([_satellite("X-1", 0.0), _satellite("X-2", 30.0)]),
+    )
+
+    assert result["satellite_id"] == "X-2"
+    assert result["total"] == 2
+    assert [point["point"] for point in result["coordinates"]] == [
+        "aircraft",
+        "satellite",
+    ]
+    assert result["coordinates"][0]["longitude"] == 15.0
+    assert result["coordinates"][1]["longitude"] == 30.0
+
+
+def test_active_x_link_marks_green_outside_normal_forbidden_window(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    mission = Mission(
+        id="mission-85",
+        name="Mission 85",
+        legs=[
+            MissionLeg(
+                id="leg-1",
+                name="Leg 1",
+                route_id="test-route",
+                is_active=True,
+                transports=TransportConfig(initial_x_satellite_id="X-1"),
+            )
+        ],
+    )
+    save_mission_v2(mission)
+
+    result = build_active_x_link(
+        coordinator=StaticCoordinator(
+            _telemetry(latitude=0.0, longitude=0.0, heading=90.0)
+        ),
+        route_manager=StaticRouteManager(_route()),
+        poi_manager=StaticPOIManager([_satellite("X-1", 30.0)]),
+    )
+
+    assert result["state"] == "normal"
+    assert result["color"] == "green"
+    assert result["in_forbidden_window"] is False
+
+
+def test_active_x_link_marks_warning_inside_normal_forbidden_window(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    mission = Mission(
+        id="mission-85",
+        name="Mission 85",
+        legs=[
+            MissionLeg(
+                id="leg-1",
+                name="Leg 1",
+                route_id="test-route",
+                is_active=True,
+                transports=TransportConfig(initial_x_satellite_id="X-1"),
+            )
+        ],
+    )
+    save_mission_v2(mission)
+
+    result = build_active_x_link(
+        coordinator=StaticCoordinator(
+            _telemetry(latitude=0.0, longitude=0.0, heading=270.0)
+        ),
+        route_manager=StaticRouteManager(_route()),
+        poi_manager=StaticPOIManager([_satellite("X-1", 30.0)]),
+    )
+
+    assert result["state"] == "warning"
+    assert result["color"] == "yellow"
+    assert result["in_forbidden_window"] is True

--- a/backend/starlink-location/tests/unit/test_active_x_link.py
+++ b/backend/starlink-location/tests/unit/test_active_x_link.py
@@ -120,6 +120,52 @@ def _save_active_mission(tmp_path: Path) -> None:
     save_mission_v2(mission)
 
 
+def test_active_x_link_prefers_active_leg_matching_active_route(tmp_path, monkeypatch):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    save_mission_v2(
+        Mission(
+            id="a-other-mission",
+            name="Other Mission",
+            legs=[
+                MissionLeg(
+                    id="other-leg",
+                    name="Other Leg",
+                    route_id="other-route",
+                    is_active=True,
+                    transports=TransportConfig(initial_x_satellite_id="X-1"),
+                )
+            ],
+        )
+    )
+    save_mission_v2(
+        Mission(
+            id="z-current-mission",
+            name="Current Mission",
+            legs=[
+                MissionLeg(
+                    id="current-leg",
+                    name="Current Leg",
+                    route_id="test-route",
+                    is_active=True,
+                    transports=TransportConfig(initial_x_satellite_id="X-2"),
+                )
+            ],
+        )
+    )
+
+    result = build_active_x_link(
+        coordinator=StaticCoordinator(
+            _telemetry(latitude=0.0, longitude=0.0, heading=90.0)
+        ),
+        route_manager=StaticRouteManager(_route()),
+        poi_manager=StaticPOIManager([_satellite("X-1", 0.0), _satellite("X-2", 30.0)]),
+    )
+
+    assert result["satellite_id"] == "X-2"
+
+
 def test_active_x_link_uses_transitioned_satellite_after_projected_transition(
     tmp_path, monkeypatch
 ):

--- a/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
+++ b/monitoring/grafana/provisioning/dashboards/fullscreen-overview.json
@@ -445,6 +445,56 @@
               "showLegend": false,
               "style": {
                 "color": {
+                  "fixed": "green"
+                },
+                "lineWidth": 4,
+                "opacity": 0.9
+              }
+            },
+            "filterByRefId": "ActiveXLinkNormal",
+            "filterData": {
+              "id": "byRefId",
+              "options": "ActiveXLinkNormal"
+            },
+            "location": {
+              "latitude": "latitude",
+              "longitude": "longitude",
+              "mode": "coords"
+            },
+            "name": "Active X-band Link - Normal",
+            "tooltip": true,
+            "type": "route"
+          },
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "fixed": "yellow"
+                },
+                "lineWidth": 4,
+                "opacity": 0.9
+              }
+            },
+            "filterByRefId": "ActiveXLinkWarning",
+            "filterData": {
+              "id": "byRefId",
+              "options": "ActiveXLinkWarning"
+            },
+            "location": {
+              "latitude": "latitude",
+              "longitude": "longitude",
+              "mode": "coords"
+            },
+            "name": "Active X-band Link - Warning",
+            "tooltip": true,
+            "type": "route"
+          },
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
                   "fixed": "blue"
                 },
                 "lineWidth": 3,
@@ -1005,6 +1055,60 @@
                 "value": "${poi_category}"
               }
             ]
+          },
+          "url_options": {
+            "data": "",
+            "method": "GET",
+            "params": []
+          }
+        },
+        {
+          "cacheDurationSeconds": 1,
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filterExpression": "",
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "backend",
+          "refId": "ActiveXLinkNormal",
+          "root_selector": "coordinates",
+          "source": "url",
+          "type": "json",
+          "url": "/api/active-x-link?state=normal",
+          "urlOptions": {
+            "params": []
+          },
+          "url_options": {
+            "data": "",
+            "method": "GET",
+            "params": []
+          }
+        },
+        {
+          "cacheDurationSeconds": 1,
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filterExpression": "",
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "backend",
+          "refId": "ActiveXLinkWarning",
+          "root_selector": "coordinates",
+          "source": "url",
+          "type": "json",
+          "url": "/api/active-x-link?state=warning",
+          "urlOptions": {
+            "params": []
           },
           "url_options": {
             "data": "",

--- a/tools/tests/test_fullscreen_overview_dashboard.py
+++ b/tools/tests/test_fullscreen_overview_dashboard.py
@@ -16,6 +16,8 @@ CORE_MAP_LAYERS = {
     "Planned Route (KML) - Eastern Hemisphere",
     "MissionEvents",
     "Satellites",
+    "Active X-band Link - Normal",
+    "Active X-band Link - Warning",
 }
 RADAR_LAYER_NAME = "Weather Radar (RainViewer)"
 RAINVIEWER_RADAR_TILE_URL = (
@@ -165,6 +167,43 @@ def test_fullscreen_overview_has_no_hcx_comm_overlay_layer() -> None:
         if layer.get("type") == "geojson"
     }
     assert HCX_COMM_LAYER_SOURCES.isdisjoint(layer_sources)
+
+
+def test_fullscreen_overview_active_x_band_link_uses_split_state_layers() -> None:
+    map_panel = _panel_by_title("Current Position")
+    layers = _layers_by_name()
+    normal_layer = layers["Active X-band Link - Normal"]
+    warning_layer = layers["Active X-band Link - Warning"]
+    targets_by_ref = {target["refId"]: target for target in map_panel["targets"]}
+
+    assert (
+        targets_by_ref["ActiveXLinkNormal"]["url"] == "/api/active-x-link?state=normal"
+    )
+    assert (
+        targets_by_ref["ActiveXLinkWarning"]["url"]
+        == "/api/active-x-link?state=warning"
+    )
+    assert targets_by_ref["ActiveXLinkNormal"]["root_selector"] == "coordinates"
+    assert targets_by_ref["ActiveXLinkWarning"]["root_selector"] == "coordinates"
+
+    assert normal_layer["type"] == "route"
+    assert warning_layer["type"] == "route"
+    assert normal_layer["filterData"] == {
+        "id": "byRefId",
+        "options": "ActiveXLinkNormal",
+    }
+    assert warning_layer["filterData"] == {
+        "id": "byRefId",
+        "options": "ActiveXLinkWarning",
+    }
+    assert normal_layer["config"]["style"]["color"] == {"fixed": "green"}
+    assert warning_layer["config"]["style"]["color"] == {"fixed": "yellow"}
+    assert normal_layer["location"] == {
+        "latitude": "latitude",
+        "longitude": "longitude",
+        "mode": "coords",
+    }
+    assert warning_layer["location"] == normal_layer["location"]
 
 
 def test_fullscreen_overview_poi_table_hides_active_route_fields() -> None:


### PR DESCRIPTION
## Summary
- Adds `/api/active-x-link` to expose a two-point Grafana route from aircraft position to the active X-band satellite.
- Resolves the active X satellite from the active mission leg matching the active route, including projected X transitions along that route.
- Adds split Grafana route layers so the normal link renders green and the forbidden-window warning link renders yellow.

## Test Plan
- [x] `python -m ruff check backend/starlink-location/app/services/active_x_link.py backend/starlink-location/app/api/active_x_link.py backend/starlink-location/tests/unit/test_active_x_link.py backend/starlink-location/main.py tools/tests/test_fullscreen_overview_dashboard.py`
- [x] `python -m black --check backend/starlink-location/app/services/active_x_link.py backend/starlink-location/app/api/active_x_link.py backend/starlink-location/tests/unit/test_active_x_link.py backend/starlink-location/main.py tools/tests/test_fullscreen_overview_dashboard.py`
- [x] `pytest backend/starlink-location/tests/unit/test_active_x_link.py tools/tests/test_fullscreen_overview_dashboard.py -q`
- [x] `pytest backend/starlink-location/tests/unit/test_active_x_link.py backend/starlink-location/tests/unit/test_satellite_rules.py backend/starlink-location/tests/unit/test_satellite_geometry.py backend/starlink-location/tests/unit/test_mission_timeline.py tools/tests/test_fullscreen_overview_dashboard.py -q` (88 passed)
- [ ] Docker rebuild/health: attempted required sequence, but the environment approval gate blocked `docker compose down && docker compose build --no-cache && docker compose up -d && docker compose ps && curl -fsS http://localhost:8000/health` before execution.

## Release implications
- No semantic-release/package config changes.
- Runtime impact is backend API + provisioned Grafana dashboard configuration; deployment needs the normal backend image rebuild so the new API route is available.

Refs #85
