### PR TITLE
fix: make leg configuration responsive

### DIFF
--- a/frontend/mission-planner/src/pages/LegDetailPage.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage.tsx
@@ -222,7 +222,7 @@ export function LegDetailPage() {
   }
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="container mx-auto min-w-0 space-y-6 p-4 sm:p-6">
       <LegHeader
         missionId={missionId || ''}
         legId={legId || ''}
@@ -230,9 +230,9 @@ export function LegDetailPage() {
         onBackClick={handleBackClick}
       />
 
-      <div className="grid grid-cols-2 gap-6">
+      <div className="grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.9fr)]">
         {/* Left Column: Configuration Tabs */}
-        <div className="space-y-6">
+        <div className="min-w-0 space-y-6">
           <TimingSection
             leg={leg}
             timeline={timeline || null}
@@ -256,7 +256,7 @@ export function LegDetailPage() {
             error={error}
           />
 
-          <div className="flex justify-end space-x-4">
+          <div className="flex flex-wrap justify-end gap-4">
             <button
               className="px-4 py-2 border rounded-md hover:bg-gray-100"
               onClick={() => navigate(`/missions/${missionId}`)}

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
@@ -35,17 +35,19 @@ export function LegConfigTabs({
 }: LegConfigTabsProps) {
   return (
     <Tabs defaultValue="xband" className="w-full">
-      <TabsList>
-        <TabsTrigger value="xband">X-Band</TabsTrigger>
-        <TabsTrigger value="ka">Ka Outages</TabsTrigger>
-        <TabsTrigger value="ku">Ku/Starlink Outages</TabsTrigger>
-        <TabsTrigger value="aar">AAR Segments</TabsTrigger>
-        <TabsTrigger value="manual-ar">Manual AR Tracks</TabsTrigger>
-      </TabsList>
+      <div className="-mx-1 overflow-x-auto px-1 pb-1">
+        <TabsList className="min-w-max justify-start">
+          <TabsTrigger value="xband">X-Band</TabsTrigger>
+          <TabsTrigger value="ka">Ka Outages</TabsTrigger>
+          <TabsTrigger value="ku">Ku/Starlink Outages</TabsTrigger>
+          <TabsTrigger value="aar">AAR Segments</TabsTrigger>
+          <TabsTrigger value="manual-ar">Manual AR Tracks</TabsTrigger>
+        </TabsList>
+      </div>
 
       <TabsContent value="xband" className="space-y-4">
-        <div className="rounded-lg border p-6">
-          <div className="flex justify-between items-center mb-4">
+        <div className="rounded-lg border p-4 sm:p-6">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
             <h2 className="text-xl font-semibold">X-Band Configuration</h2>
             <Link
               to="/satellites"
@@ -73,7 +75,7 @@ export function LegConfigTabs({
       </TabsContent>
 
       <TabsContent value="ka" className="space-y-4">
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 sm:p-6">
           <h2 className="text-xl font-semibold mb-4">
             Ka Outage Configuration
           </h2>
@@ -87,7 +89,7 @@ export function LegConfigTabs({
       </TabsContent>
 
       <TabsContent value="ku" className="space-y-4">
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 sm:p-6">
           <h2 className="text-xl font-semibold mb-4">
             Ku/Starlink Outage Configuration
           </h2>
@@ -101,7 +103,7 @@ export function LegConfigTabs({
       </TabsContent>
 
       <TabsContent value="aar" className="space-y-4">
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 sm:p-6">
           <h2 className="text-xl font-semibold mb-4">
             AAR Segment Configuration
           </h2>
@@ -116,7 +118,7 @@ export function LegConfigTabs({
       </TabsContent>
 
       <TabsContent value="manual-ar" className="space-y-4">
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 sm:p-6">
           <h2 className="text-xl font-semibold mb-4">Manual AR Track</h2>
           <ManualAARTrackEditor
             tracks={aarConfig.manualTracks}

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegHeader.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegHeader.tsx
@@ -65,9 +65,9 @@ export function LegHeader({
       <Button variant="ghost" onClick={onBackClick} className="mb-4">
         ← Back to Mission
       </Button>
-      <div className="flex justify-between items-start">
-        <div>
-          <h1 className="text-3xl font-bold">Leg Configuration</h1>
+      <div className="flex flex-col items-start justify-between gap-4 sm:flex-row">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-bold sm:text-3xl">Leg Configuration</h1>
           <p className="text-muted-foreground">
             Mission: {missionId} | Leg: {legId}
           </p>
@@ -77,7 +77,7 @@ export function LegHeader({
             </p>
           )}
         </div>
-        <div className="flex items-center space-x-2">
+        <div className="flex items-center gap-2 self-stretch sm:self-auto">
           <input
             ref={fileInputRef}
             type="file"
@@ -87,6 +87,7 @@ export function LegHeader({
           />
           <Button
             variant="outline"
+            className="w-full sm:w-auto"
             onClick={handleUpdateRouteClick}
             disabled={updateRouteMutation.isPending}
           >

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegMapVisualization.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegMapVisualization.tsx
@@ -28,7 +28,7 @@ export function LegMapVisualization({
   timelinePreview,
 }: LegMapVisualizationProps) {
   return (
-    <div className="sticky top-6 h-fit">
+    <div className="min-w-0 lg:sticky lg:top-6 lg:h-fit">
       <h2 className="text-xl font-semibold mb-4">Route Visualization</h2>
       <RouteMap
         coordinates={routeCoordinates}
@@ -41,7 +41,7 @@ export function LegMapVisualization({
         waypoints={waypointNames}
         waypointObjects={availableWaypoints}
         timelinePreview={timelinePreview}
-        height="600px"
+        height="clamp(20rem, 50vw, 37.5rem)"
       />
       <div className="mt-4 text-sm text-gray-600 space-y-1">
         <p>• Blue line: Flight route</p>

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const mission = {
+  id: 'responsive-mission',
+  name: 'Responsive Mission',
+  description: 'Leg layout test fixture',
+  created_at: '2026-08-13T00:00:00Z',
+  updated_at: '2026-08-13T00:00:00Z',
+  metadata: {},
+  legs: [
+    {
+      id: 'responsive-leg',
+      name: 'Responsive Leg',
+      route_id: 'responsive-route',
+      transports: {
+        initial_x_satellite_id: 'X-1',
+        initial_ka_satellite_ids: ['AOR', 'POR', 'IOR'],
+        x_transitions: [],
+        ka_outages: [],
+        aar_windows: [],
+        manual_aar_tracks: [],
+        ku_overrides: [],
+      },
+    },
+  ],
+};
+
+async function mockLegDetailApis(page: Page) {
+  await page.route(
+    'http://localhost:8000/api/v2/missions/responsive-mission',
+    async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ json: mission });
+        return;
+      }
+      await route.continue();
+    }
+  );
+
+  await page.route(
+    'http://localhost:8000/api/routes/responsive-route',
+    async (route) => {
+      await route.fulfill({
+        json: {
+          points: [
+            { latitude: 34, longitude: -118 },
+            { latitude: 35, longitude: -117 },
+          ],
+          waypoints: [],
+        },
+      });
+    }
+  );
+
+  await page.route(
+    'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg/timeline',
+    async (route) => {
+      await route.fulfill({
+        json: {
+          mission_leg_id: 'responsive-leg',
+          created_at: '2026-08-13T00:00:00Z',
+          segments: [],
+        },
+      });
+    }
+  );
+
+  await page.route(
+    'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg/timeline/preview',
+    async (route) => {
+      await route.fulfill({
+        json: {
+          mission_leg_id: 'responsive-leg',
+          created_at: '2026-08-13T00:00:00Z',
+          segments: [],
+        },
+      });
+    }
+  );
+
+  await page.route('http://localhost:8000/api/satellites', async (route) => {
+    await route.fulfill({ json: [] });
+  });
+
+  await page.route('http://localhost:8000/api/pois**', async (route) => {
+    await route.fulfill({ json: { pois: [], total: 0 } });
+  });
+}
+
+test.describe('Leg detail responsive layout', () => {
+  test('stacks the map and keeps Manual AR Tracks reachable on mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockLegDetailApis(page);
+
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+
+    const manualArTab = page.getByRole('tab', { name: 'Manual AR Tracks' });
+    const mapHeading = page.getByRole('heading', {
+      name: 'Route Visualization',
+    });
+
+    await expect(manualArTab).toBeVisible();
+    await expect(mapHeading).toBeVisible();
+    await manualArTab.scrollIntoViewIfNeeded();
+    await expect(manualArTab).toBeInViewport();
+
+    const [tabBox, mapBox] = await Promise.all([
+      manualArTab.boundingBox(),
+      mapHeading.boundingBox(),
+    ]);
+    expect(tabBox).not.toBeNull();
+    expect(mapBox).not.toBeNull();
+    expect(mapBox!.y).toBeGreaterThan(tabBox!.y);
+
+    await manualArTab.click();
+    await expect(
+      page.getByRole('heading', { name: 'Manual AR Track' })
+    ).toBeVisible();
+  });
+
+  test('keeps both panels and the complete tab strip inside a narrow desktop viewport', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await mockLegDetailApis(page);
+
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+
+    const manualArTab = page.getByRole('tab', { name: 'Manual AR Tracks' });
+    const mapHeading = page.getByRole('heading', {
+      name: 'Route Visualization',
+    });
+
+    await expect(manualArTab).toBeVisible();
+    await manualArTab.scrollIntoViewIfNeeded();
+    await expect(manualArTab).toBeInViewport();
+    await expect(mapHeading).toBeVisible();
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(overflow).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Stack leg configuration and map below `lg`, with shrink-safe desktop grid tracks.
- Make the tab strip horizontally scrollable so Manual AR Tracks remains reachable.
- Disable map stickiness on mobile, use responsive map height, and make header/actions wrap safely.
- Add Playwright viewport regression coverage with mocked leg, route, timeline, satellite, and POI APIs.

## Verification
- `npm run build`
- `npm run lint`
- `npx prettier --check src/pages/LegDetailPage.tsx src/pages/LegDetailPage/LegConfigTabs.tsx src/pages/LegDetailPage/LegHeader.tsx src/pages/LegDetailPage/LegMapVisualization.tsx tests/e2e/leg-detail-responsive.spec.ts`
- `git diff --check`
- Playwright viewport test was added but could not execute: the worker environment lacks the Chromium headless-shell executable, and two browser-install attempts timed out after download.

## Release implications
- Layout-only frontend fix; no backend, data model, migration, or deployment changes.

Closes #93