### PR TITLE
fix: keep POI dialog actions visible

### DIFF
--- a/frontend/mission-planner/src/components/pois/POIDialog.tsx
+++ b/frontend/mission-planner/src/components/pois/POIDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { usePOI, useCreatePOI, useUpdatePOI } from '../../hooks/api/usePOIs';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Button } from '../ui/button';
 import { POIForm } from './POIForm';
 import { POIMap } from './POIMap';
 import type { POICreate, POIUpdate, POI } from '../../services/pois';
@@ -126,44 +127,59 @@ export function POIDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[800px] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-[800px]">
         <DialogHeader>
           <DialogTitle>{isNew ? 'Create POI' : 'Edit POI'}</DialogTitle>
         </DialogHeader>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Form */}
-          <div>
-            <POIForm
-              poi={poi}
-              onSubmit={handleSubmit}
-              onCancel={() => onOpenChange(false)}
-              isLoading={isLoading}
-              error={error}
-              selectedCoords={currentCoords || undefined}
-            />
-          </div>
-
-          {/* Map for positioning */}
-          <div className="space-y-2">
-            <p className="text-sm text-gray-600">
-              Click on the map to set the POI position
-            </p>
-            <div className="h-80 border rounded-lg overflow-hidden">
-              <POIMap
-                pois={mapPOIs}
-                onMapClick={handleMapClick}
-                center={
-                  currentCoords
-                    ? [currentCoords.lat, currentCoords.lng]
-                    : poi
-                      ? [poi.latitude, poi.longitude]
-                      : [0, 0]
-                }
-                zoom={currentCoords || poi ? 10 : 3}
+        <div className="min-h-0 overflow-y-auto pr-1 [scrollbar-gutter:stable]">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {/* Form */}
+            <div>
+              <POIForm
+                poi={poi}
+                onSubmit={handleSubmit}
+                isLoading={isLoading}
+                error={error}
+                selectedCoords={currentCoords || undefined}
               />
             </div>
+
+            {/* Map for positioning */}
+            <div className="space-y-2">
+              <p className="text-sm text-gray-600">
+                Click on the map to set the POI position
+              </p>
+              <div className="h-80 overflow-hidden rounded-lg border">
+                <POIMap
+                  pois={mapPOIs}
+                  onMapClick={handleMapClick}
+                  center={
+                    currentCoords
+                      ? [currentCoords.lat, currentCoords.lng]
+                      : poi
+                        ? [poi.latitude, poi.longitude]
+                        : [0, 0]
+                  }
+                  zoom={currentCoords || poi ? 10 : 3}
+                />
+              </div>
+            </div>
           </div>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t pt-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button form="poi-form" type="submit" disabled={isLoading}>
+            {isLoading ? 'Saving...' : 'Save POI'}
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/mission-planner/src/components/pois/POIForm.tsx
+++ b/frontend/mission-planner/src/components/pois/POIForm.tsx
@@ -3,7 +3,6 @@ import type { POI, POICreate, POIUpdate } from '../../services/pois';
 import { useRoutes } from '../../hooks/api/useRoutes';
 import { useMissions } from '../../hooks/api/useMissions';
 import { Input } from '../ui/input';
-import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { IconPicker } from '../ui/IconPicker';
 
@@ -22,7 +21,6 @@ const CATEGORY_OPTIONS = [
 interface POIFormProps {
   poi?: POI;
   onSubmit: (data: POICreate | POIUpdate) => void;
-  onCancel: () => void;
   isLoading?: boolean;
   error?: string;
   selectedCoords?: { lat: number; lng: number };
@@ -31,7 +29,6 @@ interface POIFormProps {
 export function POIForm({
   poi,
   onSubmit,
-  onCancel,
   isLoading,
   error,
   selectedCoords,
@@ -102,7 +99,7 @@ export function POIForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form id="poi-form" onSubmit={handleSubmit} className="space-y-4">
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded">
           {error}
@@ -253,20 +250,6 @@ export function POIForm({
             ))}
           </select>
         </div>
-      </div>
-
-      <div className="flex gap-2 justify-end pt-4">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          disabled={isLoading}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled={isLoading}>
-          {isLoading ? 'Saving...' : 'Save POI'}
-        </Button>
       </div>
     </form>
   );

--- a/frontend/mission-planner/tests/e2e/poi-dialog-actions.spec.ts
+++ b/frontend/mission-planner/tests/e2e/poi-dialog-actions.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+async function mockPOIApis(page: import('@playwright/test').Page) {
+  await page.route('**/api/pois**', async (route) => {
+    await route.fulfill({ json: { pois: [], total: 0 } });
+  });
+  await page.route('**/api/routes**', async (route) => {
+    await route.fulfill({ json: { routes: [], total: 0 } });
+  });
+  await page.route('**/api/v2/missions**', async (route) => {
+    await route.fulfill({ json: [] });
+  });
+}
+
+async function expectActionsVisible(page: import('@playwright/test').Page) {
+  const dialog = page.getByRole('dialog');
+  const cancel = page.getByRole('button', { name: 'Cancel' });
+  const save = page.getByRole('button', { name: 'Save POI' });
+
+  await expect(dialog).toBeVisible();
+  await expect(cancel).toBeVisible();
+  await expect(save).toBeVisible();
+
+  const [dialogBox, cancelBox, saveBox] = await Promise.all([
+    dialog.boundingBox(),
+    cancel.boundingBox(),
+    save.boundingBox(),
+  ]);
+
+  expect(dialogBox).not.toBeNull();
+  expect(cancelBox).not.toBeNull();
+  expect(saveBox).not.toBeNull();
+
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+
+  for (const action of [cancelBox!, saveBox!]) {
+    expect(action.y).toBeGreaterThanOrEqual(dialogBox!.y);
+    expect(action.y + action.height).toBeLessThanOrEqual(
+      dialogBox!.y + dialogBox!.height
+    );
+    expect(action.y + action.height).toBeLessThanOrEqual(viewport!.height);
+  }
+}
+
+test.describe('POI dialog actions', () => {
+  test('keeps Create POI actions visible at short desktop height', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 577 });
+    await mockPOIApis(page);
+
+    await page.goto('/pois');
+    await page.getByRole('button', { name: 'Create POI' }).click();
+
+    await expectActionsVisible(page);
+  });
+
+  test('keeps Create POI actions visible on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockPOIApis(page);
+
+    await page.goto('/pois');
+    await page.getByRole('button', { name: 'Create POI' }).click();
+
+    await expectActionsVisible(page);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the POI dialog action bar outside its scrollable form and map content.
- Constrain the dialog to the viewport while retaining a visible scrollbar gutter for overflow.
- Add Playwright coverage for short desktop and mobile Create POI action visibility.

## Validation
- npm run build
- npm run lint
- npx prettier --check src/components/pois/POIDialog.tsx src/components/pois/POIForm.tsx tests/e2e/poi-dialog-actions.spec.ts
- git diff --check
- npx playwright test tests/e2e/poi-dialog-actions.spec.ts --list

Playwright execution is blocked because this worker lacks the Chromium headless-shell executable; npx playwright install chromium could not complete in this environment.

Relates to #104.