### PR TITLE
fix: keep mobile leg controls reachable

### DIFF
--- a/frontend/mission-planner/src/App.tsx
+++ b/frontend/mission-planner/src/App.tsx
@@ -15,8 +15,8 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <nav className="bg-gray-800 text-white p-4 mb-6">
-          <div className="container mx-auto flex gap-6">
+        <nav className="mb-6 bg-gray-800 p-4 text-white">
+          <div className="container mx-auto flex flex-wrap gap-x-6 gap-y-3">
             <Link to="/missions" className="hover:underline">
               Missions
             </Link>

--- a/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage/LegConfigTabs.tsx
@@ -37,15 +37,13 @@ export function LegConfigTabs({
 }: LegConfigTabsProps) {
   return (
     <Tabs defaultValue="xband" className="w-full">
-      <div className="-mx-1 overflow-x-auto px-1 pb-1">
-        <TabsList className="min-w-max justify-start">
-          <TabsTrigger value="xband">X-Band</TabsTrigger>
-          <TabsTrigger value="ka">Ka Outages</TabsTrigger>
-          <TabsTrigger value="ku">Ku/Starlink Outages</TabsTrigger>
-          <TabsTrigger value="aar">AAR Segments</TabsTrigger>
-          <TabsTrigger value="manual-ar">Manual AR Tracks</TabsTrigger>
-        </TabsList>
-      </div>
+      <TabsList className="h-auto w-full flex-wrap justify-start gap-1">
+        <TabsTrigger value="xband">X-Band</TabsTrigger>
+        <TabsTrigger value="ka">Ka Outages</TabsTrigger>
+        <TabsTrigger value="ku">Ku/Starlink Outages</TabsTrigger>
+        <TabsTrigger value="aar">AAR Segments</TabsTrigger>
+        <TabsTrigger value="manual-ar">Manual AR Tracks</TabsTrigger>
+      </TabsList>
 
       <TabsContent value="xband" className="space-y-4">
         <div className="rounded-lg border p-4 sm:p-6">

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -202,7 +202,7 @@ test.describe('Leg detail responsive layout', () => {
     );
   });
 
-  test('stacks the map and keeps Manual AR Tracks reachable on mobile', async ({
+  test('keeps navigation and every tab reachable without mobile page overflow', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
@@ -210,15 +210,39 @@ test.describe('Leg detail responsive layout', () => {
 
     await page.goto('/missions/responsive-mission/legs/responsive-leg');
 
+    const navigationLinks = [
+      'Missions',
+      'Satellites',
+      'POIs',
+      'Routes',
+      'Data Export',
+      'Configuration',
+    ];
+    const tabNames = [
+      'X-Band',
+      'Ka Outages',
+      'Ku/Starlink Outages',
+      'AAR Segments',
+      'Manual AR Tracks',
+    ];
     const manualArTab = page.getByRole('tab', { name: 'Manual AR Tracks' });
     const mapHeading = page.getByRole('heading', {
       name: 'Route Visualization',
     });
 
-    await expect(manualArTab).toBeVisible();
+    const hasPageOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(hasPageOverflow).toBe(false);
+    for (const linkName of navigationLinks) {
+      await expect(
+        page.getByRole('link', { name: linkName, exact: true })
+      ).toBeInViewport();
+    }
+    for (const tabName of tabNames) {
+      await expect(page.getByRole('tab', { name: tabName })).toBeInViewport();
+    }
     await expect(mapHeading).toBeVisible();
-    await manualArTab.scrollIntoViewIfNeeded();
-    await expect(manualArTab).toBeInViewport();
 
     const [tabBox, mapBox] = await Promise.all([
       manualArTab.boundingBox(),
@@ -228,7 +252,9 @@ test.describe('Leg detail responsive layout', () => {
     expect(mapBox).not.toBeNull();
     expect(mapBox!.y).toBeGreaterThan(tabBox!.y);
 
-    await manualArTab.click();
+    await manualArTab.focus();
+    await expect(manualArTab).toBeFocused();
+    await page.keyboard.press('Enter');
     await expect(
       page.getByRole('heading', { name: 'Manual AR Track', exact: true })
     ).toBeVisible();


### PR DESCRIPTION
## Summary
- Wrap primary navigation so every destination remains visible at 390px.
- Wrap the five leg-configuration tabs rather than hiding them behind an unlabelled horizontal scroller.
- Add a Chromium regression test for viewport width, navigation reachability, all tabs, and keyboard activation.

## Verification
- `npx prettier --check src/App.tsx src/pages/LegDetailPage/LegConfigTabs.tsx tests/e2e/leg-detail-responsive.spec.ts`
- `npm run build`
- `npx playwright test tests/e2e/leg-detail-responsive.spec.ts --project=chromium` (4 passed)
- `npm run lint` remains blocked by three pre-existing `react-hooks/set-state-in-effect` errors outside this PR.

## Documentation impact
None; this is a responsive UI regression fix.

Closes #102