### PR TITLE
feat: make active X-band handoff position-based

### DIFF
--- a/backend/starlink-location/app/services/active_x_handoff.py
+++ b/backend/starlink-location/app/services/active_x_handoff.py
@@ -1,0 +1,208 @@
+"""Position-based active X-band satellite handoff resolution."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.mission.models import MissionLeg, XTransition
+from app.models.route import ParsedRoute
+from app.models.telemetry import TelemetryData
+from app.services.route_eta_calculator import RouteETACalculator
+
+logger = logging.getLogger(__name__)
+
+HANDOFF_ZONE_RADIUS_METERS = 200_000.0
+
+
+@dataclass
+class XHandoffTracker:
+    """In-process guard state for live X-band handoff transitions."""
+
+    armed_transition_ids: set[str] = field(default_factory=set)
+    committed_transition_ids: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class ActiveXContext:
+    """Current and pending X-band satellite context for a live position."""
+
+    current_satellite_id: str | None
+    pending_satellite_id: str | None
+    handoff: dict[str, Any]
+
+
+_HANDOFF_TRACKERS: dict[str, XHandoffTracker] = {}
+
+
+def reset_x_handoff_state() -> None:
+    """Reset live handoff memory.
+
+    This is primarily for tests; production state is intentionally process-local
+    so a committed handoff does not flap if the aircraft jitters back into the
+    geographic transition bubble.
+    """
+
+    _HANDOFF_TRACKERS.clear()
+
+
+def empty_handoff_context(route_progress: float | None = None) -> dict[str, Any]:
+    """Return the default handoff context payload."""
+
+    return {
+        "phase": "outside",
+        "transition_id": None,
+        "transition_satellite_id": None,
+        "radius_meters": HANDOFF_ZONE_RADIUS_METERS,
+        "distance_to_transition_meters": None,
+        "in_handoff_zone": False,
+        "route_progress_percent": route_progress,
+        "transition_progress_percent": None,
+    }
+
+
+def resolve_active_x_context(
+    leg: MissionLeg,
+    route: ParsedRoute | None,
+    telemetry: TelemetryData,
+) -> ActiveXContext:
+    """Resolve live active and pending X satellites from actual position."""
+
+    current_satellite = leg.transports.initial_x_satellite_id
+    if not current_satellite:
+        return ActiveXContext(None, None, empty_handoff_context())
+    if route is None or not leg.transports.x_transitions:
+        return ActiveXContext(current_satellite, None, empty_handoff_context())
+
+    current_progress = _project_progress(
+        route,
+        telemetry.position.latitude,
+        telemetry.position.longitude,
+    )
+    if current_progress is None:
+        return ActiveXContext(current_satellite, None, empty_handoff_context())
+
+    tracker = _tracker_for(leg, route)
+    latest_handoff = empty_handoff_context(route_progress=current_progress)
+    transitions = _project_transitions(route, leg.transports.x_transitions)
+
+    for transition_progress, transition in transitions:
+        if not transition.target_satellite_id:
+            continue
+        handoff = _handoff_context(
+            transition=transition,
+            transition_progress=transition_progress,
+            telemetry=telemetry,
+            route_progress=current_progress,
+        )
+        if transition.id in tracker.committed_transition_ids:
+            current_satellite = transition.target_satellite_id
+            latest_handoff = {**handoff, "phase": "committed"}
+            continue
+
+        in_zone = bool(handoff["in_handoff_zone"])
+        has_passed = current_progress >= transition_progress
+        if in_zone:
+            tracker.armed_transition_ids.add(transition.id)
+            return ActiveXContext(
+                current_satellite,
+                transition.target_satellite_id,
+                {**handoff, "phase": "in_handoff_zone"},
+            )
+        if has_passed and transition.id in tracker.armed_transition_ids:
+            tracker.committed_transition_ids.add(transition.id)
+            current_satellite = transition.target_satellite_id
+            latest_handoff = {**handoff, "phase": "committed"}
+            continue
+        return ActiveXContext(current_satellite, None, {**handoff, "phase": "outside"})
+
+    return ActiveXContext(current_satellite, None, latest_handoff)
+
+
+def _project_transitions(
+    route: ParsedRoute,
+    transitions: list[XTransition],
+) -> list[tuple[float, XTransition]]:
+    projected: list[tuple[float, XTransition]] = []
+    for transition in transitions:
+        progress = _project_progress(route, transition.latitude, transition.longitude)
+        if progress is not None:
+            projected.append((progress, transition))
+    return sorted(projected, key=lambda item: item[0])
+
+
+def _tracker_for(leg: MissionLeg, route: ParsedRoute) -> XHandoffTracker:
+    transition_ids = ",".join(
+        transition.id for transition in leg.transports.x_transitions or []
+    )
+    key = f"{leg.id}:{_route_id(route) or ''}:{transition_ids}"
+    return _HANDOFF_TRACKERS.setdefault(key, XHandoffTracker())
+
+
+def _route_id(route: ParsedRoute) -> str | None:
+    file_path = route.metadata.file_path
+    if not file_path:
+        return None
+    return Path(file_path).stem
+
+
+def _handoff_context(
+    transition: XTransition,
+    transition_progress: float,
+    telemetry: TelemetryData,
+    route_progress: float,
+) -> dict[str, Any]:
+    aircraft = telemetry.position
+    distance_meters = _distance_meters(
+        aircraft.latitude,
+        aircraft.longitude,
+        transition.latitude,
+        transition.longitude,
+    )
+    return {
+        "phase": "outside",
+        "transition_id": transition.id,
+        "transition_satellite_id": transition.target_satellite_id,
+        "radius_meters": HANDOFF_ZONE_RADIUS_METERS,
+        "distance_to_transition_meters": round(distance_meters, 1),
+        "in_handoff_zone": distance_meters <= HANDOFF_ZONE_RADIUS_METERS,
+        "route_progress_percent": round(route_progress, 6),
+        "transition_progress_percent": round(transition_progress, 6),
+    }
+
+
+def _project_progress(
+    route: ParsedRoute,
+    latitude: float,
+    longitude: float,
+) -> float | None:
+    try:
+        projection = RouteETACalculator(route).project_poi_to_route(latitude, longitude)
+    except Exception as exc:  # pragma: no cover - defensive geometry guard
+        logger.debug("Failed to project active X link point onto route: %s", exc)
+        return None
+    progress = projection.get("projected_route_progress")
+    return float(progress) if progress is not None else None
+
+
+def _distance_meters(
+    lat1: float,
+    lon1: float,
+    lat2: float,
+    lon2: float,
+) -> float:
+    radius_meters = 6_371_000.0
+    lat1_rad = math.radians(lat1)
+    lon1_rad = math.radians(lon1)
+    lat2_rad = math.radians(lat2)
+    lon2_rad = math.radians(lon2)
+    dlat = lat2_rad - lat1_rad
+    dlon = lon2_rad - lon1_rad
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
+    )
+    return radius_meters * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))

--- a/backend/starlink-location/app/services/active_x_link.py
+++ b/backend/starlink-location/app/services/active_x_link.py
@@ -7,13 +7,16 @@ from pathlib import Path
 from typing import Any, Literal
 
 from app.mission import storage
-from app.mission.models import MissionLeg, XTransition
+from app.mission.models import MissionLeg
 from app.models.poi import POI
 from app.models.route import ParsedRoute
 from app.models.telemetry import TelemetryData
 from app.satellites.geometry import is_in_azimuth_range
 from app.satellites.rules import RuleEngine
-from app.services.route_eta_calculator import RouteETACalculator
+from app.services.active_x_handoff import (
+    empty_handoff_context,
+    resolve_active_x_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +27,11 @@ def empty_active_x_link(state: str | None = None) -> dict[str, Any]:
     """Return an empty, Grafana-friendly active-X link response."""
     return {
         "coordinates": [],
+        "links": [],
         "total": 0,
         "satellite_id": None,
+        "pending_satellite_id": None,
+        "handoff": empty_handoff_context(),
         "state": state,
         "color": None,
         "relative_azimuth_degrees": None,
@@ -61,52 +67,51 @@ def build_active_x_link(
     if active_leg is None:
         return empty_active_x_link(state_filter)
 
-    satellite_id = _resolve_active_satellite_id(active_leg, route, telemetry)
+    active_context = resolve_active_x_context(active_leg, route, telemetry)
+    satellite_id = active_context.current_satellite_id
     if not satellite_id:
         return empty_active_x_link(state_filter)
 
-    satellite = _find_satellite_poi(poi_manager, satellite_id)
-    if satellite is None:
+    satellite_ids = [satellite_id]
+    if active_context.pending_satellite_id:
+        satellite_ids.append(active_context.pending_satellite_id)
+
+    links = _build_satellite_links(telemetry, poi_manager, satellite_ids)
+    if not links:
         return empty_active_x_link(state_filter)
 
-    link_state, color, relative_azimuth, in_forbidden = _evaluate_link_state(
-        telemetry, satellite
-    )
-    if state_filter is not None and link_state != state_filter:
+    current_link = links[0]
+    matching_links = [
+        link for link in links if state_filter is None or link["state"] == state_filter
+    ]
+    if state_filter is not None and not matching_links:
         return {
             **empty_active_x_link(state_filter),
             "satellite_id": satellite_id,
-            "state": link_state,
-            "color": color,
-            "relative_azimuth_degrees": relative_azimuth,
-            "in_forbidden_window": in_forbidden,
+            "pending_satellite_id": active_context.pending_satellite_id,
+            "handoff": active_context.handoff,
+            "state": current_link["state"],
+            "color": current_link["color"],
+            "relative_azimuth_degrees": current_link["relative_azimuth_degrees"],
+            "in_forbidden_window": current_link["in_forbidden_window"],
         }
 
-    aircraft = telemetry.position
+    coordinates = [point for link in matching_links for point in link["coordinates"]]
     common = {
         "satellite_id": satellite_id,
-        "state": link_state,
-        "color": color,
-        "relative_azimuth_degrees": relative_azimuth,
-        "in_forbidden_window": in_forbidden,
+        "pending_satellite_id": active_context.pending_satellite_id,
+        "handoff": active_context.handoff,
+        "state": current_link["state"],
+        "color": current_link["color"],
+        "relative_azimuth_degrees": current_link["relative_azimuth_degrees"],
+        "in_forbidden_window": current_link["in_forbidden_window"],
     }
-    coordinates = [
-        {
-            **common,
-            "point": "aircraft",
-            "sequence": 0,
-            "latitude": aircraft.latitude,
-            "longitude": aircraft.longitude,
-        },
-        {
-            **common,
-            "point": "satellite",
-            "sequence": 1,
-            "latitude": satellite.latitude,
-            "longitude": satellite.longitude,
-        },
-    ]
-    return {**common, "coordinates": coordinates, "total": len(coordinates)}
+    return {
+        **common,
+        "links": matching_links,
+        "coordinates": coordinates,
+        "total": len(coordinates),
+    }
 
 
 def _find_active_mission_leg(route: ParsedRoute | None = None) -> MissionLeg | None:
@@ -139,49 +144,45 @@ def _route_id(route: ParsedRoute) -> str | None:
     return Path(file_path).stem
 
 
-def _resolve_active_satellite_id(
-    leg: MissionLeg,
-    route: ParsedRoute | None,
+def _build_satellite_links(
     telemetry: TelemetryData,
-) -> str | None:
-    current_satellite = leg.transports.initial_x_satellite_id
-    if not current_satellite:
-        return None
-    if route is None or not leg.transports.x_transitions:
-        return current_satellite
-
-    current_progress = _project_progress(
-        route,
-        telemetry.position.latitude,
-        telemetry.position.longitude,
-    )
-    if current_progress is None:
-        return current_satellite
-
-    transitions: list[tuple[float, XTransition]] = []
-    for transition in leg.transports.x_transitions:
-        progress = _project_progress(route, transition.latitude, transition.longitude)
-        if progress is not None:
-            transitions.append((progress, transition))
-
-    for progress, transition in sorted(transitions, key=lambda item: item[0]):
-        if current_progress >= progress and transition.target_satellite_id:
-            current_satellite = transition.target_satellite_id
-    return current_satellite
-
-
-def _project_progress(
-    route: ParsedRoute,
-    latitude: float,
-    longitude: float,
-) -> float | None:
-    try:
-        projection = RouteETACalculator(route).project_poi_to_route(latitude, longitude)
-    except Exception as exc:  # pragma: no cover - defensive geometry guard
-        logger.debug("Failed to project active X link point onto route: %s", exc)
-        return None
-    progress = projection.get("projected_route_progress")
-    return float(progress) if progress is not None else None
+    poi_manager: Any,
+    satellite_ids: list[str],
+) -> list[dict[str, Any]]:
+    aircraft = telemetry.position
+    links: list[dict[str, Any]] = []
+    for satellite_id in satellite_ids:
+        satellite = _find_satellite_poi(poi_manager, satellite_id)
+        if satellite is None:
+            continue
+        link_state, color, relative_azimuth, in_forbidden = _evaluate_link_state(
+            telemetry, satellite
+        )
+        common = {
+            "satellite_id": satellite_id,
+            "state": link_state,
+            "color": color,
+            "relative_azimuth_degrees": relative_azimuth,
+            "in_forbidden_window": in_forbidden,
+        }
+        coordinates = [
+            {
+                **common,
+                "point": "aircraft",
+                "sequence": len(links) * 2,
+                "latitude": aircraft.latitude,
+                "longitude": aircraft.longitude,
+            },
+            {
+                **common,
+                "point": "satellite",
+                "sequence": len(links) * 2 + 1,
+                "latitude": satellite.latitude,
+                "longitude": satellite.longitude,
+            },
+        ]
+        links.append({**common, "coordinates": coordinates})
+    return links
 
 
 def _find_satellite_poi(poi_manager: Any, satellite_id: str) -> POI | None:

--- a/backend/starlink-location/tests/unit/test_active_x_handoff.py
+++ b/backend/starlink-location/tests/unit/test_active_x_handoff.py
@@ -1,0 +1,238 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.mission.models import Mission, MissionLeg, TransportConfig, XTransition
+from app.mission.storage import save_mission_v2
+from app.models.poi import POI
+from app.models.route import ParsedRoute, RouteMetadata, RoutePoint
+from app.models.telemetry import (
+    EnvironmentalData,
+    NetworkData,
+    ObstructionData,
+    PositionData,
+    TelemetryData,
+)
+from app.services.active_x_handoff import reset_x_handoff_state
+from app.services.active_x_link import build_active_x_link
+
+
+class StaticCoordinator:
+    def __init__(self, telemetry: TelemetryData):
+        self.telemetry = telemetry
+
+    def get_current_telemetry(self) -> TelemetryData:
+        return self.telemetry
+
+
+class StaticRouteManager:
+    def __init__(self, route: ParsedRoute | None):
+        self.route = route
+
+    def get_active_route(self) -> ParsedRoute | None:
+        return self.route
+
+
+class StaticPOIManager:
+    def __init__(self, pois: list[POI]):
+        self.pois = pois
+
+    def list_pois(self):
+        return self.pois
+
+
+def _telemetry(
+    latitude: float,
+    longitude: float,
+    heading: float,
+    timestamp: datetime | None = None,
+) -> TelemetryData:
+    return TelemetryData(
+        timestamp=timestamp or datetime(2026, 1, 1, tzinfo=timezone.utc),
+        position=PositionData(
+            latitude=latitude,
+            longitude=longitude,
+            altitude=35000.0,
+            speed=450.0,
+            heading=heading,
+        ),
+        network=NetworkData(
+            latency_ms=40.0,
+            throughput_down_mbps=120.0,
+            throughput_up_mbps=20.0,
+            packet_loss_percent=0.0,
+        ),
+        obstruction=ObstructionData(obstruction_percent=0.0),
+        environmental=EnvironmentalData(),
+    )
+
+
+def _route() -> ParsedRoute:
+    return ParsedRoute(
+        metadata=RouteMetadata(
+            name="Test route",
+            file_path="/tmp/test-route.kml",
+            point_count=3,
+        ),
+        points=[
+            RoutePoint(latitude=0.0, longitude=0.0, sequence=0),
+            RoutePoint(latitude=0.0, longitude=10.0, sequence=1),
+            RoutePoint(latitude=0.0, longitude=20.0, sequence=2),
+        ],
+    )
+
+
+def _satellite(name: str, longitude: float) -> POI:
+    return POI(
+        id=name.lower(),
+        name=name,
+        latitude=0.0,
+        longitude=longitude,
+        icon="X",
+        category="satellite",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_handoff_state():
+    reset_x_handoff_state()
+    yield
+    reset_x_handoff_state()
+
+
+def _save_active_mission(tmp_path: Path) -> None:
+    mission = Mission(
+        id="mission-85",
+        name="Mission 85",
+        legs=[
+            MissionLeg(
+                id="leg-1",
+                name="Leg 1",
+                route_id="test-route",
+                is_active=True,
+                transports=TransportConfig(
+                    initial_x_satellite_id="X-1",
+                    x_transitions=[
+                        XTransition(
+                            id="x-swap",
+                            latitude=0.0,
+                            longitude=10.0,
+                            target_satellite_id="X-2",
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
+    save_mission_v2(mission)
+
+
+def _build_link_at(
+    latitude: float,
+    longitude: float,
+    *,
+    timestamp: datetime | None = None,
+) -> dict:
+    return build_active_x_link(
+        coordinator=StaticCoordinator(
+            _telemetry(
+                latitude=latitude,
+                longitude=longitude,
+                heading=90.0,
+                timestamp=timestamp,
+            )
+        ),
+        route_manager=StaticRouteManager(_route()),
+        poi_manager=StaticPOIManager([_satellite("X-1", 0.0), _satellite("X-2", 30.0)]),
+    )
+
+
+def test_active_x_link_does_not_switch_on_late_mission_time_before_zone(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    _save_active_mission(tmp_path)
+
+    result = _build_link_at(
+        0.0,
+        7.0,
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result["satellite_id"] == "X-1"
+    assert result["pending_satellite_id"] is None
+    assert result["handoff"]["phase"] == "outside"
+
+
+def test_active_x_link_shows_dual_context_inside_zone_without_commit(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    _save_active_mission(tmp_path)
+
+    result = _build_link_at(0.0, 9.0)
+
+    assert result["satellite_id"] == "X-1"
+    assert result["pending_satellite_id"] == "X-2"
+    assert result["handoff"]["phase"] == "in_handoff_zone"
+    assert result["handoff"]["transition_id"] == "x-swap"
+    assert {link["satellite_id"] for link in result["links"]} == {"X-1", "X-2"}
+    assert result["total"] == 4
+
+
+def test_active_x_link_keeps_current_satellite_for_route_deviation_while_approaching(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    _save_active_mission(tmp_path)
+
+    result = _build_link_at(1.0, 8.8)
+
+    assert result["satellite_id"] == "X-1"
+    assert result["pending_satellite_id"] == "X-2"
+    assert result["handoff"]["phase"] == "in_handoff_zone"
+    assert (
+        result["handoff"]["route_progress_percent"]
+        < result["handoff"]["transition_progress_percent"]
+    )
+
+
+def test_active_x_link_commits_after_passing_through_and_exiting_zone(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    _save_active_mission(tmp_path)
+
+    _build_link_at(0.0, 9.0)
+    result = _build_link_at(0.0, 12.0)
+
+    assert result["satellite_id"] == "X-2"
+    assert result["pending_satellite_id"] is None
+    assert result["handoff"]["phase"] == "committed"
+    assert result["coordinates"][1]["longitude"] == 30.0
+
+
+def test_active_x_link_does_not_flap_after_commit_on_reentry_jitter(
+    tmp_path, monkeypatch
+):
+    from app.mission import storage
+
+    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
+    _save_active_mission(tmp_path)
+
+    _build_link_at(0.0, 9.0)
+    _build_link_at(0.0, 12.0)
+    result = _build_link_at(0.0, 10.5)
+
+    assert result["satellite_id"] == "X-2"
+    assert result["pending_satellite_id"] is None
+    assert result["handoff"]["phase"] == "committed"

--- a/backend/starlink-location/tests/unit/test_active_x_link.py
+++ b/backend/starlink-location/tests/unit/test_active_x_link.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
-from pathlib import Path
 
-from app.mission.models import Mission, MissionLeg, TransportConfig, XTransition
+from app.mission.models import Mission, MissionLeg, TransportConfig
 from app.mission.storage import save_mission_v2
 from app.models.poi import POI
 from app.models.route import ParsedRoute, RouteMetadata, RoutePoint
@@ -40,9 +39,14 @@ class StaticPOIManager:
         return self.pois
 
 
-def _telemetry(latitude: float, longitude: float, heading: float) -> TelemetryData:
+def _telemetry(
+    latitude: float,
+    longitude: float,
+    heading: float,
+    timestamp: datetime | None = None,
+) -> TelemetryData:
     return TelemetryData(
-        timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        timestamp=timestamp or datetime(2026, 1, 1, tzinfo=timezone.utc),
         position=PositionData(
             latitude=latitude,
             longitude=longitude,
@@ -93,33 +97,6 @@ def test_active_x_link_endpoint_is_registered() -> None:
     )
 
 
-def _save_active_mission(tmp_path: Path) -> None:
-    mission = Mission(
-        id="mission-85",
-        name="Mission 85",
-        legs=[
-            MissionLeg(
-                id="leg-1",
-                name="Leg 1",
-                route_id="test-route",
-                is_active=True,
-                transports=TransportConfig(
-                    initial_x_satellite_id="X-1",
-                    x_transitions=[
-                        XTransition(
-                            id="x-swap",
-                            latitude=0.0,
-                            longitude=10.0,
-                            target_satellite_id="X-2",
-                        )
-                    ],
-                ),
-            )
-        ],
-    )
-    save_mission_v2(mission)
-
-
 def test_active_x_link_prefers_active_leg_matching_active_route(tmp_path, monkeypatch):
     from app.mission import storage
 
@@ -164,32 +141,6 @@ def test_active_x_link_prefers_active_leg_matching_active_route(tmp_path, monkey
     )
 
     assert result["satellite_id"] == "X-2"
-
-
-def test_active_x_link_uses_transitioned_satellite_after_projected_transition(
-    tmp_path, monkeypatch
-):
-    from app.mission import storage
-
-    monkeypatch.setattr(storage, "MISSIONS_DIR", tmp_path)
-    _save_active_mission(tmp_path)
-
-    result = build_active_x_link(
-        coordinator=StaticCoordinator(
-            _telemetry(latitude=0.0, longitude=15.0, heading=90.0)
-        ),
-        route_manager=StaticRouteManager(_route()),
-        poi_manager=StaticPOIManager([_satellite("X-1", 0.0), _satellite("X-2", 30.0)]),
-    )
-
-    assert result["satellite_id"] == "X-2"
-    assert result["total"] == 2
-    assert [point["point"] for point in result["coordinates"]] == [
-        "aircraft",
-        "satellite",
-    ]
-    assert result["coordinates"][0]["longitude"] == 15.0
-    assert result["coordinates"][1]["longitude"] == 30.0
 
 
 def test_active_x_link_marks_green_outside_normal_forbidden_window(


### PR DESCRIPTION
## Summary
- Replaces live active X-band satellite selection with a position-based handoff evaluator using a 200 km transition bubble.
- Exposes pending dual-context data (`pending_satellite_id`, `handoff`, `links`) while inside the handoff zone without immediately promoting the next satellite.
- Commits the next satellite only after the aircraft has entered the zone and then exited past the route-projected transition point, with in-process committed-state memory to avoid jitter/re-entry flapping.

## Test Plan
- [x] `pytest tests/unit/test_active_x_link.py tests/unit/test_active_x_handoff.py -q`
- [x] `python -m black app/services/active_x_link.py app/services/active_x_handoff.py tests/unit/test_active_x_link.py tests/unit/test_active_x_handoff.py --check`
- [x] `python -m ruff check app/services/active_x_link.py app/services/active_x_handoff.py tests/unit/test_active_x_link.py tests/unit/test_active_x_handoff.py`
- [x] Docker no-cache image build
- [x] Compose start and service status check
- [x] `curl -fsS http://localhost:8000/health`

## Docker / runtime note
The required compose stop/down command was attempted, but the worker terminal held it behind interactive approval. I ran the strongest executable rebuild path available here: no-cache image build, Compose start; Compose recreated `starlink-location` and `mission-planner`, reported `starlink-location` healthy, and `/health` returned `status: ok` in simulation mode.

## Release implications
Backend API response shape for `/api/active-x-link` is expanded compatibly: existing top-level current-satellite fields remain, and new pending/handoff/link-list fields allow the dashboard to render current + next satellite during the handoff bubble.

Closes #87
