### PR TITLE
fix: support client IDs when crypto.randomUUID is unavailable

### DIFF
--- a/frontend/mission-planner/src/components/aar/AARSegmentEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/AARSegmentEditor.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import { createClientId } from '@/lib/clientId';
 import type { AARSegment } from '../../types/aar';
 
 interface AARSegmentEditorProps {
@@ -95,7 +96,7 @@ export function AARSegmentEditor({
       onSegmentsChange([
         ...segments,
         {
-          id: crypto.randomUUID(),
+          id: createClientId(),
           start_waypoint_name: newSegment.start_waypoint_name,
           end_waypoint_name: newSegment.end_waypoint_name,
         },

--- a/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { createClientId } from '@/lib/clientId';
 import type { ManualAARTrack, ManualAARTrackPoint } from '../../types/aar';
 
 interface ManualAARTrackEditorProps {
@@ -92,7 +93,7 @@ export function ManualAARTrackEditor({
     try {
       setIsSaving(true);
       await onSaveTrack({
-        id: crypto.randomUUID(),
+        id: createClientId(),
         name: name.trim(),
         points: parsedPoints,
       });

--- a/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
+++ b/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
@@ -9,6 +9,7 @@ import {
 } from '../ui/table';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { createClientId } from '@/lib/clientId';
 import { toISO8601, formatTime24Hour } from '@/lib/utils';
 import type { KaOutage } from '../../types/satellite';
 
@@ -105,7 +106,7 @@ export function KaOutageConfig({
       onOutagesChange([
         ...outages,
         {
-          id: crypto.randomUUID(),
+          id: createClientId(),
           start_time: toISO8601(newOutage.start_time!),
           duration_seconds: durationSeconds,
         },

--- a/frontend/mission-planner/src/components/satellites/KuOutageConfig.tsx
+++ b/frontend/mission-planner/src/components/satellites/KuOutageConfig.tsx
@@ -9,6 +9,7 @@ import {
 } from '../ui/table';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { createClientId } from '@/lib/clientId';
 import { toISO8601, formatTime24Hour } from '@/lib/utils';
 import type { KuOutageOverride } from '../../types/satellite';
 
@@ -107,7 +108,7 @@ export function KuOutageConfig({
       onOutagesChange([
         ...outages,
         {
-          id: crypto.randomUUID(),
+          id: createClientId(),
           start_time: toISO8601(newOutage.start_time!),
           duration_seconds: durationSeconds,
           reason: newOutage.reason || undefined,

--- a/frontend/mission-planner/src/components/satellites/XBandConfig.tsx
+++ b/frontend/mission-planner/src/components/satellites/XBandConfig.tsx
@@ -16,6 +16,7 @@ import {
 } from '../ui/table';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { createClientId } from '@/lib/clientId';
 import type { XBandTransition } from '../../types/satellite';
 
 interface XBandConfigProps {
@@ -87,7 +88,7 @@ export function XBandConfig({
       onTransitionsChange([
         ...transitions,
         {
-          id: crypto.randomUUID(),
+          id: createClientId(),
           latitude: newTransition.latitude!,
           longitude: newTransition.longitude!,
           target_satellite_id: newTransition.target_satellite_id!,

--- a/frontend/mission-planner/src/lib/clientId.test.ts
+++ b/frontend/mission-planner/src/lib/clientId.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createClientId } from './clientId';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('createClientId', () => {
+  it('uses crypto.randomUUID when the browser supports it', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: () => 'secure-browser-id',
+    });
+
+    expect(createClientId()).toBe('secure-browser-id');
+  });
+
+  it('creates distinct client IDs when crypto.randomUUID is unavailable', () => {
+    vi.stubGlobal('crypto', undefined);
+
+    const ids = [createClientId(), createClientId()];
+
+    expect(ids[0]).toMatch(/^client-/);
+    expect(new Set(ids)).toHaveLength(2);
+  });
+});

--- a/frontend/mission-planner/src/lib/clientId.ts
+++ b/frontend/mission-planner/src/lib/clientId.ts
@@ -1,0 +1,27 @@
+const formatUuid = (bytes: Uint8Array): string => {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex
+    .slice(6, 8)
+    .join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+};
+
+/**
+ * Generates a client-side ID in secure and non-secure browser contexts.
+ */
+export function createClientId(): string {
+  const cryptoApi = globalThis.crypto;
+  if (typeof cryptoApi?.randomUUID === 'function') {
+    return cryptoApi.randomUUID();
+  }
+
+  if (typeof cryptoApi?.getRandomValues === 'function') {
+    return formatUuid(cryptoApi.getRandomValues(new Uint8Array(16)));
+  }
+
+  return `client-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 12)}`;
+}

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -113,10 +113,16 @@ async function mockLegDetailApis(page: Page) {
 }
 
 test.describe('Leg detail responsive layout', () => {
-  test('persists a manual AR track, confirms it, and retains it after reload', async ({
+  test('persists a manual AR track without crypto.randomUUID on mobile', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
+    await page.addInitScript(() => {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        value: undefined,
+      });
+    });
     const persistedMission = structuredClone(mission);
 
     await mockLegDetailApis(page);


### PR DESCRIPTION
## Summary
- Centralizes client-side ID generation with a `crypto.randomUUID()` fast path and compatible fallbacks.
- Updates Manual AR, AAR segment, Ka outage, Ku outage, and X-band editors to use the shared helper.
- Adds unit coverage plus an HTTP/mobile manual-track regression that removes `crypto.randomUUID`.

## Verification
- `npx vitest run src/lib/clientId.test.ts` (2 passed)
- `npm run lint`
- `npm run build`
- `npx prettier --check` for changed frontend files
- Attempted the focused Playwright Chromium regression; the configured Chromium executable was absent and `npx playwright install chromium` could not complete in this worker environment.

## Documentation impact
None.

Closes #99
