### PR TITLE
fix: restore Ka outage duration input

### DIFF
--- a/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
+++ b/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
@@ -9,6 +9,7 @@ import {
 } from '../ui/table';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Label } from '../ui/label';
 import { createClientId } from '@/lib/clientId';
 import { toISO8601, formatTime24Hour } from '@/lib/utils';
 import type { KaOutage } from '../../types/satellite';
@@ -22,23 +23,30 @@ interface KaOutageConfigProps {
 }
 
 /**
- * Helper to calculate duration from times
+ * Formats a local Date for the datetime-local input used by this form.
  */
-const calculateDuration = (startTime: string, endTime: string): number => {
-  const start = new Date(startTime).getTime();
-  const end = new Date(endTime).getTime();
-  return Math.max(0, (end - start) / 1000); // seconds
+const toDatetimeLocalValue = (date: Date): string => {
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
 
-const validateDuration = (duration: number): string | null => {
+const validateDurationHours = (durationHours: string): string | null => {
+  if (!durationHours.trim()) {
+    return 'Duration is required.';
+  }
+  const duration = Number(durationHours);
+  if (!Number.isFinite(duration)) {
+    return 'Enter a valid number of hours.';
+  }
   if (duration <= 0) {
-    return 'Duration must be greater than 0 seconds';
+    return 'Duration must be greater than 0 hours.';
   }
-  if (duration > 86400) {
-    // 24 hours
-    return 'Duration cannot exceed 24 hours (86400 seconds)';
+  if (duration > 24) {
+    return 'Duration cannot exceed 24 hours.';
   }
-  return null; // Valid
+  return null;
 };
 
 const validateDatetime = (datetime: string): string | null => {
@@ -58,7 +66,7 @@ const validateDatetime = (datetime: string): string | null => {
 
 interface NewOutageInput {
   start_time: string;
-  end_time: string;
+  duration_hours: string;
 }
 
 /**
@@ -70,8 +78,8 @@ interface NewOutageInput {
  *
  * Features:
  * - Display existing outage windows with start time, duration, and end time
- * - Add new outage windows using datetime-local inputs (24-hour format)
- * - Automatic duration calculation
+ * - Add new outage windows using a start time and duration in hours
+ * - Automatic calculated end time using the local datetime input semantics
  * - Validation for required fields and duration limits (0-24 hours)
  * - Helper text indicating 24-hour format requirement
  *
@@ -84,37 +92,36 @@ export function KaOutageConfig({
 }: KaOutageConfigProps) {
   const [newOutage, setNewOutage] = useState<Partial<NewOutageInput>>({});
   const [startTimeError, setStartTimeError] = useState<string | null>(null);
-  const [endTimeError, setEndTimeError] = useState<string | null>(null);
   const [durationError, setDurationError] = useState<string | null>(null);
 
+  const durationHours = newOutage.duration_hours ?? '';
+  const startDate = new Date(newOutage.start_time ?? '');
+  const duration = Number(durationHours);
+  const calculatedEndTime =
+    !Number.isNaN(startDate.getTime()) &&
+    Number.isFinite(duration) &&
+    duration > 0
+      ? toDatetimeLocalValue(new Date(startDate.getTime() + duration * 3600000))
+      : '';
+
   const handleAddOutage = () => {
-    // Validate inputs
     const startError = validateDatetime(newOutage.start_time || '');
-    const endError = validateDatetime(newOutage.end_time || '');
-    const durationSeconds = calculateDuration(
-      newOutage.start_time || '',
-      newOutage.end_time || ''
-    );
-    const durError = validateDuration(durationSeconds);
+    const durError = validateDurationHours(durationHours);
 
     setStartTimeError(startError);
-    setEndTimeError(endError);
     setDurationError(durError);
 
-    // Only proceed if all validations pass
-    if (!startError && !endError && !durError) {
+    if (!startError && !durError) {
       onOutagesChange([
         ...outages,
         {
           id: createClientId(),
           start_time: toISO8601(newOutage.start_time!),
-          duration_seconds: durationSeconds,
+          duration_seconds: duration * 3600,
         },
       ]);
       setNewOutage({});
-      // Clear errors after successful submission
       setStartTimeError(null);
-      setEndTimeError(null);
       setDurationError(null);
     }
   };
@@ -127,7 +134,10 @@ export function KaOutageConfig({
     <div className="space-y-4">
       <div>
         <h3 className="text-sm font-medium mb-2">Ka Outage Windows</h3>
-        <Table>
+        <p className="mb-2 text-xs text-muted-foreground">
+          Scroll horizontally to access all outage columns on narrow screens.
+        </p>
+        <Table className="min-w-[42rem]">
           <TableHeader>
             <TableRow>
               <TableHead>Start Time</TableHead>
@@ -165,8 +175,11 @@ export function KaOutageConfig({
             <TableRow>
               <TableCell>
                 <div>
-                  {/* datetime-local input with step="60" for 1-minute precision (no seconds) */}
+                  <Label htmlFor="ka-outage-start-time" className="sr-only">
+                    Ka outage start time
+                  </Label>
                   <Input
+                    id="ka-outage-start-time"
                     type="datetime-local"
                     step="60"
                     value={newOutage.start_time ?? ''}
@@ -177,88 +190,80 @@ export function KaOutageConfig({
                         start_time: value,
                       });
                       setStartTimeError(validateDatetime(value));
-                      // Re-validate duration if end time exists
-                      if (newOutage.end_time) {
-                        const dur = calculateDuration(
-                          value,
-                          newOutage.end_time
-                        );
-                        setDurationError(validateDuration(dur));
-                      }
                     }}
+                    aria-describedby={
+                      startTimeError ? 'ka-outage-start-time-error' : undefined
+                    }
+                    aria-invalid={Boolean(startTimeError)}
                     className={startTimeError ? 'border-red-500' : ''}
                   />
-                  {/* Helper text guides users to enter time in 24-hour format */}
                   <p className="text-xs text-muted-foreground mt-1">
                     24-hour format (HH:mm)
                   </p>
                   {startTimeError && (
-                    <p className="text-sm text-red-500 mt-1">
+                    <p
+                      id="ka-outage-start-time-error"
+                      className="text-sm text-red-500 mt-1"
+                      role="alert"
+                    >
                       {startTimeError}
                     </p>
                   )}
                 </div>
               </TableCell>
               <TableCell>
-                {newOutage.start_time && newOutage.end_time && (
-                  <div>
-                    <span>
-                      {(
-                        calculateDuration(
-                          newOutage.start_time,
-                          newOutage.end_time
-                        ) / 3600
-                      ).toFixed(2)}
-                    </span>
-                    {durationError && (
-                      <p className="text-sm text-red-500 mt-1">
-                        {durationError}
-                      </p>
-                    )}
-                  </div>
+                <Label htmlFor="ka-outage-duration-hours" className="sr-only">
+                  Duration (hours)
+                </Label>
+                <Input
+                  id="ka-outage-duration-hours"
+                  type="number"
+                  min="0.01"
+                  max="24"
+                  step="0.01"
+                  required
+                  value={durationHours}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    setNewOutage({ ...newOutage, duration_hours: value });
+                    setDurationError(validateDurationHours(value));
+                  }}
+                  aria-describedby={
+                    durationError ? 'ka-outage-duration-error' : undefined
+                  }
+                  aria-invalid={Boolean(durationError)}
+                  className={durationError ? 'border-red-500' : ''}
+                />
+                {durationError && (
+                  <p
+                    id="ka-outage-duration-error"
+                    className="text-sm text-red-500 mt-1"
+                    role="alert"
+                  >
+                    {durationError}
+                  </p>
                 )}
               </TableCell>
               <TableCell>
                 <div>
+                  <Label htmlFor="ka-outage-end-time" className="sr-only">
+                    Calculated Ka outage end time
+                  </Label>
                   <Input
+                    id="ka-outage-end-time"
                     type="datetime-local"
                     step="60"
-                    value={newOutage.end_time ?? ''}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      setNewOutage({
-                        ...newOutage,
-                        end_time: value,
-                      });
-                      setEndTimeError(validateDatetime(value));
-                      // Re-validate duration if start time exists
-                      if (newOutage.start_time) {
-                        const dur = calculateDuration(
-                          newOutage.start_time,
-                          value
-                        );
-                        setDurationError(validateDuration(dur));
-                      }
-                    }}
-                    className={endTimeError ? 'border-red-500' : ''}
+                    value={calculatedEndTime}
+                    readOnly
+                    aria-live="polite"
                   />
                   <p className="text-xs text-muted-foreground mt-1">
-                    24-hour format (HH:mm)
+                    Calculated from the local start time and duration.
                   </p>
-                  {endTimeError && (
-                    <p className="text-sm text-red-500 mt-1">{endTimeError}</p>
-                  )}
                 </div>
               </TableCell>
               <TableCell>
-                <Button
-                  onClick={handleAddOutage}
-                  disabled={
-                    !!startTimeError || !!endTimeError || !!durationError
-                  }
-                >
-                  Add
-                </Button>
+                <Button onClick={handleAddOutage}>Add</Button>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
+++ b/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
@@ -32,7 +32,9 @@ const toDatetimeLocalValue = (date: Date): string => {
   )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
 
-const durationHoursPattern = /^(?:\d+\.?\d*|\.\d+)$/;
+// Signed decimal input reaches range validation so negative values receive
+// the actionable minimum-duration feedback instead of a generic format error.
+const durationHoursPattern = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
 
 const validateDurationHours = (durationHours: string): string | null => {
   if (!durationHours.trim()) {
@@ -225,7 +227,7 @@ export function KaOutageConfig({
                   id="ka-outage-duration-hours"
                   type="text"
                   inputMode="decimal"
-                  pattern="[0-9]*\.?[0-9]*"
+                  pattern="[+-]?[0-9]*\.?[0-9]*"
                   min="0.01"
                   max="24"
                   step="0.01"

--- a/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
+++ b/frontend/mission-planner/src/components/satellites/KaOutageConfig.tsx
@@ -32,9 +32,14 @@ const toDatetimeLocalValue = (date: Date): string => {
   )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
 
+const durationHoursPattern = /^(?:\d+\.?\d*|\.\d+)$/;
+
 const validateDurationHours = (durationHours: string): string | null => {
   if (!durationHours.trim()) {
     return 'Duration is required.';
+  }
+  if (!durationHoursPattern.test(durationHours)) {
+    return 'Enter a valid number of hours.';
   }
   const duration = Number(durationHours);
   if (!Number.isFinite(duration)) {
@@ -99,6 +104,7 @@ export function KaOutageConfig({
   const duration = Number(durationHours);
   const calculatedEndTime =
     !Number.isNaN(startDate.getTime()) &&
+    durationHoursPattern.test(durationHours) &&
     Number.isFinite(duration) &&
     duration > 0
       ? toDatetimeLocalValue(new Date(startDate.getTime() + duration * 3600000))
@@ -217,7 +223,9 @@ export function KaOutageConfig({
                 </Label>
                 <Input
                   id="ka-outage-duration-hours"
-                  type="number"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*\.?[0-9]*"
                   min="0.01"
                   max="24"
                   step="0.01"

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -338,7 +338,9 @@ test.describe('Leg detail responsive layout', () => {
     const endTime = page.getByLabel('Calculated Ka outage end time');
     const addOutage = page.getByRole('button', { name: 'Add', exact: true });
 
-    await expect(duration).toHaveAttribute('type', 'number');
+    await expect(duration).toHaveAttribute('type', 'text');
+    await expect(duration).toHaveAttribute('inputmode', 'decimal');
+    await expect(duration).toHaveAttribute('pattern', '[0-9]*\\.?[0-9]*');
     await expect(duration).toHaveAttribute('min', '0.01');
     await expect(duration).toHaveAttribute('max', '24');
     await startTime.fill('2026-08-13T00:30');
@@ -402,5 +404,19 @@ test.describe('Leg detail responsive layout', () => {
       page.getByText('Duration cannot exceed 24 hours.')
     ).toBeVisible();
     await expect(duration).toHaveValue('25');
+
+    await duration.fill('abc');
+    await addOutage.click();
+    await expect(
+      page.getByText('Enter a valid number of hours.')
+    ).toBeVisible();
+    await expect(duration).toHaveValue('abc');
+
+    await duration.fill('1e-1');
+    await addOutage.click();
+    await expect(
+      page.getByText('Enter a valid number of hours.')
+    ).toBeVisible();
+    await expect(duration).toHaveValue('1e-1');
   });
 });

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -283,4 +283,124 @@ test.describe('Leg detail responsive layout', () => {
     );
     expect(overflow).toBe(false);
   });
+
+  test('adds, saves, reloads, and previews a Ka outage from duration hours on mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const persistedMission = structuredClone(mission);
+    let savedKaOutages: Array<{ duration_seconds: number }> = [];
+    let previewKaOutages: Array<{ duration_seconds: number }> = [];
+
+    await mockLegDetailApis(page);
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission',
+      async (route) => {
+        await route.fulfill({ json: persistedMission });
+      }
+    );
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg',
+      async (route) => {
+        if (route.request().method() !== 'PUT') {
+          await route.continue();
+          return;
+        }
+
+        const updatedLeg = route.request().postDataJSON();
+        savedKaOutages = updatedLeg.transports.ka_outages;
+        persistedMission.legs[0] = updatedLeg;
+        await route.fulfill({ json: { leg: updatedLeg, warnings: [] } });
+      }
+    );
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg/timeline/preview',
+      async (route) => {
+        if (route.request().method() === 'POST') {
+          previewKaOutages = route.request().postDataJSON()
+            .transports.ka_outages;
+        }
+        await route.fulfill({
+          json: {
+            mission_leg_id: 'responsive-leg',
+            created_at: '2026-08-13T00:00:00Z',
+            segments: [],
+          },
+        });
+      }
+    );
+
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+    await page.getByRole('tab', { name: 'Ka Outages' }).click();
+
+    const startTime = page.getByLabel('Ka outage start time');
+    const duration = page.getByLabel('Duration (hours)');
+    const endTime = page.getByLabel('Calculated Ka outage end time');
+    const addOutage = page.getByRole('button', { name: 'Add', exact: true });
+
+    await expect(duration).toHaveAttribute('type', 'number');
+    await expect(duration).toHaveAttribute('min', '0.01');
+    await expect(duration).toHaveAttribute('max', '24');
+    await startTime.fill('2026-08-13T00:30');
+    await duration.fill('1.5');
+    await expect(endTime).toHaveValue('2026-08-13T02:00');
+
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth > window.innerWidth
+      )
+    ).toBe(false);
+    await addOutage.scrollIntoViewIfNeeded();
+    await expect(addOutage).toBeInViewport();
+    await addOutage.click();
+
+    await expect.poll(() => previewKaOutages[0]?.duration_seconds).toBe(5400);
+    await expect(page.getByText('1.50', { exact: true })).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await expect.poll(() => savedKaOutages[0]?.duration_seconds).toBe(5400);
+
+    await page.reload();
+    await page.getByRole('tab', { name: 'Ka Outages' }).click();
+    await expect(page.getByText('1.50', { exact: true })).toBeVisible();
+  });
+
+  test('keeps invalid Ka outage values and explains how to correct them', async ({
+    page,
+  }) => {
+    await mockLegDetailApis(page);
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+    await page.getByRole('tab', { name: 'Ka Outages' }).click();
+
+    const startTime = page.getByLabel('Ka outage start time');
+    const duration = page.getByLabel('Duration (hours)');
+    const addOutage = page.getByRole('button', { name: 'Add', exact: true });
+
+    await addOutage.click();
+    await expect(page.getByText('Datetime is required')).toBeVisible();
+    await expect(page.getByText('Duration is required.')).toBeVisible();
+
+    await startTime.fill('2026-08-13T00:30');
+    await duration.fill('0');
+    await addOutage.click();
+    await expect(
+      page.getByText('Duration must be greater than 0 hours.')
+    ).toBeVisible();
+    await expect(duration).toHaveValue('0');
+
+    await duration.fill('-1');
+    await addOutage.click();
+    await expect(
+      page.getByText('Duration must be greater than 0 hours.')
+    ).toBeVisible();
+    await expect(duration).toHaveValue('-1');
+
+    await duration.fill('25');
+    await addOutage.click();
+    await expect(
+      page.getByText('Duration cannot exceed 24 hours.')
+    ).toBeVisible();
+    await expect(duration).toHaveValue('25');
+  });
 });

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -340,7 +340,7 @@ test.describe('Leg detail responsive layout', () => {
 
     await expect(duration).toHaveAttribute('type', 'text');
     await expect(duration).toHaveAttribute('inputmode', 'decimal');
-    await expect(duration).toHaveAttribute('pattern', '[0-9]*\\.?[0-9]*');
+    await expect(duration).toHaveAttribute('pattern', '[+-]?[0-9]*\\.?[0-9]*');
     await expect(duration).toHaveAttribute('min', '0.01');
     await expect(duration).toHaveAttribute('max', '24');
     await startTime.fill('2026-08-13T00:30');


### PR DESCRIPTION
## Summary
- restore an accessible numeric Duration (hours) field for new Ka outage windows
- calculate the read-only end time from the local start-time input and duration
- keep mobile table overflow contained and documented, with inline validation that preserves invalid input
- add focused mobile end-to-end coverage for add, preview, save/reload, and validation paths

## Verification
- `npm run build`
- `npm run lint`
- `npx prettier --check src/components/satellites/KaOutageConfig.tsx tests/e2e/leg-detail-responsive.spec.ts`
- `git diff --check`
- attempted `npx playwright test tests/e2e/leg-detail-responsive.spec.ts --project=chromium` (blocked: required Chromium headless-shell download did not complete in this worker environment)

## Documentation impact
None; existing local datetime semantics are described inline beside the calculated end time.

Closes #101