### PR TITLE
chore: pin Grafana Infinity datasource plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_INSTALL_PLUGINS=grafana-clock-panel,yesoreyeram-infinity-datasource
+      - GF_PLUGINS_PREINSTALL=grafana-clock-panel,yesoreyeram-infinity-datasource@3.11.1
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
     volumes:
       - grafana_data:/var/lib/grafana

--- a/tools/tests/test_grafana_compose.py
+++ b/tools/tests/test_grafana_compose.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "docker-compose.yml"
+EXPECTED_PREINSTALL = (
+    "GF_PLUGINS_PREINSTALL="
+    "grafana-clock-panel,yesoreyeram-infinity-datasource@3.11.1"
+)
+
+
+def test_grafana_preinstalls_pinned_infinity_datasource() -> None:
+    compose = COMPOSE_PATH.read_text(encoding="utf-8")
+
+    assert EXPECTED_PREINSTALL in compose
+    assert "GF_INSTALL_PLUGINS=" not in compose


### PR DESCRIPTION
## Summary
- replace Grafana's deprecated/unpinned `GF_INSTALL_PLUGINS` entry with `GF_PLUGINS_PREINSTALL`
- pin `yesoreyeram-infinity-datasource` at `3.11.1` while retaining `grafana-clock-panel`
- add a focused regression test for the exact Compose plugin environment setting

## Validation
- `uv run --with pytest pytest tools/tests/test_grafana_compose.py -q` (RED before implementation, then GREEN)
- `uv run --with pytest pytest tools/tests/test_grafana_compose.py tools/tests/test_check_filename_convention.py tools/tests/test_fullscreen_overview_dashboard.py tools/tests/test_link_checker_config.py -q` (30 passed)
- `docker compose --env-file /dev/null config --no-interpolate --quiet`
- `docker compose --env-file /dev/null config --no-interpolate` confirms the pinned `GF_PLUGINS_PREINSTALL` value

## Documentation impact
None; this is an internal container startup configuration correction.

Closes #89