### PR TITLE
fix: apply manual AR tracks to timeline

### DIFF
--- a/backend/starlink-location/app/mission/state.py
+++ b/backend/starlink-location/app/mission/state.py
@@ -224,6 +224,16 @@ def _apply_event(
     if event.event_type == EventType.AAR_WINDOW:
         return False
 
+    if event.event_type in (
+        EventType.MANUAL_AAR_TRACK_START,
+        EventType.MANUAL_AAR_TRACK_END,
+    ):
+        track_id = event.metadata.get("track_id", "unknown") if event.metadata else "unknown"
+        key = f"manual_aar_track:{track_id}"
+        if event.event_type == EventType.MANUAL_AAR_TRACK_START:
+            return activate("degraded", key, reason or "Manual AR Track")
+        return deactivate("degraded", key)
+
     if event.event_type == EventType.X_AZIMUTH_VIOLATION:
         key = "x_azimuth"
         if event.severity in ("warning", "critical"):

--- a/backend/starlink-location/app/mission/timeline_builder/aar.py
+++ b/backend/starlink-location/app/mission/timeline_builder/aar.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from app.mission.models import MissionLeg
+from app.mission.models import ManualAARTrack, MissionLeg
 from app.models.route import ParsedRoute
 from app.satellites.rules import RuleEngine
 from app.mission.timeline_builder.calculator import (
@@ -86,6 +86,36 @@ def resolve_aar_windows(
         )
 
     return windows
+
+
+def apply_manual_aar_tracks(
+    rule_engine: RuleEngine,
+    tracks: list[ManualAARTrack],
+    projector: RouteTemporalProjector,
+) -> None:
+    """Project manual AR track points onto route time and degrade X over the span.
+
+    Each geographic track point maps to its closest position on the planned
+    route. The earliest and latest projected timestamps delimit the manual AR
+    operation. This preserves route timing, including antimeridian-aware route
+    projection, while making the track an explicit X-band degradation rather
+    than an implicit replacement for the planned route.
+    """
+    for track in tracks:
+        projections = [
+            projector.project(point.latitude, point.longitude) for point in track.points
+        ]
+        start_time = min(projection.timestamp for projection in projections)
+        end_time = max(projection.timestamp for projection in projections)
+        if end_time <= start_time:
+            logger.warning(
+                "Skipping manual AR track %s: all points project to one route time",
+                track.id,
+            )
+            continue
+        rule_engine.add_manual_aar_track_events(
+            start_time, end_time, track.id, track.name
+        )
 
 
 def parse_elapsed_offset(value: str) -> timedelta:

--- a/backend/starlink-location/app/mission/timeline_service.py
+++ b/backend/starlink-location/app/mission/timeline_service.py
@@ -32,7 +32,11 @@ from app.mission.timeline_builder.events import (
     apply_x_azimuth_events,
     apply_manual_outages,
 )
-from app.mission.timeline_builder.aar import resolve_aar_windows, apply_x_transitions
+from app.mission.timeline_builder.aar import (
+    apply_manual_aar_tracks,
+    apply_x_transitions,
+    resolve_aar_windows,
+)
 from app.mission.timeline_builder.pois import sync_ka_pois, sync_x_aar_pois
 from app.mission.timeline_builder.stats import (
     TimelineSummary,
@@ -129,6 +133,9 @@ def build_mission_timeline(
         rule_engine.add_aar_window_events(
             window.start_time, window.end_time, window.name
         )
+    apply_manual_aar_tracks(
+        rule_engine, mission.transports.manual_aar_tracks, projector
+    )
 
     transition_schedule = apply_x_transitions(
         rule_engine, mission, projector, aar_windows

--- a/backend/starlink-location/app/satellites/rules.py
+++ b/backend/starlink-location/app/satellites/rules.py
@@ -36,6 +36,8 @@ class EventType(str, Enum):
     TAKEOFF_BUFFER = "takeoff_buffer"
     LANDING_BUFFER = "landing_buffer"
     AAR_WINDOW = "aar_window"
+    MANUAL_AAR_TRACK_START = "manual_aar_track_start"
+    MANUAL_AAR_TRACK_END = "manual_aar_track_end"
 
 
 @dataclass
@@ -324,6 +326,44 @@ class RuleEngine:
                 severity="info",
                 reason=end_label,
             )
+        )
+
+    def add_manual_aar_track_events(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        track_id: str,
+        track_name: str,
+    ) -> None:
+        """Degrade X while the planned route overlaps a manual AR track.
+
+        A manual track is a geographic deviation, not a route replacement. Its
+        points are projected onto the planned route and the earliest/latest
+        projections bound the interval in which the X-band link is degraded.
+        """
+        reason = f"Manual AR Track: {track_name}"
+        metadata = {"track_id": track_id, "track_name": track_name}
+        self.events.extend(
+            [
+                MissionEvent(
+                    timestamp=start_time,
+                    event_type=EventType.MANUAL_AAR_TRACK_START,
+                    transport=Transport.X,
+                    affected_transport=Transport.X,
+                    severity="warning",
+                    reason=reason,
+                    metadata=metadata,
+                ),
+                MissionEvent(
+                    timestamp=end_time,
+                    event_type=EventType.MANUAL_AAR_TRACK_END,
+                    transport=Transport.X,
+                    affected_transport=Transport.X,
+                    severity="info",
+                    reason=f"{reason} complete",
+                    metadata=metadata,
+                ),
+            ]
         )
 
     def get_sorted_events(self) -> List[MissionEvent]:

--- a/backend/starlink-location/tests/unit/test_manual_aar_track.py
+++ b/backend/starlink-location/tests/unit/test_manual_aar_track.py
@@ -1,10 +1,56 @@
 """Regression tests for operator-created manual AAR tracks."""
 
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
 import pytest
 from pydantic import ValidationError
 
-from app.mission.models import ManualAARTrack, ManualAARTrackPoint, Mission, MissionLeg, TransportConfig
+from app.mission.models import (
+    ManualAARTrack,
+    ManualAARTrackPoint,
+    Mission,
+    MissionLeg,
+    TimelineStatus,
+    TransportConfig,
+)
 from app.mission.storage import load_mission_v2, save_mission_v2
+from app.mission.timeline_service import build_mission_timeline
+from app.models.route import ParsedRoute, RouteMetadata, RoutePoint, RouteTimingProfile
+
+
+def _timed_manual_track_route(start: datetime) -> ParsedRoute:
+    return ParsedRoute(
+        metadata=RouteMetadata(
+            name="Manual track route", file_path="manual-track.kml", point_count=3
+        ),
+        points=[
+            RoutePoint(
+                latitude=60.0,
+                longitude=-50.0,
+                sequence=0,
+                expected_arrival_time=start,
+            ),
+            RoutePoint(
+                latitude=40.0,
+                longitude=-50.0,
+                sequence=1,
+                expected_arrival_time=start + timedelta(hours=1),
+            ),
+            RoutePoint(
+                latitude=20.0,
+                longitude=-50.0,
+                sequence=2,
+                expected_arrival_time=start + timedelta(hours=2),
+            ),
+        ],
+        timing_profile=RouteTimingProfile(
+            departure_time=start,
+            arrival_time=start + timedelta(hours=2),
+            has_timing_data=True,
+            segment_count_with_timing=3,
+        ),
+    )
 
 
 def test_manual_aar_track_persists_ordered_deviation_points(isolate_mission_storage):
@@ -91,3 +137,50 @@ def test_manual_aar_track_rejects_out_of_range_coordinates(point, message):
     """Manual position entry accepts only decimal-degree geographic coordinates."""
     with pytest.raises(ValidationError, match=message):
         ManualAARTrackPoint(**point)
+
+
+def test_manual_aar_track_degrades_x_between_projected_endpoints():
+    """A track creates an X degradation over its route-projected time span."""
+    start = datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+    route_manager = MagicMock()
+    route_manager.get_route.return_value = _timed_manual_track_route(start)
+    base_leg = MissionLeg(
+        id="manual-track-leg",
+        name="Manual track leg",
+        route_id="manual-track-route",
+        transports=TransportConfig(initial_x_satellite_id="X-1"),
+    )
+    manual_track = ManualAARTrack(
+        id="manual-track",
+        name="AR deviation",
+        points=[
+            ManualAARTrackPoint(latitude=50.0, longitude=-50.0),
+            ManualAARTrackPoint(latitude=30.0, longitude=-50.0),
+        ],
+    )
+    tracked_leg = base_leg.model_copy(
+        update={
+            "transports": base_leg.transports.model_copy(
+                update={"manual_aar_tracks": [manual_track]}
+            )
+        }
+    )
+
+    baseline, _ = build_mission_timeline(
+        base_leg, route_manager=route_manager, coverage_sampler=None
+    )
+    tracked, _ = build_mission_timeline(
+        tracked_leg, route_manager=route_manager, coverage_sampler=None
+    )
+
+    assert baseline.statistics["degraded_seconds"] == 0
+    assert tracked.statistics["degraded_seconds"] == 3600
+    degraded = [
+        segment
+        for segment in tracked.segments
+        if segment.status == TimelineStatus.DEGRADED
+    ]
+    assert [(segment.start_time, segment.end_time) for segment in degraded] == [
+        (start + timedelta(minutes=30), start + timedelta(minutes=90))
+    ]
+    assert "Manual AR Track: AR deviation" in degraded[0].reasons[0]

--- a/docs/features/mission-planning.md
+++ b/docs/features/mission-planning.md
@@ -32,8 +32,12 @@ Create and manage missions with transport configurations.
 ### Real-Time Timeline Preview
 
 The preview recalculates automatically after a short debounce whenever you edit
-satellite transitions, outages, or AAR windows. You can make a change, watch
-the route and status colors update, and only save once the result looks sane.
+satellite transitions, outages, AAR windows, or manual AR tracks. A manual AR
+track is projected onto the planned route: its earliest and latest projected
+points bound an X-Band degraded interval. The manual track remains an orange
+dashed geographic overlay; it does not replace or redraw the planned route.
+You can make a change, watch the route and status colors update, and only save
+once the result looks sane.
 The preview panel shows an Unsaved badge whenever the current configuration
 differs from the persisted leg.
 

--- a/frontend/mission-planner/src/services/timeline.ts
+++ b/frontend/mission-planner/src/services/timeline.ts
@@ -53,6 +53,14 @@ export interface TimelinePreviewRequest {
       override_end_time?: string | null;
       override_start_elapsed?: string | null;
     }>;
+    manual_aar_tracks: Array<{
+      id: string;
+      name: string;
+      points: Array<{
+        latitude: number;
+        longitude: number;
+      }>;
+    }>;
     ku_overrides: Array<Record<string, unknown>>;
   };
   adjusted_departure_time?: string;

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -68,11 +68,36 @@ async function mockLegDetailApis(page: Page) {
   await page.route(
     'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg/timeline/preview',
     async (route) => {
+      const request = route.request();
+      const hasManualTrack =
+        request.method() === 'POST' &&
+        request.postDataJSON().transports.manual_aar_tracks.length > 0;
       await route.fulfill({
         json: {
           mission_leg_id: 'responsive-leg',
           created_at: '2026-08-13T00:00:00Z',
-          segments: [],
+          segments: hasManualTrack
+            ? [
+                {
+                  id: 'manual-ar-segment',
+                  start_time: '2026-08-13T00:30:00Z',
+                  end_time: '2026-08-13T01:30:00Z',
+                  status: 'degraded',
+                  x_state: 'degraded',
+                  ka_state: 'available',
+                  ku_state: 'available',
+                  reasons: ['Manual AR Track: Manual AR Track'],
+                },
+              ]
+            : [],
+          statistics: hasManualTrack
+            ? {
+                total_duration_seconds: 7200,
+                degraded_seconds: 3600,
+                critical_seconds: 0,
+                nominal_seconds: 3600,
+              }
+            : undefined,
         },
       });
     }
@@ -131,6 +156,10 @@ test.describe('Leg detail responsive layout', () => {
 
     await expect(page.getByRole('status')).toHaveText('Manual AR track saved.');
     await expect(page.getByText('2 operator-entered points')).toBeVisible();
+    await expect(page.locator('path[stroke="#F97316"]')).toBeVisible();
+    await expect(page.getByText('1 segments')).toBeVisible();
+    await expect(page.getByText('Degraded Time')).toBeVisible();
+    await expect(page.getByText('60m')).toBeVisible();
 
     await page.reload();
     await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -43,8 +43,8 @@ async function mockLegDetailApis(page: Page) {
       await route.fulfill({
         json: {
           points: [
-            { latitude: 34, longitude: -118 },
-            { latitude: 35, longitude: -117 },
+            { latitude: 50, longitude: -50 },
+            { latitude: 30, longitude: -50 },
           ],
           waypoints: [],
         },
@@ -156,14 +156,19 @@ test.describe('Leg detail responsive layout', () => {
 
     await expect(page.getByRole('status')).toHaveText('Manual AR track saved.');
     await expect(page.getByText('2 operator-entered points')).toBeVisible();
-    await expect(page.locator('path[stroke="#F97316"]')).toBeVisible();
+    const manualTrackOverlay = page.locator('path[stroke="#F97316"]');
+    await expect(manualTrackOverlay).toBeAttached();
+    await expect(manualTrackOverlay).not.toHaveAttribute('d', 'M0 0');
     await expect(page.getByText('1 segments')).toBeVisible();
     await expect(page.getByText('Degraded Time')).toBeVisible();
-    await expect(page.getByText('60m')).toBeVisible();
+    await expect(
+      page.getByText('Degraded Time').locator('..').getByText('60m')
+    ).toBeVisible();
 
     await page.reload();
     await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();
     await expect(page.getByText('2 operator-entered points')).toBeVisible();
+    await expect(page.locator('path[stroke="#F97316"]')).toBeAttached();
   });
 
   test('keeps invalid manual AR track input and shows an inline error', async ({
@@ -219,7 +224,7 @@ test.describe('Leg detail responsive layout', () => {
 
     await manualArTab.click();
     await expect(
-      page.getByRole('heading', { name: 'Manual AR Track' })
+      page.getByRole('heading', { name: 'Manual AR Track', exact: true })
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- Project each manual AR track's geographic points onto the planned route and degrade X-Band between the earliest and latest projected times.
- Use the same timeline builder for persisted legs and unsaved previews; preserve the existing orange dashed map overlay and antimeridian normalization.
- Add backend regression coverage for (50,-50) to (30,-50), browser regression assertions for saved/read-back overlay and timeline updates, and operator documentation.

## Verification
- `pytest tests/unit/test_manual_aar_track.py tests/unit/test_mission_timeline.py tests/unit/test_package_adjusted_export.py -q` — 37 passed
- `npm run build`
- `npx eslint src/services/timeline.ts tests/e2e/leg-detail-responsive.spec.ts`
- Docker no-cache rebuild and health sequence completed: backend healthy and `curl http://localhost:8000/health` succeeded.

## Browser note
Playwright browser coverage was updated, but the Chromium binary download stalled after transfer in this worker environment, so the E2E suite could not be executed here. The frontend production build and scoped lint passed.

Closes #96
