### PR TITLE
fix: persist manual AR tracks from editor

### DIFF
--- a/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
@@ -5,11 +5,14 @@ import type { ManualAARTrack, ManualAARTrackPoint } from '../../types/aar';
 
 interface ManualAARTrackEditorProps {
   tracks: ManualAARTrack[];
-  onTracksChange: (tracks: ManualAARTrack[]) => void;
+  onSaveTrack: (track: ManualAARTrack) => Promise<void>;
+  onRemoveTrack: (trackId: string) => void;
 }
 
-const isLatitude = (value: number) => Number.isFinite(value) && value >= -90 && value <= 90;
-const isLongitude = (value: number) => Number.isFinite(value) && value >= -180 && value <= 180;
+const isLatitude = (value: number) =>
+  Number.isFinite(value) && value >= -90 && value <= 90;
+const isLongitude = (value: number) =>
+  Number.isFinite(value) && value >= -180 && value <= 180;
 
 interface DraftPoint {
   latitude: string;
@@ -20,11 +23,17 @@ const emptyPoint = (): DraftPoint => ({ latitude: '', longitude: '' });
 
 export function ManualAARTrackEditor({
   tracks,
-  onTracksChange,
+  onSaveTrack,
+  onRemoveTrack,
 }: ManualAARTrackEditorProps) {
   const [name, setName] = useState('Manual AR Track');
-  const [points, setPoints] = useState<DraftPoint[]>([emptyPoint(), emptyPoint()]);
+  const [points, setPoints] = useState<DraftPoint[]>([
+    emptyPoint(),
+    emptyPoint(),
+  ]);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   const updatePoint = (
     pointIndex: number,
@@ -38,7 +47,8 @@ export function ManualAARTrackEditor({
     );
   };
 
-  const addTrack = () => {
+  const addTrack = async () => {
+    setSuccess(null);
     if (!name.trim()) {
       setError('Enter a name for the manual AR track.');
       return;
@@ -47,29 +57,57 @@ export function ManualAARTrackEditor({
       setError('A manual AR track needs at least two points.');
       return;
     }
-    if (points.some((point) => !point.latitude.trim() || !point.longitude.trim())) {
-      setError('Enter both latitude and longitude for every manual AR track point.');
+    if (
+      points.some((point) => !point.latitude.trim() || !point.longitude.trim())
+    ) {
+      setError(
+        'Enter both latitude and longitude for every manual AR track point.'
+      );
       return;
     }
     const parsedPoints: ManualAARTrackPoint[] = points.map((point) => ({
       latitude: Number(point.latitude),
       longitude: Number(point.longitude),
     }));
-    if (!parsedPoints.every((point) => isLatitude(point.latitude) && isLongitude(point.longitude))) {
+    if (
+      !parsedPoints.every(
+        (point) => isLatitude(point.latitude) && isLongitude(point.longitude)
+      )
+    ) {
       setError('Latitude must be -90 to 90 and longitude must be -180 to 180.');
       return;
     }
-    if (parsedPoints.some((point, index) => index > 0 && point.latitude === parsedPoints[index - 1].latitude && point.longitude === parsedPoints[index - 1].longitude)) {
+    if (
+      parsedPoints.some(
+        (point, index) =>
+          index > 0 &&
+          point.latitude === parsedPoints[index - 1].latitude &&
+          point.longitude === parsedPoints[index - 1].longitude
+      )
+    ) {
       setError('Adjacent manual AR track points cannot be duplicates.');
       return;
     }
 
-    onTracksChange([
-      ...tracks,
-      { id: crypto.randomUUID(), name: name.trim(), points: parsedPoints },
-    ]);
-    setError(null);
-    setPoints([emptyPoint(), emptyPoint()]);
+    try {
+      setIsSaving(true);
+      await onSaveTrack({
+        id: crypto.randomUUID(),
+        name: name.trim(),
+        points: parsedPoints,
+      });
+      setError(null);
+      setSuccess('Manual AR track saved.');
+      setPoints([emptyPoint(), emptyPoint()]);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? `Unable to save manual AR track: ${saveError.message}`
+          : 'Unable to save manual AR track. Please try again.'
+      );
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -77,8 +115,9 @@ export function ManualAARTrackEditor({
       <div>
         <h3 className="text-sm font-medium">Manual AR Tracks</h3>
         <p className="mt-1 text-xs text-muted-foreground">
-          Add a deviation track by ordered latitude/longitude points. It is saved
-          separately from the planned route and may cross the antimeridian.
+          Add a deviation track by ordered latitude/longitude points. It is
+          saved separately from the planned route and may cross the
+          antimeridian.
         </p>
       </div>
 
@@ -94,7 +133,7 @@ export function ManualAARTrackEditor({
             <Button
               variant="destructive"
               size="sm"
-              onClick={() => onTracksChange(tracks.filter((item) => item.id !== track.id))}
+              onClick={() => onRemoveTrack(track.id)}
             >
               Remove
             </Button>
@@ -103,7 +142,11 @@ export function ManualAARTrackEditor({
       ))}
 
       <div className="space-y-3 rounded border p-3">
-        <Input value={name} onChange={(event) => setName(event.target.value)} aria-label="Manual AR track name" />
+        <Input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          aria-label="Manual AR track name"
+        />
         {points.map((point, index) => (
           <div key={index} className="flex items-center gap-2">
             <Input
@@ -113,7 +156,9 @@ export function ManualAARTrackEditor({
               max={90}
               step="any"
               aria-label={`Manual AR point ${index + 1} latitude`}
-              onChange={(event) => updatePoint(index, 'latitude', event.target.value)}
+              onChange={(event) =>
+                updatePoint(index, 'latitude', event.target.value)
+              }
             />
             <Input
               type="number"
@@ -122,24 +167,46 @@ export function ManualAARTrackEditor({
               max={180}
               step="any"
               aria-label={`Manual AR point ${index + 1} longitude`}
-              onChange={(event) => updatePoint(index, 'longitude', event.target.value)}
+              onChange={(event) =>
+                updatePoint(index, 'longitude', event.target.value)
+              }
             />
             <Button
               variant="outline"
               size="sm"
               disabled={points.length <= 2}
-              onClick={() => setPoints(points.filter((_, pointIndex) => pointIndex !== index))}
+              onClick={() =>
+                setPoints(
+                  points.filter((_, pointIndex) => pointIndex !== index)
+                )
+              }
             >
               Remove
             </Button>
           </div>
         ))}
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        {success && (
+          <p role="status" className="text-sm text-green-700">
+            {success}
+          </p>
+        )}
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => setPoints([...points, emptyPoint()])}>
+          <Button
+            variant="outline"
+            onClick={() => setPoints([...points, emptyPoint()])}
+          >
             Add Point
           </Button>
-          <Button onClick={addTrack}>Save Manual AR Track</Button>
+          <Button onClick={addTrack} disabled={isSaving}>
+            {isSaving
+              ? 'Saving Manual AR Track...'
+              : 'Save and Persist Manual AR Track'}
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/mission-planner/src/pages/LegDetailPage.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage.tsx
@@ -10,7 +10,7 @@ import { LegMapVisualization } from './LegDetailPage/LegMapVisualization';
 import { TimingSection } from './LegDetailPage/TimingSection';
 import { TimelinePreviewSection } from '../components/timeline/TimelinePreviewSection';
 import type { SatelliteConfig } from '../types/satellite';
-import type { AARConfig } from '../types/aar';
+import type { AARConfig, ManualAARTrack } from '../types/aar';
 import type { TimelinePreviewRequest } from '../services/timeline';
 
 export function LegDetailPage() {
@@ -117,6 +117,32 @@ export function LegDetailPage() {
   const handleAARConfigChange = (config: AARConfig) => {
     setAARConfig(config);
     setHasUnsavedChanges(true);
+  };
+
+  const handleManualTrackSave = async (track: ManualAARTrack) => {
+    if (!leg) {
+      throw new Error('The leg is no longer available. Reload and try again.');
+    }
+
+    const updatedAARConfig = {
+      ...aarConfig,
+      manualTracks: [...aarConfig.manualTracks, track],
+    };
+    await updateLegMutation.mutateAsync({
+      ...leg,
+      transports: {
+        initial_x_satellite_id:
+          satelliteConfig.xband_starting_satellite || 'X-1',
+        initial_ka_satellite_ids: ['AOR', 'POR', 'IOR'],
+        x_transitions: satelliteConfig.xband_transitions,
+        ka_outages: satelliteConfig.ka_outages,
+        aar_windows: updatedAARConfig.segments,
+        manual_aar_tracks: updatedAARConfig.manualTracks,
+        ku_overrides: satelliteConfig.ku_outages,
+      },
+    });
+    setAARConfig(updatedAARConfig);
+    setHasUnsavedChanges(false);
   };
 
   const handleBackClick = () => {
@@ -247,6 +273,7 @@ export function LegDetailPage() {
             waypointNames={waypointNames}
             onSatelliteConfigChange={handleSatelliteConfigChange}
             onAARConfigChange={handleAARConfigChange}
+            onManualTrackSave={handleManualTrackSave}
           />
 
           <TimelinePreviewSection

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
@@ -11,7 +11,7 @@ import { KuOutageConfig } from '../../components/satellites/KuOutageConfig';
 import { AARSegmentEditor } from '../../components/aar/AARSegmentEditor';
 import { ManualAARTrackEditor } from '../../components/aar/ManualAARTrackEditor';
 import type { SatelliteConfig } from '../../types/satellite';
-import type { AARConfig } from '../../types/aar';
+import type { AARConfig, ManualAARTrack } from '../../types/aar';
 
 interface LegConfigTabsProps {
   satelliteConfig: SatelliteConfig;
@@ -20,6 +20,7 @@ interface LegConfigTabsProps {
   waypointNames: string[];
   onSatelliteConfigChange: (updates: Partial<SatelliteConfig>) => void;
   onAARConfigChange: (config: AARConfig) => void;
+  onManualTrackSave: (track: ManualAARTrack) => Promise<void>;
 }
 
 /**
@@ -32,6 +33,7 @@ export function LegConfigTabs({
   waypointNames,
   onSatelliteConfigChange,
   onAARConfigChange,
+  onManualTrackSave,
 }: LegConfigTabsProps) {
   return (
     <Tabs defaultValue="xband" className="w-full">
@@ -122,8 +124,14 @@ export function LegConfigTabs({
           <h2 className="text-xl font-semibold mb-4">Manual AR Track</h2>
           <ManualAARTrackEditor
             tracks={aarConfig.manualTracks}
-            onTracksChange={(manualTracks) =>
-              onAARConfigChange({ ...aarConfig, manualTracks })
+            onSaveTrack={onManualTrackSave}
+            onRemoveTrack={(trackId) =>
+              onAARConfigChange({
+                ...aarConfig,
+                manualTracks: aarConfig.manualTracks.filter(
+                  (track) => track.id !== trackId
+                ),
+              })
             }
           />
         </div>

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -88,6 +88,80 @@ async function mockLegDetailApis(page: Page) {
 }
 
 test.describe('Leg detail responsive layout', () => {
+  test('persists a manual AR track, confirms it, and retains it after reload', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const persistedMission = structuredClone(mission);
+
+    await mockLegDetailApis(page);
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg',
+      async (route) => {
+        if (route.request().method() !== 'PUT') {
+          await route.continue();
+          return;
+        }
+
+        const updatedLeg = route.request().postDataJSON();
+        persistedMission.legs[0] = updatedLeg;
+        await route.fulfill({ json: { leg: updatedLeg, warnings: [] } });
+      }
+    );
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission',
+      async (route) => {
+        await route.fulfill({ json: persistedMission });
+      }
+    );
+
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+    await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();
+    await page.getByLabel('Manual AR point 1 latitude').fill('50');
+    await page.getByLabel('Manual AR point 1 longitude').fill('-50');
+    await page.getByLabel('Manual AR point 2 latitude').fill('30');
+    await page.getByLabel('Manual AR point 2 longitude').fill('-50');
+
+    const saveTrack = page.getByRole('button', {
+      name: 'Save and Persist Manual AR Track',
+    });
+    await saveTrack.scrollIntoViewIfNeeded();
+    await expect(saveTrack).toBeInViewport();
+    await saveTrack.click();
+
+    await expect(page.getByRole('status')).toHaveText('Manual AR track saved.');
+    await expect(page.getByText('2 operator-entered points')).toBeVisible();
+
+    await page.reload();
+    await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();
+    await expect(page.getByText('2 operator-entered points')).toBeVisible();
+  });
+
+  test('keeps invalid manual AR track input and shows an inline error', async ({
+    page,
+  }) => {
+    await mockLegDetailApis(page);
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+    await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();
+    await page.getByLabel('Manual AR point 1 latitude').fill('50');
+    await page.getByLabel('Manual AR point 1 longitude').fill('-50');
+    await page.getByLabel('Manual AR point 2 latitude').fill('30');
+
+    await page
+      .getByRole('button', { name: 'Save and Persist Manual AR Track' })
+      .click();
+
+    await expect(page.getByRole('alert')).toHaveText(
+      'Enter both latitude and longitude for every manual AR track point.'
+    );
+    await expect(page.getByLabel('Manual AR point 1 latitude')).toHaveValue(
+      '50'
+    );
+    await expect(page.getByLabel('Manual AR point 2 latitude')).toHaveValue(
+      '30'
+    );
+  });
+
   test('stacks the map and keeps Manual AR Tracks reachable on mobile', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Makes the Manual AR Track editor action persist the complete leg configuration through the existing v2 leg update API instead of only mutating React state.
- Adds clear saving, success, and actionable inline error states while preserving invalid draft values after validation or API failures.
- Adds browser regression coverage for valid save/read-back/reload, invalid-input retention, and mobile-reachable save control.

## Verification
- `npm run build` — passed
- `npm run lint` — passed
- `npx prettier --check src/components/aar/ManualAARTrackEditor.tsx src/pages/LegDetailPage.tsx src/pages/LegDetailPage/LegConfigTabs.tsx tests/e2e/leg-detail-responsive.spec.ts` — passed
- `git diff --check` — passed
- Focused Playwright test was attempted. Chromium download repeatedly stalled after reporting 100%, so browser execution could not complete in this worker environment.

## Documentation impact
None; this fixes existing UI behavior and labels the control explicitly.

## Follow-up
#96 is a separate confirmed timeline/domain-calculation issue. Its dependent implementation card will handle applying saved/current manual tracks to preview/persisted timelines and map/timeline end-to-end behavior.

Closes #95