### PR TITLE
fix: hydrate persisted Manual AR track editor

### DIFF
--- a/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
+++ b/frontend/mission-planner/src/components/aar/ManualAARTrackEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { createClientId } from '@/lib/clientId';
@@ -35,6 +35,30 @@ export function ManualAARTrackEditor({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [editingTrackId, setEditingTrackId] = useState<string | null>(null);
+  const hasHydratedPersistedTrack = useRef(false);
+
+  const loadTrack = (track: ManualAARTrack) => {
+    setEditingTrackId(track.id);
+    setName(track.name);
+    setPoints(
+      track.points.map((point) => ({
+        latitude: String(point.latitude),
+        longitude: String(point.longitude),
+      }))
+    );
+    setError(null);
+    setSuccess(null);
+  };
+
+  useEffect(() => {
+    if (hasHydratedPersistedTrack.current || tracks.length === 0) {
+      return;
+    }
+
+    hasHydratedPersistedTrack.current = true;
+    loadTrack(tracks[0]);
+  }, [tracks]);
 
   const updatePoint = (
     pointIndex: number,
@@ -93,13 +117,12 @@ export function ManualAARTrackEditor({
     try {
       setIsSaving(true);
       await onSaveTrack({
-        id: createClientId(),
+        id: editingTrackId ?? createClientId(),
         name: name.trim(),
         points: parsedPoints,
       });
       setError(null);
       setSuccess('Manual AR track saved.');
-      setPoints([emptyPoint(), emptyPoint()]);
     } catch (saveError) {
       setError(
         saveError instanceof Error
@@ -131,6 +154,13 @@ export function ManualAARTrackEditor({
                 {track.points.length} operator-entered points
               </p>
             </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => loadTrack(track)}
+            >
+              Edit
+            </Button>
             <Button
               variant="destructive"
               size="sm"
@@ -197,6 +227,20 @@ export function ManualAARTrackEditor({
           </p>
         )}
         <div className="flex gap-2">
+          {tracks.length > 0 && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setEditingTrackId(null);
+                setName('Manual AR Track');
+                setPoints([emptyPoint(), emptyPoint()]);
+                setError(null);
+                setSuccess(null);
+              }}
+            >
+              New Track
+            </Button>
+          )}
           <Button
             variant="outline"
             onClick={() => setPoints([...points, emptyPoint()])}

--- a/frontend/mission-planner/src/pages/LegDetailPage.tsx
+++ b/frontend/mission-planner/src/pages/LegDetailPage.tsx
@@ -126,7 +126,13 @@ export function LegDetailPage() {
 
     const updatedAARConfig = {
       ...aarConfig,
-      manualTracks: [...aarConfig.manualTracks, track],
+      manualTracks: aarConfig.manualTracks.some(
+        (existingTrack) => existingTrack.id === track.id
+      )
+        ? aarConfig.manualTracks.map((existingTrack) =>
+            existingTrack.id === track.id ? track : existingTrack
+          )
+        : [...aarConfig.manualTracks, track],
     };
     await updateLegMutation.mutateAsync({
       ...leg,

--- a/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
+++ b/frontend/mission-planner/tests/e2e/leg-detail-responsive.spec.ts
@@ -177,6 +177,103 @@ test.describe('Leg detail responsive layout', () => {
     await expect(page.locator('path[stroke="#F97316"]')).toBeAttached();
   });
 
+  test('hydrates persisted manual AR track points for no-op save and reload', async ({
+    page,
+  }) => {
+    const persistedMission = {
+      ...mission,
+      legs: mission.legs.map((leg) => ({
+        ...leg,
+        transports: {
+          ...leg.transports,
+          manual_aar_tracks: [
+            {
+              id: 'persisted-manual-ar-track',
+              name: 'Persisted Manual AR Track',
+              points: [
+                { latitude: 50, longitude: -50 },
+                { latitude: 30, longitude: -50 },
+              ],
+            },
+          ],
+        },
+      })),
+    };
+    let savedManualTracks: Array<{
+      id: string;
+      name: string;
+      points: Array<{ latitude: number; longitude: number }>;
+    }> = [];
+
+    await mockLegDetailApis(page);
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission',
+      async (route) => {
+        await route.fulfill({ json: persistedMission });
+      }
+    );
+    await page.route(
+      'http://localhost:8000/api/v2/missions/responsive-mission/legs/responsive-leg',
+      async (route) => {
+        if (route.request().method() !== 'PUT') {
+          await route.continue();
+          return;
+        }
+
+        const updatedLeg = route.request().postDataJSON();
+        savedManualTracks = updatedLeg.transports.manual_aar_tracks;
+        persistedMission.legs[0] = updatedLeg;
+        await route.fulfill({ json: { leg: updatedLeg, warnings: [] } });
+      }
+    );
+
+    await page.goto('/missions/responsive-mission/legs/responsive-leg');
+    await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();
+
+    await expect(page.getByLabel('Manual AR track name')).toHaveValue(
+      'Persisted Manual AR Track'
+    );
+    await expect(page.getByLabel('Manual AR point 1 latitude')).toHaveValue(
+      '50'
+    );
+    await expect(page.getByLabel('Manual AR point 1 longitude')).toHaveValue(
+      '-50'
+    );
+    await expect(page.getByLabel('Manual AR point 2 latitude')).toHaveValue(
+      '30'
+    );
+    await expect(page.getByLabel('Manual AR point 2 longitude')).toHaveValue(
+      '-50'
+    );
+
+    await page
+      .getByRole('button', { name: 'Save and Persist Manual AR Track' })
+      .click();
+    await expect(page.getByRole('status')).toHaveText('Manual AR track saved.');
+    await expect
+      .poll(() => savedManualTracks)
+      .toEqual([
+        {
+          id: 'persisted-manual-ar-track',
+          name: 'Persisted Manual AR Track',
+          points: [
+            { latitude: 50, longitude: -50 },
+            { latitude: 30, longitude: -50 },
+          ],
+        },
+      ]);
+
+    await page.reload();
+    await page.getByRole('tab', { name: 'Manual AR Tracks' }).click();
+    await expect(page.getByLabel('Manual AR point 1 latitude')).toHaveValue(
+      '50'
+    );
+    await expect(page.getByLabel('Manual AR point 2 longitude')).toHaveValue(
+      '-50'
+    );
+    await expect(page.locator('path[stroke="#F97316"]')).toBeAttached();
+  });
+
   test('keeps invalid manual AR track input and shows an inline error', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- hydrate the first persisted Manual AR track into its editable coordinate inputs on load
- retain the track ID and replace it on save instead of appending a duplicate
- add Edit and New Track controls for persisted tracks
- cover persisted load, no-op save, and reload in the Playwright suite

## Verification
- `npm run build`
- `npm run lint`
- `npx prettier --check src/components/aar/ManualAARTrackEditor.tsx src/pages/LegDetailPage.tsx tests/e2e/leg-detail-responsive.spec.ts`
- Playwright Chromium suite could not launch because another active browser-install process holds the shared Playwright cache lock.

## Documentation impact
None.

Refs #103