### PR TITLE
feat: add manual AR tracks by position

### DIFF
--- a/backend/starlink-location/app/mission/models.py
+++ b/backend/starlink-location/app/mission/models.py
@@ -224,38 +224,18 @@ class ManualAARTrack(BaseModel):
         ..., description="Ordered manual AAR track points"
     )
 
-    @field_validator("points", mode="before")
+    @field_validator("points")
     @classmethod
     def validate_points(
-        cls, points: list[ManualAARTrackPoint] | list[dict]
-    ) -> list[ManualAARTrackPoint] | list[dict]:
+        cls, points: list[ManualAARTrackPoint]
+    ) -> list[ManualAARTrackPoint]:
         """Require a line with no duplicate consecutive points."""
         if len(points) < 2:
             raise ValueError("Manual AAR track must contain at least two points")
         for previous, current in zip(points, points[1:]):
-            previous_latitude = (
-                previous.latitude
-                if isinstance(previous, ManualAARTrackPoint)
-                else previous.get("latitude")
-            )
-            previous_longitude = (
-                previous.longitude
-                if isinstance(previous, ManualAARTrackPoint)
-                else previous.get("longitude")
-            )
-            current_latitude = (
-                current.latitude
-                if isinstance(current, ManualAARTrackPoint)
-                else current.get("latitude")
-            )
-            current_longitude = (
-                current.longitude
-                if isinstance(current, ManualAARTrackPoint)
-                else current.get("longitude")
-            )
             if (
-                previous_latitude == current_latitude
-                and previous_longitude == current_longitude
+                previous.latitude == current.latitude
+                and previous.longitude == current.longitude
             ):
                 raise ValueError("Manual AAR track contains a duplicate consecutive point")
         return points

--- a/backend/starlink-location/app/mission/models.py
+++ b/backend/starlink-location/app/mission/models.py
@@ -188,6 +188,79 @@ class AARWindow(BaseModel):
     }
 
 
+class ManualAARTrackPoint(BaseModel):
+    """An operator-entered geographic point on a manual AAR track."""
+
+    latitude: float = Field(
+        ..., description="Point latitude in decimal degrees (-90 to 90)"
+    )
+    longitude: float = Field(
+        ..., description="Point longitude in decimal degrees (-180 to 180)"
+    )
+
+    @field_validator("latitude")
+    @classmethod
+    def validate_latitude(cls, value: float) -> float:
+        """Reject coordinates outside the valid latitude range."""
+        if not -90 <= value <= 90:
+            raise ValueError("Latitude must be between -90 and 90 degrees")
+        return value
+
+    @field_validator("longitude")
+    @classmethod
+    def validate_longitude(cls, value: float) -> float:
+        """Reject coordinates outside the valid longitude range."""
+        if not -180 <= value <= 180:
+            raise ValueError("Longitude must be between -180 and 180 degrees")
+        return value
+
+
+class ManualAARTrack(BaseModel):
+    """An operator-created AAR track independent of the planned route KML."""
+
+    id: str = Field(..., description="Unique manual AAR track identifier")
+    name: str = Field(..., description="Operator-facing manual track name", min_length=1)
+    points: list[ManualAARTrackPoint] = Field(
+        ..., description="Ordered manual AAR track points"
+    )
+
+    @field_validator("points", mode="before")
+    @classmethod
+    def validate_points(
+        cls, points: list[ManualAARTrackPoint] | list[dict]
+    ) -> list[ManualAARTrackPoint] | list[dict]:
+        """Require a line with no duplicate consecutive points."""
+        if len(points) < 2:
+            raise ValueError("Manual AAR track must contain at least two points")
+        for previous, current in zip(points, points[1:]):
+            previous_latitude = (
+                previous.latitude
+                if isinstance(previous, ManualAARTrackPoint)
+                else previous.get("latitude")
+            )
+            previous_longitude = (
+                previous.longitude
+                if isinstance(previous, ManualAARTrackPoint)
+                else previous.get("longitude")
+            )
+            current_latitude = (
+                current.latitude
+                if isinstance(current, ManualAARTrackPoint)
+                else current.get("latitude")
+            )
+            current_longitude = (
+                current.longitude
+                if isinstance(current, ManualAARTrackPoint)
+                else current.get("longitude")
+            )
+            if (
+                previous_latitude == current_latitude
+                and previous_longitude == current_longitude
+            ):
+                raise ValueError("Manual AAR track contains a duplicate consecutive point")
+        return points
+
+
 class KuOutageOverride(BaseModel):
     """Manual override for Ku transport outage (LEO link failure).
 
@@ -242,6 +315,10 @@ class TransportConfig(BaseModel):
         default_factory=list,
         description="Air-refueling segments",
     )
+    manual_aar_tracks: list[ManualAARTrack] = Field(
+        default_factory=list,
+        description="Operator-created AAR tracks independent of the planned route",
+    )
     ku_overrides: list[KuOutageOverride] = Field(
         default_factory=list,
         description="Manual Ku outage overrides",
@@ -255,6 +332,7 @@ class TransportConfig(BaseModel):
                 "x_transitions": [],
                 "ka_outages": [],
                 "aar_windows": [],
+                "manual_aar_tracks": [],
                 "ku_overrides": [],
             }
         }

--- a/backend/starlink-location/tests/unit/test_manual_aar_track.py
+++ b/backend/starlink-location/tests/unit/test_manual_aar_track.py
@@ -1,0 +1,76 @@
+"""Regression tests for operator-created manual AAR tracks."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.mission.models import ManualAARTrack, ManualAARTrackPoint, Mission, MissionLeg, TransportConfig
+from app.mission.storage import load_mission_v2, save_mission_v2
+
+
+def test_manual_aar_track_persists_ordered_deviation_points(isolate_mission_storage):
+    """A manual track remains separate from the planned route after reload."""
+    track = ManualAARTrack(
+        id="deviation-track",
+        name="Deviation AR",
+        points=[
+            ManualAARTrackPoint(latitude=35.0, longitude=179.5),
+            ManualAARTrackPoint(latitude=35.2, longitude=-179.7),
+        ],
+    )
+    mission = Mission(
+        id="manual-track-mission",
+        name="Manual track mission",
+        legs=[
+            MissionLeg(
+                id="deviation-leg",
+                name="Deviation leg",
+                route_id="planned-route",
+                transports=TransportConfig(
+                    initial_x_satellite_id="X-1", manual_aar_tracks=[track]
+                ),
+            )
+        ],
+    )
+
+    save_mission_v2(mission)
+    reloaded = load_mission_v2(mission.id)
+
+    assert reloaded is not None
+    saved_track = reloaded.legs[0].transports.manual_aar_tracks[0]
+    assert saved_track.name == "Deviation AR"
+    assert [(point.latitude, point.longitude) for point in saved_track.points] == [
+        (35.0, 179.5),
+        (35.2, -179.7),
+    ]
+
+
+@pytest.mark.parametrize(
+    "points, message",
+    [
+        ([{"latitude": 35.0, "longitude": -120.0}], "at least two points"),
+        (
+            [
+                {"latitude": 35.0, "longitude": -120.0},
+                {"latitude": 35.0, "longitude": -120.0},
+            ],
+            "duplicate consecutive point",
+        ),
+    ],
+)
+def test_manual_aar_track_rejects_insufficient_or_duplicate_points(points, message):
+    """Tracks require a usable ordered line rather than ambiguous point input."""
+    with pytest.raises(ValidationError, match=message):
+        ManualAARTrack(id="manual-track", name="Deviation", points=points)
+
+
+@pytest.mark.parametrize(
+    "point, message",
+    [
+        ({"latitude": 90.1, "longitude": 0}, "Latitude must be between -90 and 90"),
+        ({"latitude": 0, "longitude": 180.1}, "Longitude must be between -180 and 180"),
+    ],
+)
+def test_manual_aar_track_rejects_out_of_range_coordinates(point, message):
+    """Manual position entry accepts only decimal-degree geographic coordinates."""
+    with pytest.raises(ValidationError, match=message):
+        ManualAARTrackPoint(**point)

--- a/backend/starlink-location/tests/unit/test_manual_aar_track.py
+++ b/backend/starlink-location/tests/unit/test_manual_aar_track.py
@@ -64,6 +64,23 @@ def test_manual_aar_track_rejects_insufficient_or_duplicate_points(points, messa
 
 
 @pytest.mark.parametrize(
+    "points",
+    [
+        None,
+        "not a point list",
+        [
+            {"latitude": 35.0, "longitude": -120.0},
+            "not a coordinate mapping",
+        ],
+    ],
+)
+def test_manual_aar_track_rejects_malformed_point_collections(points):
+    """Malformed request data produces Pydantic validation errors rather than crashes."""
+    with pytest.raises(ValidationError):
+        ManualAARTrack(id="manual-track", name="Deviation", points=points)
+
+
+@pytest.mark.parametrize(
     "point, message",
     [
         ({"latitude": 90.1, "longitude": 0}, "Latitude must be between -90 and 90"),

--- a/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import type { ManualAARTrack, ManualAARTrackPoint } from '../../types/aar';
+
+interface ManualAARTrackEditorProps {
+  tracks: ManualAARTrack[];
+  onTracksChange: (tracks: ManualAARTrack[]) => void;
+}
+
+const isLatitude = (value: number) => Number.isFinite(value) && value >= -90 && value <= 90;
+const isLongitude = (value: number) => Number.isFinite(value) && value >= -180 && value <= 180;
+
+interface DraftPoint {
+  latitude: string;
+  longitude: string;
+}
+
+const emptyPoint = (): DraftPoint => ({ latitude: '', longitude: '' });
+
+export function ManualAARTrackEditor({
+  tracks,
+  onTracksChange,
+}: ManualAARTrackEditorProps) {
+  const [name, setName] = useState('Manual AR Track');
+  const [points, setPoints] = useState<DraftPoint[]>([emptyPoint(), emptyPoint()]);
+  const [error, setError] = useState<string | null>(null);
+
+  const updatePoint = (
+    pointIndex: number,
+    field: keyof DraftPoint,
+    value: string
+  ) => {
+    setPoints((currentPoints) =>
+      currentPoints.map((point, index) =>
+        index === pointIndex ? { ...point, [field]: value } : point
+      )
+    );
+  };
+
+  const addTrack = () => {
+    if (!name.trim()) {
+      setError('Enter a name for the manual AR track.');
+      return;
+    }
+    if (points.length < 2) {
+      setError('A manual AR track needs at least two points.');
+      return;
+    }
+    if (points.some((point) => !point.latitude.trim() || !point.longitude.trim())) {
+      setError('Enter both latitude and longitude for every manual AR track point.');
+      return;
+    }
+    const parsedPoints: ManualAARTrackPoint[] = points.map((point) => ({
+      latitude: Number(point.latitude),
+      longitude: Number(point.longitude),
+    }));
+    if (!parsedPoints.every((point) => isLatitude(point.latitude) && isLongitude(point.longitude))) {
+      setError('Latitude must be -90 to 90 and longitude must be -180 to 180.');
+      return;
+    }
+    if (parsedPoints.some((point, index) => index > 0 && point.latitude === parsedPoints[index - 1].latitude && point.longitude === parsedPoints[index - 1].longitude)) {
+      setError('Adjacent manual AR track points cannot be duplicates.');
+      return;
+    }
+
+    onTracksChange([
+      ...tracks,
+      { id: crypto.randomUUID(), name: name.trim(), points: parsedPoints },
+    ]);
+    setError(null);
+    setPoints([emptyPoint(), emptyPoint()]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-medium">Manual AR Tracks</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Add a deviation track by ordered latitude/longitude points. It is saved
+          separately from the planned route and may cross the antimeridian.
+        </p>
+      </div>
+
+      {tracks.map((track) => (
+        <div key={track.id} className="rounded border p-3 text-sm">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <strong>{track.name}</strong>
+              <p className="text-xs text-muted-foreground">
+                {track.points.length} operator-entered points
+              </p>
+            </div>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => onTracksChange(tracks.filter((item) => item.id !== track.id))}
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ))}
+
+      <div className="space-y-3 rounded border p-3">
+        <Input value={name} onChange={(event) => setName(event.target.value)} aria-label="Manual AR track name" />
+        {points.map((point, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <Input
+              type="number"
+              value={point.latitude}
+              min={-90}
+              max={90}
+              step="any"
+              aria-label={`Manual AR point ${index + 1} latitude`}
+              onChange={(event) => updatePoint(index, 'latitude', event.target.value)}
+            />
+            <Input
+              type="number"
+              value={point.longitude}
+              min={-180}
+              max={180}
+              step="any"
+              aria-label={`Manual AR point ${index + 1} longitude`}
+              onChange={(event) => updatePoint(index, 'longitude', event.target.value)}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={points.length <= 2}
+              onClick={() => setPoints(points.filter((_, pointIndex) => pointIndex !== index))}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setPoints([...points, emptyPoint()])}>
+            Add Point
+          </Button>
+          <Button onClick={addTrack}>Save Manual AR Track</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/mission-planner/src/components/common/RouteMap.tsx
+++ b/frontend/mission-planner/src/components/common/RouteMap.tsx
@@ -6,7 +6,7 @@ import type {
   KaOutage,
   KuOutageOverride,
 } from '../../types/satellite';
-import type { AARSegment } from '../../types/aar';
+import type { AARSegment, ManualAARTrack } from '../../types/aar';
 import type { Waypoint } from '../../services/routes';
 import type { KaTransition } from '../../types/timeline';
 import type { Timeline } from '../../services/timeline';
@@ -23,6 +23,7 @@ interface RouteMapProps {
   xbandTransitions?: XBandTransition[];
   kaTransitions?: KaTransition[];
   aarSegments?: AARSegment[];
+  manualAARTracks?: ManualAARTrack[];
   kaOutages?: KaOutage[];
   kuOutages?: KuOutageOverride[];
   waypoints?: string[];
@@ -36,6 +37,7 @@ export function RouteMap({
   xbandTransitions = [],
   kaTransitions = [],
   aarSegments = [],
+  manualAARTracks = [],
   kaOutages = [],
   kuOutages = [],
   timelinePreview = null,
@@ -105,6 +107,7 @@ export function RouteMap({
             xbandTransitions={normalizedXBandTransitions}
             kaTransitions={normalizedKaTransitions}
             aarSegments={aarSegments}
+            manualAARTracks={manualAARTracks}
             getWaypointCoordinateIndex={getWaypointCoordinateIndex}
             coordinates={coordinates}
             normalizedCoordinates={normalizedCoordinates}

--- a/frontend/mission-planner/src/components/common/RouteMap/RouteLayer.tsx
+++ b/frontend/mission-planner/src/components/common/RouteMap/RouteLayer.tsx
@@ -2,7 +2,7 @@ import { Polyline, Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import type { LatLngExpression } from 'leaflet';
 import type { XBandTransition } from '../../../types/satellite';
-import type { AARSegment } from '../../../types/aar';
+import type { AARSegment, ManualAARTrack } from '../../../types/aar';
 import type { KaTransition } from '../../../types/timeline';
 import { logger } from '../../../utils/logger';
 import { formatTime24Hour } from '@/lib/utils';
@@ -12,6 +12,7 @@ interface RouteLayerProps {
   xbandTransitions: XBandTransition[];
   kaTransitions: KaTransition[];
   aarSegments: AARSegment[];
+  manualAARTracks: ManualAARTrack[];
   getWaypointCoordinateIndex: (waypointName: string) => number;
   coordinates: LatLngExpression[];
   normalizedCoordinates: LatLngExpression[];
@@ -26,9 +27,27 @@ export function RouteLayer({
   xbandTransitions,
   kaTransitions,
   aarSegments,
+  manualAARTracks,
   getWaypointCoordinateIndex,
   normalizedCoordinates,
+  isIDLCrossing,
 }: RouteLayerProps) {
+  const getManualTrackPoints = (track: ManualAARTrack): [number, number][] => {
+    const crossesAntimeridian = track.points.some(
+      (point, index) =>
+        index > 0 &&
+        Math.abs(point.longitude - track.points[index - 1].longitude) > 180
+    );
+    const normalizeLongitude = isIDLCrossing || crossesAntimeridian;
+
+    return track.points.map((point) => [
+      point.latitude,
+      normalizeLongitude && point.longitude < 0
+        ? point.longitude + 360
+        : point.longitude,
+    ]);
+  };
+
   // Create X-Band transition icon
   const createXBandIcon = () => {
     return L.divIcon({
@@ -142,6 +161,19 @@ export function RouteLayer({
           </Polyline>
         );
       })}
+
+      {manualAARTracks.map((track) => (
+        <Polyline
+          key={`manual-aar-${track.id}`}
+          positions={getManualTrackPoints(track)}
+          color="#F97316"
+          weight={5}
+          opacity={0.9}
+          dashArray="8, 6"
+        >
+          <Popup>Manual AR Track: {track.name}</Popup>
+        </Polyline>
+      ))}
     </>
   );
 }

--- a/frontend/mission-planner/src/pages/LegDetailPage.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage.tsx
@@ -71,6 +71,7 @@ export function LegDetailPage() {
           override_end_time: s.override_end_time,
           override_start_elapsed: s.override_start_elapsed,
         })),
+        manual_aar_tracks: aarConfig.manualTracks,
         ku_overrides: satelliteConfig.ku_outages.map((k) => ({
           id: k.id,
           start_time: k.start_time,
@@ -87,6 +88,7 @@ export function LegDetailPage() {
     satelliteConfig.ka_outages,
     satelliteConfig.ku_outages,
     aarConfig.segments,
+    aarConfig.manualTracks,
   ]);
 
   // Memoize preview options to prevent unnecessary hook re-runs
@@ -144,6 +146,7 @@ export function LegDetailPage() {
           x_transitions: satelliteConfig.xband_transitions,
           ka_outages: satelliteConfig.ka_outages,
           aar_windows: aarConfig.segments,
+          manual_aar_tracks: aarConfig.manualTracks,
           ku_overrides: satelliteConfig.ku_outages,
         },
       });

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
@@ -9,6 +9,7 @@ import { XBandConfig } from '../../components/satellites/XBandConfig';
 import { KaOutageConfig } from '../../components/satellites/KaOutageConfig';
 import { KuOutageConfig } from '../../components/satellites/KuOutageConfig';
 import { AARSegmentEditor } from '../../components/aar/AARSegmentEditor';
+import { ManualAARTrackEditor } from '../../components/aar/ManualAARTrackEditor';
 import type { SatelliteConfig } from '../../types/satellite';
 import type { AARConfig } from '../../types/aar';
 
@@ -39,6 +40,7 @@ export function LegConfigTabs({
         <TabsTrigger value="ka">Ka Outages</TabsTrigger>
         <TabsTrigger value="ku">Ku/Starlink Outages</TabsTrigger>
         <TabsTrigger value="aar">AAR Segments</TabsTrigger>
+        <TabsTrigger value="manual-ar">Manual AR Tracks</TabsTrigger>
       </TabsList>
 
       <TabsContent value="xband" className="space-y-4">
@@ -109,6 +111,18 @@ export function LegConfigTabs({
               onAARConfigChange({ ...aarConfig, segments })
             }
             availableWaypoints={waypointNames}
+          />
+        </div>
+      </TabsContent>
+
+      <TabsContent value="manual-ar" className="space-y-4">
+        <div className="rounded-lg border p-6">
+          <h2 className="text-xl font-semibold mb-4">Manual AR Track</h2>
+          <ManualAARTrackEditor
+            tracks={aarConfig.manualTracks}
+            onTracksChange={(manualTracks) =>
+              onAARConfigChange({ ...aarConfig, manualTracks })
+            }
           />
         </div>
       </TabsContent>

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegMapVisualization.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegMapVisualization.tsx
@@ -35,6 +35,7 @@ export function LegMapVisualization({
         xbandTransitions={satelliteConfig.xband_transitions}
         kaTransitions={kaTransitions}
         aarSegments={aarConfig.segments}
+        manualAARTracks={aarConfig.manualTracks}
         kaOutages={satelliteConfig.ka_outages || []}
         kuOutages={satelliteConfig.ku_outages || []}
         waypoints={waypointNames}
@@ -47,6 +48,7 @@ export function LegMapVisualization({
         <p>• Blue circles: X-Band transition points</p>
         <p>• Green circles: Ka satellite transitions</p>
         <p>• Yellow dashed line: AAR segments</p>
+        <p>• Orange dashed line: Manual AR deviation tracks</p>
         {timelinePreview && (
           <>
             <p>• Green segments: Nominal communication status</p>

--- a/frontend/mission-planner/src/pages/LegDetailPage/useLegData.ts
+++ b/frontend/mission-planner/src/pages/LegDetailPage/useLegData.ts
@@ -58,10 +58,11 @@ function initializeSatelliteConfig(
  */
 function initializeAARConfig(legTransports?: TransportConfig): AARConfig {
   if (!legTransports) {
-    return { segments: [] };
+    return { segments: [], manualTracks: [] };
   }
   return {
     segments: legTransports.aar_windows || [],
+    manualTracks: legTransports.manual_aar_tracks || [],
   };
 }
 

--- a/frontend/mission-planner/src/types/aar.ts
+++ b/frontend/mission-planner/src/types/aar.ts
@@ -7,6 +7,18 @@ export interface AARSegment {
   override_start_elapsed?: string | null;
 }
 
+export interface ManualAARTrackPoint {
+  latitude: number;
+  longitude: number;
+}
+
+export interface ManualAARTrack {
+  id: string;
+  name: string;
+  points: ManualAARTrackPoint[];
+}
+
 export interface AARConfig {
   segments: AARSegment[];
+  manualTracks: ManualAARTrack[];
 }

--- a/frontend/mission-planner/src/types/mission.ts
+++ b/frontend/mission-planner/src/types/mission.ts
@@ -1,5 +1,5 @@
 import type { XBandTransition, KaOutage, KuOutageOverride } from './satellite';
-import type { AARSegment } from './aar';
+import type { AARSegment, ManualAARTrack } from './aar';
 
 export interface Mission {
   id: string;
@@ -17,6 +17,7 @@ export interface TransportConfig {
   x_transitions?: XBandTransition[];
   ka_outages?: KaOutage[];
   aar_windows?: AARSegment[];
+  manual_aar_tracks?: ManualAARTrack[];
   ku_overrides?: KuOutageOverride[];
 }
 


### PR DESCRIPTION
## Summary
- Adds operator-managed manual AR tracks with ordered latitude/longitude points, distinct from planned-route KML.
- Validates incomplete, out-of-range, insufficient, and duplicate-consecutive points; supports antimeridian tracks.
- Persists tracks through v2 mission storage/API and renders them as distinct orange map overlays.

## Verification
- `uv run --with-requirements requirements.txt pytest tests/unit/test_manual_aar_track.py tests/unit/test_mission_storage.py -q` — 53 passed
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check` — passed

## Runtime verification
The required Docker no-cache rebuild sequence was requested but requires approval because it executes `docker compose down`; it has not been run in this worker session.

Closes #90
